### PR TITLE
Do not validate AWSHelperFun's (Fix for Issue 8)

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,8 +1,9 @@
 import unittest
-from troposphere import AWSObject, Template, UpdatePolicy
+from troposphere import AWSObject, Template, UpdatePolicy, Ref
 from troposphere.ec2 import Instance
 from troposphere.autoscaling import AutoScalingGroup
 from troposphere.elasticloadbalancing import HealthCheck
+from troposphere.validators import positive_integer
 
 
 class TestBasic(unittest.TestCase):
@@ -40,6 +41,7 @@ class FakeAWSObject(AWSObject):
         'singlelist': (list, False),
         'multilist': ([bool, int, float], False),
         'multituple': ((basestring, int), False),
+        'helperfun': (positive_integer, False),
     }
 
     def __init__(self, name, **kwargs):
@@ -96,6 +98,9 @@ class TestValidators(unittest.TestCase):
         FakeAWSObject('fake', multituple=10)
         with self.assertRaises(TypeError):
             FakeAWSObject('fake', multituple=0.1)
+
+    def test_helperfun(self):
+        FakeAWSObject('fake', helperfun=Ref('fake_ref'))
 
 
 class TestHealthCheck(unittest.TestCase):

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -68,8 +68,14 @@ class AWSObject(object):
             # expecting.
             expected_type = self.props[name][0]
 
+            # If the value is a AWSHelperFn we can't do much validation
+            # we'll have to leave that to Amazon.  Maybe there's another way
+            # to deal with this that we'll come up with eventually
+            if isinstance(value, AWSHelperFn):
+                return self.properties.__setitem__(name, value)
+
             # If it's a function, call it...
-            if isinstance(expected_type, types.FunctionType):
+            elif isinstance(expected_type, types.FunctionType):
                 value = expected_type(value)
                 return self.properties.__setitem__(name, value)
 
@@ -89,8 +95,7 @@ class AWSObject(object):
 
             # Single type so check the type of the object and compare against
             # what we were expecting. Special case AWS helper functions.
-            elif isinstance(value, expected_type) or \
-                    isinstance(value, AWSHelperFn):
+            elif isinstance(value, expected_type):
                 return self.properties.__setitem__(name, value)
             else:
                 self._raise_type(name, value, expected_type)


### PR DESCRIPTION
I tested the new test before updating **init**.py and it failed.  I then updated **init**.py with my fix and tested again, and it passes.
