### PR TITLE
Improved cfn2py

### DIFF
--- a/scripts/cfn2py
+++ b/scripts/cfn2py
@@ -165,7 +165,7 @@ def output_value(v):
     if isinstance(v, basestring):
         return '"%s"' % (v,)
     elif isinstance(v, bool):
-        return '"%s"' % (str(v).lower(),)
+        return '%s' % (str(v))
     elif isinstance(v, list):
         return "[" + ", ".join(map(output_value, v)) + "]"
 

--- a/scripts/cfn2py
+++ b/scripts/cfn2py
@@ -243,7 +243,7 @@ function_map = {
     'Fn::GetAtt': ("GetAtt", handle_one_object),
     'Fn::GetAZs': ("GetAZs", handle_no_objects),
     'Fn::Join': ("Join", handle_no_objects),
-    'Fn::Select': ("Select", handle_no_objects),
+    'Fn::Select': ("Select", handle_one_object),
     'Ref': ("Ref", handle_one_object),
 }
 

--- a/scripts/cfn2py
+++ b/scripts/cfn2py
@@ -163,7 +163,7 @@ function_map = {
 def output_value(v):
     """Output a value which may be a string or a set of function calls."""
     if isinstance(v, basestring):
-        return '"%s"' % (v,)
+        return '"%s"' % (v.replace('\\', '\\\\').replace('\n', '\\n').replace("\"", "\\\""))
     elif isinstance(v, bool):
         return '%s' % (str(v))
     elif isinstance(v, list):

--- a/scripts/cfn2py
+++ b/scripts/cfn2py
@@ -254,6 +254,8 @@ def output_value(v):
         return '"%s"' % (v.replace('\\', '\\\\').replace('\n', '\\n').replace("\"", "\\\""))
     elif isinstance(v, bool):
         return '%s' % (str(v))
+    elif isinstance(v, int):
+        return '%d' % (v)
     elif isinstance(v, list):
         return "[" + ", ".join(map(output_value, v)) + "]"
 

--- a/scripts/cfn2py
+++ b/scripts/cfn2py
@@ -118,7 +118,7 @@ def generate_troposphere_object(typename):
 def output_dict(d):
     out = []
     for k,v in d.items():
-        out.append("%s=%s" % (k, output_value(v)))
+        out.append("%s=%s" % (k.replace('\\', '\\\\'), output_value(v)))
     return ", ".join(out)
 
 known_functions = {

--- a/scripts/cfn2py
+++ b/scripts/cfn2py
@@ -72,7 +72,7 @@ def do_parameters(d):
         print '%s = t.add_parameter(Parameter(' % (object_name,)
         print '    "%s",' % (k, )
         for pk, pv in v.items():
-            print '    %s="%s",' % (pk, pv)
+            print '    %s=%s,' % (pk, output_value(pv))
         print "))"
         print
 

--- a/scripts/cfn2py
+++ b/scripts/cfn2py
@@ -113,19 +113,20 @@ def do_resources(d):
         (_, tropo_object) = generate_troposphere_object(v['Type'])
         print '%s = t.add_resource(%s(' % (object_name, tropo_object)
         print '    "%s",' % (k, )
-        for pk, pv in v['Properties'].items():
-            if pk == "Tags":
-                print '    Tags=Tags('
-                for d in pv:
-                    print "        %s=%s," % (
-                        d['Key'], output_value(d['Value']))
-                print '    )'
-            elif pk == 'PortRange':
-                print "    %s=%s(%s)," % (pk, pk, output_dict(pv))
-            elif isinstance(pv, basestring):
-                print '    %s="%s",' % (pk, pv)
-            else:
-                print '    %s=%s,' % (pk, output_value(pv))
+        if v.has_key('Properties'):
+            for pk, pv in v['Properties'].items():
+                if pk == "Tags":
+                    print '    Tags=Tags('
+                    for d in pv:
+                        print "        %s=%s," % (
+                            d['Key'], output_value(d['Value']))
+                    print '    )'
+                elif pk == 'PortRange':
+                    print "    %s=%s(%s)," % (pk, pk, output_dict(pv))
+                elif isinstance(pv, basestring):
+                    print '    %s="%s",' % (pk, pv)
+                else:
+                    print '    %s=%s,' % (pk, output_value(pv))
         print "))"
         print
 

--- a/scripts/cfn2py
+++ b/scripts/cfn2py
@@ -169,6 +169,7 @@ def output_value(v):
     elif isinstance(v, list):
         return "[" + ", ".join(map(output_value, v)) + "]"
 
+    out = []
     # Should only be one of these...
     for fk, fv in v.items():
         if fk in function_map:
@@ -176,6 +177,9 @@ def output_value(v):
             if not isinstance(fv, list):
                 fv = [fv]
             return handler(shortname, fv)
+        else:
+            out.append( '"' + fk + '": ' + output_value(fv))
+    return "{ " + ", ".join(out) + " }"
 
 
 def do_outputs(d):

--- a/scripts/cfn2py
+++ b/scripts/cfn2py
@@ -173,7 +173,7 @@ def output_value(v):
     for fk, fv in v.items():
         if fk in function_map:
             (shortname, handler) = function_map[fk]
-            if isinstance(fv, basestring):
+            if not isinstance(fv, list):
                 fv = [fv]
             return handler(shortname, fv)
 

--- a/scripts/cfn2py
+++ b/scripts/cfn2py
@@ -23,7 +23,7 @@ class object_registry(object):
         if o in self.objects:
             return self.objects[o]
         else:
-            return '"%s"' % o
+            return output_value(o)
 
 objects = object_registry()
 

--- a/scripts/cfn2py
+++ b/scripts/cfn2py
@@ -167,6 +167,10 @@ def do_resources_content(k, v):
     else:
         do_output_function(k, k, v)
 
+top_level_aliases = {
+    "RecordSet": "RecordSetType",
+    "Policy":    "PolicyType",
+}
 
 def do_resources(d):
     """Output the template Resources"""
@@ -174,6 +178,8 @@ def do_resources(d):
     for k, v in resources.items():
         object_name = objects.add(k)
         (_, tropo_object) = generate_troposphere_object(v['Type'])
+        if(top_level_aliases.has_key(tropo_object)):
+            tropo_object = top_level_aliases[tropo_object]
         print '%s = t.add_resource(%s(' % (object_name, tropo_object)
         print '    "%s",' % (k, )
         if v.has_key('Properties'):

--- a/scripts/cfn2py
+++ b/scripts/cfn2py
@@ -29,7 +29,7 @@ objects = object_registry()
 
 object_functions = {
     "Table":        [ "ProvisionedThroughput", "PrimaryKey", "Element" ],
-    "LoadBalancer": [ "HealthCheck" ],
+    "LoadBalancer": [ "HealthCheck", "ConnectionDrainingPolicy", "AccessLoggingPolicy" ],
     "Queue":        [ "RedrivePolicy" ],
     "Bucket":       [ "WebsiteConfiguration" ],
     "User":         [ "LoginProfile" ],
@@ -51,6 +51,7 @@ def do_header(d):
     """
     print 'from troposphere import Base64, Select, FindInMap, GetAtt, GetAZs, Join, Output'
     print 'from troposphere import Parameter, Ref, Tags, Template'
+    print 'from troposphere.cloudformation import Init'
     print 'from troposphere.cloudfront import Distribution, DistributionConfig'
     print 'from troposphere.cloudfront import Origin, DefaultCacheBehavior'
     print 'from troposphere.ec2 import PortRange'
@@ -133,6 +134,9 @@ known_functions = {
     "HashKeyElement":           1,
     "HealthCheck":              1,
     "LoginProfile":             1,
+    "ConnectionDrainingPolicy": 1,
+    "AccessLoggingPolicy":      1,
+    "AWS::CloudFormation::Init":1,
 }
 
 function_quirks = {
@@ -141,13 +145,14 @@ function_quirks = {
     "NetworkInterfaces":  [ "NetworkInterfaceProperty" ],
     "Subscription":       [ "Subscription" ],
     "LoginProfile":       { "LoginProfile": ["Password"] },
+    "AWS::CloudFormation::Init": {"Init": []},
 }
 
 def do_output_function(k, f, v):
     print '    %s=%s(' % (k, f)
     for pk, pv in v.items():
         if known_functions.has_key(pk):
-            do_resources_content(pk, pv)
+            do_resources_content(pk, pv, "")
         else:
             print "        %s=%s," % (pk, output_value(pv))
     print '    ),'
@@ -172,15 +177,25 @@ def do_output_quirk_mapping(k, v):
             print "        %s," % (output_value(v[e]))
         print '    ),'
 
-def do_resources_content(k, v):
+def do_output_quirk_metadata(k, v):
+    m = function_quirks[k]
+    for pk in m.keys():
+        print '    Metadata=%s(' % (pk)
+        print "        %s," % (output_value(v))
+        print '    ),'
+
+def do_resources_content(k, v, p):
     if function_quirks.has_key(k):
         x = function_quirks[k];
         if(isinstance(x, dict)):
-           do_output_quirk_mapping(k, v)
+            if(p == "Metadata"):
+                do_output_quirk_metadata(k, v)
+            else:
+                do_output_quirk_mapping(k, v)
         elif(isinstance(x, list)):
-           do_output_quirk_list(k, function_quirks[k][0], v)
+           do_output_quirk_list(k, x[0], v)
         else:
-           do_output_function(k, function_quirks[k], v)
+           do_output_function(k, x, v)
     else:
         do_output_function(k, k, v)
 
@@ -199,8 +214,8 @@ def do_resources(d):
             tropo_object = top_level_aliases[tropo_object]
         print '%s = t.add_resource(%s(' % (object_name, tropo_object)
         print '    "%s",' % (k, )
-        if v.has_key('Properties'):
-            for pk, pv in v['Properties'].items():
+        for p in filter(lambda x: v.has_key(x), ['Metadata', 'Properties']):
+            for pk, pv in v[p].items():
                 if pk == "Tags":
                     print '    Tags=Tags('
                     for d in pv:
@@ -210,11 +225,13 @@ def do_resources(d):
                 elif pk == 'PortRange':
                     print "    %s=%s(%s)," % (pk, pk, output_dict(pv))
                 elif known_functions.has_key(pk):
-                    do_resources_content(pk, pv)
+                    do_resources_content(pk, pv, p)
                 elif isinstance(pv, basestring):
                     print '    %s="%s",' % (pk, pv)
                 else:
                     print '    %s=%s,' % (pk, output_value(pv))
+        if v.has_key("DependsOn"):
+            print '    %s=%s,' % ("DependsOn", output_value(v['DependsOn']))
         print "))"
         print
 

--- a/scripts/cfn2py
+++ b/scripts/cfn2py
@@ -167,10 +167,7 @@ def output_value(v):
     elif isinstance(v, bool):
         return '"%s"' % (str(v).lower(),)
     elif isinstance(v, list):
-        out = []
-        for item in v:
-            out.append(output_value(item))
-        return "[" + ", ".join(out) + "]"
+        return "[" + ", ".join(map(output_value, v)) + "]"
 
     # Should only be one of these...
     for fk, fv in v.items():

--- a/scripts/cfn2py
+++ b/scripts/cfn2py
@@ -120,7 +120,7 @@ def do_resources(d):
                     for d in pv:
                         print "        %s=%s," % (
                             d['Key'], output_value(d['Value']))
-                    print '    )'
+                    print '    ),'
                 elif pk == 'PortRange':
                     print "    %s=%s(%s)," % (pk, pk, output_dict(pv))
                 elif isinstance(pv, basestring):

--- a/scripts/cfn2py
+++ b/scripts/cfn2py
@@ -27,6 +27,23 @@ class object_registry(object):
 
 objects = object_registry()
 
+object_functions = {
+    "Table":        [ "ProvisionedThroughput", "PrimaryKey", "Element" ],
+    "LoadBalancer": [ "HealthCheck" ],
+    "Queue":        [ "RedrivePolicy" ],
+    "Bucket":       [ "WebsiteConfiguration" ],
+    "User":         [ "LoginProfile" ],
+    "Topic":        [ "Subscription" ],
+    "Instance":     [ "NetworkInterfaceProperty" ],
+    "RecordSet":    [ "RecordSetType" ],
+    "Policy":       [ "PolicyType" ],
+}
+
+def additional_imports(o):
+    if object_functions.has_key(o):
+        return ", ".join([o] + object_functions[o])
+    else:
+        return o
 
 def do_header(d):
     """Output a stock header for the new Python script and also try to
@@ -46,7 +63,7 @@ def do_header(d):
             (mod, tropo_object) = generate_troposphere_object(v['Type'])
             if tropo_object not in seen:
                 seen.append(tropo_object)
-                print 'from troposphere.%s import %s' % (mod, tropo_object,)
+                print 'from troposphere.%s import %s' % (mod, additional_imports(tropo_object))
     print
     print
     print "t = Template()"

--- a/scripts/cfn2py
+++ b/scripts/cfn2py
@@ -104,6 +104,69 @@ def output_dict(d):
         out.append("%s=%s" % (k, output_value(v)))
     return ", ".join(out)
 
+known_functions = {
+    "DistributionConfig":       1,
+    "DefaultCacheBehavior":     1,
+    "ProvisionedThroughput":    1,
+    "NetworkInterfaces":        1,
+    "WebsiteConfiguration":     1,
+    "RedrivePolicy":            1,
+    "Subscription":             1,
+    "KeySchema":                1,
+    "HashKeyElement":           1,
+    "HealthCheck":              1,
+    "LoginProfile":             1,
+}
+
+function_quirks = {
+    "KeySchema":          "PrimaryKey",
+    "HashKeyElement":     { "Element": ["AttributeName", "AttributeType"] },
+    "NetworkInterfaces":  [ "NetworkInterfaceProperty" ],
+    "Subscription":       [ "Subscription" ],
+    "LoginProfile":       { "LoginProfile": ["Password"] },
+}
+
+def do_output_function(k, f, v):
+    print '    %s=%s(' % (k, f)
+    for pk, pv in v.items():
+        if known_functions.has_key(pk):
+            do_resources_content(pk, pv)
+        else:
+            print "        %s=%s," % (pk, output_value(pv))
+    print '    ),'
+
+def do_output_quirk_list(k, f, v):
+    print '    %s=[' % (k)
+    for e in v:
+        print '    %s(' % (f)
+        for pk, pv in e.items():
+            if known_functions.has_key(pk):
+                do_resources_content(pk, pv)
+            else:
+                print "        %s=%s," % (pk, output_value(pv))
+        print '    ),'
+    print '    ],'
+
+def do_output_quirk_mapping(k, v):
+    m = function_quirks[k]
+    for pk in m.keys():
+        print '    %s=%s(' % (k, pk)
+        for e in m[pk]:
+            print "        %s," % (output_value(v[e]))
+        print '    ),'
+
+def do_resources_content(k, v):
+    if function_quirks.has_key(k):
+        x = function_quirks[k];
+        if(isinstance(x, dict)):
+           do_output_quirk_mapping(k, v)
+        elif(isinstance(x, list)):
+           do_output_quirk_list(k, function_quirks[k][0], v)
+        else:
+           do_output_function(k, function_quirks[k], v)
+    else:
+        do_output_function(k, k, v)
+
 
 def do_resources(d):
     """Output the template Resources"""
@@ -123,6 +186,8 @@ def do_resources(d):
                     print '    ),'
                 elif pk == 'PortRange':
                     print "    %s=%s(%s)," % (pk, pk, output_dict(pv))
+                elif known_functions.has_key(pk):
+                    do_resources_content(pk, pv)
                 elif isinstance(pv, basestring):
                     print '    %s="%s",' % (pk, pv)
                 else:

--- a/scripts/cfn2py
+++ b/scripts/cfn2py
@@ -133,13 +133,7 @@ def do_resources(d):
 
 def handle_no_objects(name, values):
     """Handle intrinsic functions which do not have a named resource"""
-    ret = name + "("
-    for i, param in enumerate(values):
-        if i > 0:
-            ret += ", "
-        ret += output_value(param)
-    return ret + ")"
-
+    return name + "(" + ", ".join(map(output_value, values)) + ")"
 
 def handle_one_object(name, values):
     """Handle intrinsic functions which have a single named resource"""

--- a/scripts/cfn2py
+++ b/scripts/cfn2py
@@ -32,7 +32,7 @@ def do_header(d):
     """Output a stock header for the new Python script and also try to
     figure out the Resource imports needed by the template.
     """
-    print 'from troposphere import Base64, FindInMap, GetAtt, Join, Output'
+    print 'from troposphere import Base64, Select, FindInMap, GetAtt, GetAZs, Join, Output'
     print 'from troposphere import Parameter, Ref, Tags, Template'
     print 'from troposphere.cloudfront import Distribution, DistributionConfig'
     print 'from troposphere.cloudfront import Origin, DefaultCacheBehavior'


### PR DESCRIPTION
Hi,

I improved cfn2py to the point where it can roundtrip the examples (except for the OpenStack examples). It also works with some private files that include AWS::CloudFormation::Init sections.

Though not perfect and not used every day, cfn2py was my gateway to using troposphere. I think these improvements might help the next future users to step onboard.

To test with the examples, I used the following script:
```bash
#!/bin/sh

if ! [ -d tmp ] ; then mkdir tmp ; fi

for i in examples/*.py ; do
    BASE=tmp/`basename $i .py`
    if python $i >$BASE.json1 2>&1 ; then
        echo $i;
        ./scripts/cfn2py $BASE.json1 > $BASE.py ;
        python $BASE.py > $BASE.json2 ;
        cmp $BASE.json1 $BASE.json2
    fi
done
```

Sincerely,
Mathias Brossard
PS: I haven't coded much in Python, so there is probably some room for improvement.