### PR TITLE
Prepare for travis-ci: add awacs to tests_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,6 @@ setup(
     packages=['troposphere'],
     scripts=['scripts/cfn', 'scripts/cfn2py'],
     test_suite="tests",
+    tests_require=["awacs"],
     use_2to3=True,
 )


### PR DESCRIPTION
awacs is used in examples/IAM_Users_snippet.py
