### PR TITLE
Make PortRange options in NetworkACLEntry.

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -176,7 +176,7 @@ class NetworkAclEntry(AWSObject):
         'Egress': (boolean, True),
         'Icmp': (ICMP, False),  # Conditional
         'NetworkAclId': (basestring, True),
-        'PortRange': (PortRange, True),
+        'PortRange': (PortRange, False),  # Conditional
         'Protocol': (network_port, True),
         'RuleAction': (basestring, True),
         'RuleNumber': (integer_range(1, 32766), True),


### PR DESCRIPTION
The PortRange should be optional since it is not required when the protocol doesn't need it. For example, when adding an ICMP rule.
