### PR TITLE
Add VPNConnectionRoute object and attribute to VPNConnection

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -342,7 +342,17 @@ class VPNConnection(AWSObject):
     props = {
         'Type': (basestring, True),
         'CustomerGatewayId': (basestring, True),
+	'StaticRoutesOnly' : (boolean, False),
         'VpnGatewayId': (basestring, True),
+        'Tags': (list, False),
+    }
+
+class VPNConnectionRoute(AWSObject):
+    type = "AWS::EC2::VPNConnectionRoute"
+
+    props = {
+        'DestinationCidrBlock': (basestring, True),
+        'VpnConnectionId': (basestring, True),
     }
 
 


### PR DESCRIPTION
Here is a quick/simple update to add VPNConnectionRoute as an available object, and to add the 'StaticRoutesOnly' and Tags attributes to the VPNConnection object.
