### PR TITLE
Add support to ELB ConnectionDrainingPolicy

### DIFF
--- a/examples/ELBSample.py
+++ b/examples/ELBSample.py
@@ -84,6 +84,10 @@ def main():
     elasticLB = template.add_resource(elb.LoadBalancer(
         'ElasticLoadBalancer',
         AvailabilityZones=GetAZs(""),
+        ConnectionDrainingPolicy=elb.ConnectionDrainingPolicy(
+            Enabled=True,
+            Timeout=300,
+        ),
         Instances=[Ref(r) for r in web_instances],
         Listeners=[
             elb.Listener(

--- a/tests/examples_output/ELBSample.template
+++ b/tests/examples_output/ELBSample.template
@@ -124,6 +124,10 @@
                 "AvailabilityZones": {
                     "Fn::GetAZs": ""
                 }, 
+                "ConnectionDrainingPolicy": {
+                    "Enabled": true, 
+                    "Timeout": 300
+                }, 
                 "HealthCheck": {
                     "HealthyThreshold": "3", 
                     "Interval": "30", 

--- a/troposphere/elasticloadbalancing.py
+++ b/troposphere/elasticloadbalancing.py
@@ -52,12 +52,20 @@ class Policy(AWSProperty):
     }
 
 
+class ConnectionDrainingPolicy(AWSProperty):
+    props = {
+        'Enabled': (bool, True),
+        'Timeout': (int, False)
+    }
+
+
 class LoadBalancer(AWSObject):
     type = "AWS::ElasticLoadBalancing::LoadBalancer"
 
     props = {
         'AppCookieStickinessPolicy': (list, False),
         'AvailabilityZones': (list, False),
+        'ConnectionDrainingPolicy': (ConnectionDrainingPolicy, False),
         'CrossZone': (boolean, False),
         'HealthCheck': (HealthCheck, False),
         'Instances': (list, False),


### PR DESCRIPTION
AWS release note: http://aws.typepad.com/aws/2014/03/elb-connection-draining-remove-instances-from-service-with-care.html

If this happens to get merged, can you please tell me when you are going to cut a new release?
