### PR TITLE
Change InstanceProfile's Path prop to be optional

### DIFF
--- a/troposphere/iam.py
+++ b/troposphere/iam.py
@@ -60,7 +60,7 @@ class InstanceProfile(AWSObject):
     type = "AWS::IAM::InstanceProfile"
 
     props = {
-        'Path': (basestring, True),
+        'Path': (basestring, False),
         'Roles': (list, True),
     }
 


### PR DESCRIPTION
Path is optional and defaults to '/': http://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateInstanceProfile.html
