### PR TITLE
Allow tags to be set on security groups.

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -287,6 +287,7 @@ class SecurityGroup(AWSObject):
         'SecurityGroupEgress': (list, False),
         'SecurityGroupIngress': (list, False),
         'VpcId': (basestring, False),
+        'Tags': (list, False),
     }
 
 


### PR DESCRIPTION
EC2 classic security groups don't support tags; if you try to set them, your template/stack will fail.
