### PR TITLE
Return integer validators as original value

### DIFF
--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -18,20 +18,21 @@ def integer(x):
     if isinstance(x, int):
         return x
     if isinstance(x, basestring):
-        return int(x)
+        int(x)
+        return x
 
 
 def positive_integer(x):
-    x = integer(x)
-    if x < 0:
+    p = integer(x)
+    if p < 0:
         raise ValueError
     return x
 
 
 def integer_range(minimum_val, maximum_val):
     def integer_range_checker(x):
-        x = integer(x)
-        if x < minimum_val or x > maximum_val:
+        i = int(x)
+        if i < minimum_val or i > maximum_val:
             raise ValueError('Integer must be between %d and %d' % (
                 minimum_val, maximum_val))
         return x
@@ -46,7 +47,7 @@ def network_port(x):
     if isinstance(x, AWSHelperFn):
         return x
 
-    x = integer(x)
-    if x < -1 or x > 65535:
+    i = int(x)
+    if i < -1 or i > 65535:
         raise ValueError
     return x


### PR DESCRIPTION
While doing spot checks of json diffs of the original template and converted
through cfn2py I noticed all of the integer values were appearing as integer
values while the original was always strings. This change returns the
original value and reduces the json diff to only be boolean changes.
