### PR TITLE
Add EnableDnsSupport and EnableDnsHostnames properties for VPC

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -311,6 +311,8 @@ class VPC(AWSObject):
     props = {
         'CidrBlock': (basestring, True),
         'InstanceTenancy': (basestring, False),
+        'EnableDnsSupport': (boolean, False),
+        'EnableDnsHostnames': (boolean, False),
         'Tags': (list, False),
     }
 


### PR DESCRIPTION
Per http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html
