### PR TITLE
Proof of concept: more terse syntax

### DIFF
--- a/examples/EC2InstanceSampleNewSyntax.py
+++ b/examples/EC2InstanceSampleNewSyntax.py
@@ -1,0 +1,63 @@
+# Converted from EC2InstanceSample.template located at:
+# http://aws.amazon.com/cloudformation/aws-cloudformation-templates/
+
+from troposphere import Base64, FindInMap, Mapping
+from troposphere import Parameter, Output, Ref, Template
+import troposphere.ec2 as ec2
+
+
+template = Template()
+
+KeyName = Parameter(
+    Description="Name of an existing EC2 KeyPair to enable SSH "
+                "access to the instance",
+    Type="String",
+)
+
+RegionMap = Mapping({
+    "us-east-1": {"AMI": "ami-7f418316"},
+    "us-west-1": {"AMI": "ami-951945d0"},
+    "us-west-2": {"AMI": "ami-16fd7026"},
+    "eu-west-1": {"AMI": "ami-24506250"},
+    "sa-east-1": {"AMI": "ami-3e3be423"},
+    "ap-southeast-1": {"AMI": "ami-74dda626"},
+    "ap-northeast-1": {"AMI": "ami-dcfa4edd"}
+})
+
+Ec2Instance = ec2.Instance(
+    ImageId=FindInMap("RegionMap", Ref("AWS::Region"), "AMI"),
+    InstanceType="t1.micro",
+    KeyName=KeyName,
+    SecurityGroups=["default"],
+    UserData=Base64("80")
+)
+
+InstanceId = Output(
+        Description="InstanceId of the newly created EC2 instance",
+        Value=Ec2Instance,
+        )
+AZ = Output(
+        Description="Availability Zone of the newly created EC2 instance",
+        Value=Ec2Instance.AvailabilityZone,
+        )
+
+PublicIP = Output(
+        Description="Public IP address of the newly created EC2 instance",
+        Value=Ec2Instance.PublicIp,
+    )
+PrivateIP = Output(
+        Description="Private IP address of the newly created EC2 instance",
+        Value=Ec2Instance.PrivateIp,
+    )
+PublicDNS = Output(
+        Description="Public DNSName of the newly created EC2 instance",
+        Value=Ec2Instance.PublicDnsName,
+    )
+PrivateDNS = Output(
+        Description="Private DNSName of the newly created EC2 instance",
+        Value=Ec2Instance.PrivateDnsName,
+    )
+
+template.add_half_baked(locals())
+
+print(template.to_json())

--- a/examples/Route53_A_NewSyntax.py
+++ b/examples/Route53_A_NewSyntax.py
@@ -38,10 +38,9 @@ Ec2Instance = Instance(
 )
 
 myDNSRecord = RecordSetType(
-    HostedZoneName=Join("", [Ref(HostedZone), "."]),
+    HostedZoneName="{}.".format(HostedZone),
     Comment="DNS name for my instance.",
-    Name=Join("", [Ec2Instance, ".", Ref("AWS::Region"), ".",
-              HostedZone, "."]),
+    Name="{}.{}.{}.".format(Ec2Instance, Ref("AWS::Region"), HostedZone),
     Type="A",
     TTL="900",
     ResourceRecords=[Ec2Instance.PublicIp],

--- a/examples/Route53_A_NewSyntax.py
+++ b/examples/Route53_A_NewSyntax.py
@@ -1,0 +1,54 @@
+# Converted from Route53_A.template located at:
+# http://aws.amazon.com/cloudformation/aws-cloudformation-templates/
+
+from troposphere import FindInMap, GetAtt, Join, Output
+from troposphere import Parameter, Ref, Template, Mapping
+from troposphere.ec2 import Instance
+from troposphere.route53 import RecordSetType
+
+
+t = Template()
+
+t.add_description(
+    "AWS CloudFormation Sample Template Route53_A: "
+    "Sample template showing how to create an Amazon Route 53 A record that "
+    "maps to the public IP address of an EC2 instance. It assumes that you "
+    "already have a Hosted Zone registered with Amazon Route 53. **WARNING** "
+    "This template creates an Amazon EC2 instance. You will be billed for "
+    "the AWS resources used if you create a stack from this template.")
+
+HostedZone = Parameter(
+    Description="The DNS name of an existing Amazon Route 53 hosted zone",
+    Type="String",
+)
+
+RegionMap = Mapping({
+    "us-east-1": {"AMI": "ami-7f418316"},
+    "us-west-1": {"AMI": "ami-951945d0"},
+    "us-west-2": {"AMI": "ami-16fd7026"},
+    "eu-west-1": {"AMI": "ami-24506250"},
+    "sa-east-1": {"AMI": "ami-3e3be423"},
+    "ap-southeast-1": {"AMI": "ami-74dda626"},
+    "ap-northeast-1": {"AMI": "ami-dcfa4edd"}
+})
+
+Ec2Instance = Instance(
+    ImageId=FindInMap("RegionMap", Ref("AWS::Region"), "AMI"),
+    InstanceType="m1.small",
+)
+
+myDNSRecord = RecordSetType(
+    HostedZoneName=Join("", [Ref(HostedZone), "."]),
+    Comment="DNS name for my instance.",
+    Name=Join("", [Ec2Instance, ".", Ref("AWS::Region"), ".",
+              HostedZone, "."]),
+    Type="A",
+    TTL="900",
+    ResourceRecords=[Ec2Instance.PublicIp],
+)
+
+
+DomainName = Output(Value=myDNSRecord)
+
+t.add_half_baked(locals())
+print(t.to_json())

--- a/examples/resolve.py
+++ b/examples/resolve.py
@@ -1,0 +1,43 @@
+from troposphere import Ref, Template
+from troposphere.resolver import Resolver
+from troposphere.ec2 import Instance
+
+class bcolors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+
+    def disable(self):
+        self.HEADER = ''
+        self.OKBLUE = ''
+        self.OKGREEN = ''
+        self.WARNING = ''
+        self.FAIL = ''
+        self.ENDC = ''
+
+class Resource(object):
+    def JSONrepr(self):
+        return {'Type':'Resource', 'id': id(self)}
+
+o1 = Resource()
+o2 = Resource()
+i = Instance('i', ImageId='ami-deadbeef')
+known = {id(o1): 'o1', id(o2): 'o2', id(i): 'i'}
+
+all = [
+        {"1":o1, "2":o2},
+        {"1":o1, "2":[o2, o1]},
+        [o1, o2],
+        {"3":["",[o1, o2]]},
+        {"4": "_Ref(%s)" % id(o1)},
+        {"5": ["", ["_Ref(%s)" % id(o1)]]},
+        "{}".format(i),
+        ]
+resolver = Resolver()
+for i in all:
+    print bcolors.OKBLUE + str(i) + bcolors.ENDC
+    resolve_references_recursively(known, i)
+    print bcolors.OKGREEN + str(i) + bcolors.ENDC

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -116,6 +116,9 @@ class BaseAWSObject(object):
     def validate(self):
         pass
 
+    def __format__(self, format_spec):
+        return "_BaseAWSObject(id={0})".format(id(self))
+
     def JSONrepr(self):
         for k, (prop_type, required) in self.props.items():
             if required and k not in self.properties:
@@ -207,10 +210,14 @@ class FindInMap(AWSHelperFn):
 
 class GetAtt(AWSHelperFn):
     def __init__(self, logicalName, attrName):
-        self.data = {'Fn::GetAtt': [self.getdata(logicalName), attrName]}
+        self.logicalName = logicalName
+        self.attrName = attrName
 
     def JSONrepr(self):
-        return self.data
+        return {'Fn::GetAtt': [self.getdata(self.logicalName), self.attrName]}
+
+    #def __format__(self, format_spec):
+    #    return "_GetAtt(id={0},attrName={1})".format(id(self.logicalName))
 
 
 class GetAZs(AWSHelperFn):
@@ -251,6 +258,12 @@ class Ref(AWSHelperFn):
 
     def JSONrepr(self):
         return {'Ref': self.getdata(self.data)}
+
+    def __format__(self, format_spec):
+        if isinstance(self.data, BaseAWSObject):
+            return '_Ref(id={})'.format(id(self.data))
+        else:
+            return '_Ref(name={})'.format(self.data)
 
 
 class awsencode(json.JSONEncoder):

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -247,10 +247,10 @@ class Select(AWSHelperFn):
 
 class Ref(AWSHelperFn):
     def __init__(self, data):
-        self.data = {'Ref': self.getdata(data)}
+        self.data = data
 
     def JSONrepr(self):
-        return self.data
+        return {'Ref': self.getdata(self.data)}
 
 
 class awsencode(json.JSONEncoder):

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -70,15 +70,15 @@ class BaseAWSObject(object):
             # expecting.
             expected_type = self.props[name][0]
 
-            if (expected_type == basestring
-                    and isinstance(value, (AWSObject, Parameter))):
-                return self.properties.__setitem__(name, "_Ref(%s)" % id(value))
-
             # If the value is a AWSHelperFn we can't do much validation
             # we'll have to leave that to Amazon.  Maybe there's another way
             # to deal with this that we'll come up with eventually
             if isinstance(value, AWSHelperFn):
                 return self.properties.__setitem__(name, value)
+
+            # if value is an AWSObject or a Parameter it is meant as new-style Ref
+            if isinstance(value, (AWSObject, Parameter)):
+                return self.properties.__setitem__(name, Ref(value))
 
             # If it's a function, call it...
             elif isinstance(expected_type, types.FunctionType):

--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -86,6 +86,8 @@ class MountPoint(AWSProperty):
 
 class Instance(AWSObject):
     type = "AWS::EC2::Instance"
+    ro_attributes = ('AvailabilityZone', 'PublicIp', 'PrivateIp',
+            'PublicDnsName', 'PrivateDnsName')
 
     props = {
         'AvailabilityZone': (basestring, False),

--- a/troposphere/resolver.py
+++ b/troposphere/resolver.py
@@ -1,0 +1,70 @@
+import re
+
+ref_re = re.compile(r'_Ref\((\d+)\)')
+getatt_re = re.compile(r'_GetAtt\((\d+),(\w+)\)')
+
+
+class Resolver(object):
+
+    def __init__(self, template):
+        self.template = template
+        self._init_known()
+
+    def _resolve_references_list(self, l):
+        for i, elem in enumerate(l):
+            l[i] = self._resolve_references_recursively(elem)
+
+    def _resolve_references_dict(self, d):
+        for k, v in d.iteritems():
+            d[k] = self._resolve_references_recursively(v)
+
+    def _resolve_references_string(self, s):
+        from troposphere import Ref, GetAtt, AWSObject, Parameter
+        m = ref_re.match(s)
+        if m:
+            i = int(m.group(1))
+            return Ref(self.known[i])
+        m = getatt_re.match(s)
+        if m:
+            i, a = m.groups()
+            i = int(i)
+            return GetAtt(self.known[i], a)
+        return None
+
+    def _resolve_references_recursively(self, o):
+        from troposphere import Ref, GetAtt, AWSObject, Parameter
+        if isinstance(o, (AWSObject, Parameter)):
+            r = Ref(o)
+            return self._resolve_references_recursively(r)
+        if hasattr(o, 'JSONrepr'):
+            return self._resolve_references_recursively(o.JSONrepr())
+        if isinstance(o, dict):
+            self._resolve_references_dict(o)
+            return o
+        if isinstance(o, list):
+            self._resolve_references_list(o)
+            return o
+        if isinstance(o, basestring):
+            _resolved = self._resolve_references_string(o)
+            if _resolved:
+                return self._resolve_references_recursively(_resolved)
+            else:
+                return o
+        return o
+
+    def _resolve_references_aws_object(self, d):
+        self._resolve_references_recursively(d.properties)
+
+    def _init_known(self):
+        known = dict((id(v), k)
+            for k, v in self.template.parameters.iteritems())
+        known.update(dict((id(v), k)
+            for k, v in self.template.resources.iteritems()))
+
+        self.known = known
+
+    def resolve_references(self):
+        for k, v in self.template.resources.iteritems():
+            self._resolve_references_aws_object(v)
+        for k, v in self.template.outputs.iteritems():
+            self._resolve_references_aws_object(v)


### PR DESCRIPTION
I am playing with an alternative syntax for templates.

I would like to implement following:
 - use python assignments to set names of resources/params/outputs:
`Ec2Instance = ec2.Instance(ImageId="some-ami")` instead of `Ec2Instance = ec2.Instance("Ec2Instance", ImageId="some-ami")`
 - if a resource/param is used somewhere in another resourse, make a Ref out of it:
`ec2.Instance(KeyName=KeyName)` instead of `ec2.Instance(KeyName=Ref(KeyName)`
 - write `resource.attribute` instead of `GetAtt(resource, 'attribute')`
 - use pythons `str.format` or `%` string operation instead of `Join` -> not yet implemented

The current syntax should still work.

The idea of resources without names is to construct the template out of `locals()` or `module.__dict__` and add everything suitable to the template.

The idea of implementation of lazy references is to generate strings containing _Ref() or _GetAtt() and the id of object being referenced, which get resolved after the resources have been added to the template.

What do you think of this approach? Is it useful? Too much magic? Conceptually impossible? A better way to implement this?

What is implemented:
 - EC2InstanceSampleNewSyntax.py produces the same output as EC2InstanceSample.py
 - shortcuts for Ref and GetAtt
 - introduced ro_attributes class constant, which lists read-only attributes, to check if GetAtt calls are valid.

What is missing/badly implemented:
 - resource references inside lists like `NetworkInterfaces=[eth0, eth1]` do not work (yet)
 - only Ec2::Instance has its read-only attributes listed
 - `str.format` instead of `Join` is not yet implemented
 - weird method/function names and placement
 - if a resource is bound to two variables in the same scope, bad things will happen. This is not yet checked.
 - name is not required anymore in BaseAWSObject, as I set it afterwards.

I've tried to implement some of this some time ago but got confused: https://github.com/fungusakafungus/python-cfn-templates. That thing had str.format to `Fn::Join` conversion working.
