### PR TITLE
AllocatedStorage must be numeric

### DIFF
--- a/troposphere/rds.py
+++ b/troposphere/rds.py
@@ -11,7 +11,7 @@ class DBInstance(AWSObject):
     type = "AWS::RDS::DBInstance"
 
     props = {
-        'AllocatedStorage': (basestring, True),
+        'AllocatedStorage': (int, True),
         'AutoMinorVersionUpgrade': (boolean, False),
         'AvailabilityZone': (basestring, False),
         'BackupRetentionPeriod': (basestring, False),


### PR DESCRIPTION
If a template is passed with a string value for AllocatedStorage, the following cloudformation error occurs:

```
CREATE_FAILED AWS::RDS::DBInstance rdsInstance  Encountered non numeric value for property AllocatedStorage
```

Outputting as an integer by changing this value fixes the template.
