### PR TITLE
Updating the block device options for ASGs

### DIFF
--- a/troposphere/autoscaling.py
+++ b/troposphere/autoscaling.py
@@ -153,15 +153,21 @@ class Trigger(AWSObject):
 
 
 class EBSBlockDevice(AWSProperty):
+    # http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig-blockdev-template.html
     props = {
+        'DeleteOnTermination': (boolean, False),
+        'Iops': (integer, False),
         'SnapshotId': (basestring, False),
         'VolumeSize': (integer, False),
+        'VolumeType': (basestring, False),
     }
 
 
 class BlockDeviceMapping(AWSProperty):
+    # http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig-blockdev-mapping.html
     props = {
         'DeviceName': (basestring, True),
         'Ebs': (EBSBlockDevice, False),
+        'NoDevice': (boolean, False),
         'VirtualName': (basestring, False),
     }


### PR DESCRIPTION
There are more options available for block device launch configs, so I have updated them.

This also allows you to take advantage of the new General Purpose SSDs by doing this:

``` python
launchConfig = t.add_resource(asg.LaunchConfiguration(
    "launchConfig",
    BlockDeviceMappings=[asg.BlockDeviceMapping(
        DeviceName="/dev/sda1",
        Ebs=asg.EBSBlockDevice(
            VolumeType="gp2"
        )
    )],
   ...
))
```

Tested this and it works in `eu-west-1`
