### PR TITLE
makes MasterUsername and MasterPassword optional

### DIFF
--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -1,0 +1,43 @@
+import unittest
+import troposphere.rds as rds
+
+
+class TestRDS(unittest.TestCase):
+
+    def test_it_allows_an_rds_instance_created_from_a_snapshot(self):
+        rds_instance = rds.DBInstance(
+            'SomeTitle',
+            AllocatedStorage=1,
+            DBInstanceClass='db.m1.small',
+            Engine='MySQL',
+            DBSnapshotIdentifier='SomeSnapshotIdentifier'
+        )
+
+        rds_instance.JSONrepr()
+
+    def test_it_allows_an_rds_instance_with_master_username_and_password(self):
+        rds_instance = rds.DBInstance(
+            'SomeTitle',
+            AllocatedStorage=1,
+            DBInstanceClass='db.m1.small',
+            Engine='MySQL',
+            MasterUsername='SomeUsername',
+            MasterUserPassword='SomePassword'
+        )
+
+        rds_instance.JSONrepr()
+
+    def test_it_rds_instances_require_either_a_snapshot_or_credentials(self):
+        rds_instance = rds.DBInstance(
+            'SomeTitle',
+            AllocatedStorage=1,
+            DBInstanceClass='db.m1.small',
+            Engine='MySQL'
+        )
+
+        with self.assertRaisesRegexp(
+                ValueError,
+                'Either \(MasterUsername and MasterUserPassword\) or'
+                ' DBSnapshotIdentifier are required'
+                ):
+            rds_instance.JSONrepr()

--- a/troposphere/rds.py
+++ b/troposphere/rds.py
@@ -38,6 +38,22 @@ class DBInstance(AWSObject):
         'VPCSecurityGroups': ([basestring, AWSHelperFn], False),
     }
 
+    def validate(self):
+        if (
+            'DBSnapshotIdentifier' not in self.properties
+            and (
+                'MasterUsername' not in self.properties
+                or 'MasterUserPassword' not in self.properties
+            )
+        ):
+            raise ValueError(
+                'Either (MasterUsername and MasterUserPassword) or'
+                ' DBSnapshotIdentifier are required in type '
+                'AWS::RDS::DBInstance.'
+            )
+
+        return True
+
 
 class DBParameterGroup(AWSObject):
     type = "AWS::RDS::DBParameterGroup"


### PR DESCRIPTION
, since they are not required if you create an RDS instance from a snapshot

http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-masterusername
