### PR TITLE
Adding separators option to json_dump

### DIFF
--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -320,7 +320,7 @@ class Template(object):
         else:
             self.version = "2010-09-09"
 
-    def to_json(self, indent=4, sort_keys=True, separators=(',',' ',':')):
+    def to_json(self, indent=4, sort_keys=True, separators=(', ', ': ')):
         t = {}
         if self.description:
             t['Description'] = self.description


### PR DESCRIPTION
Hi,

I added a separators option to the to_json function, this help me not the reach the 51200 bytes limit on the validate-template api call. Maybe other people should also benefit.

template.to_json(indent=None, separators=(',', ':'))

Regards
