### PR TITLE
Fix to NetworkInterfaceProperty and DHCPOptions

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -99,7 +99,7 @@ class NetworkInterfaceProperty(AWSProperty):
         'DeleteOnTermination': (boolean, False),
         'Description': (basestring, False),
         'DeviceIndex': (basestring, True),
-        'GroupSet': ([basestring], False),
+        'GroupSet': (list, False),
         'NetworkInterfaceId': (basestring, False),
         'PrivateIpAddress': (basestring, False),
         'PrivateIpAddresses': ([PrivateIpAddressSpecification], False),


### PR DESCRIPTION
DHCPOptions is duplicate, the NetworkInterfaceProperty fix is to allow for a list of refs...
