### PR TITLE
Patching Users class to use basestring or Ref type for Groups

### DIFF
--- a/troposphere/iam.py
+++ b/troposphere/iam.py
@@ -88,7 +88,7 @@ class User(AWSObject):
 
     props = {
         'Path': (basestring, False),
-        'Groups': ([Group], False),
+        'Groups': ([basestring, Ref], False),
         'LoginProfile': (LoginProfile, False),
         'Policies': ([Policy], False),
     }


### PR DESCRIPTION
Patching Users class to use basestring or Ref type for Groups and not the Groups type.
See: https://github.com/cloudtools/troposphere/issues/78
