### PR TITLE
VPCSecurityGroups for RDS should be a list, not a basestring

### DIFF
--- a/troposphere/rds.py
+++ b/troposphere/rds.py
@@ -30,7 +30,7 @@ class DBInstance(AWSObject):
         'PreferredBackupWindow': (basestring, False),
         'PreferredMaintenanceWindow': (basestring, False),
         'Tags': (list, False),
-        'VPCSecurityGroups': (basestring, False),
+        'VPCSecurityGroups': (list, False),
     }
 
     def __init__(self, name, **kwargs):


### PR DESCRIPTION
Title says it all. 

Thanks for a really useful library!
