### PR TITLE
Add VpcPeeringConnectionId parameter to EC2 Route

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -218,6 +218,7 @@ class Route(AWSObject):
         'InstanceId': (basestring, False),
         'NetworkInterfaceId': (basestring, False),
         'RouteTableId': (basestring, True),
+        'VpcPeeringConnectionId': (basestring, False),
     }
 
 


### PR DESCRIPTION
Ref: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-route.html
