### PR TITLE
Change Role's Path prop to be optional

### DIFF
--- a/troposphere/iam.py
+++ b/troposphere/iam.py
@@ -70,7 +70,7 @@ class Role(AWSObject):
 
     props = {
         'AssumeRolePolicyDocument': (policytypes, True),
-        'Path': (basestring, True),
+        'Path': (basestring, False),
         'Policies': ([Policy], False),
     }
 


### PR DESCRIPTION
Path is optional and defaults to '/': http://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateRole.html
