### PR TITLE
Add LogDeliveryWrite canned ACL for S3 bucket

### DIFF
--- a/troposphere/s3.py
+++ b/troposphere/s3.py
@@ -18,7 +18,7 @@ PublicReadWrite = "PublicReadWrite"
 AuthenticatedRead = "AuthenticatedRead"
 BucketOwnerRead = "BucketOwnerRead"
 BucketOwnerFullControl = "BucketOwnerFullControl"
-LogDeliveryWrite="LogDeliveryWrite"
+LogDeliveryWrite = "LogDeliveryWrite"
 
 
 class CorsRules(AWSProperty):
@@ -118,6 +118,7 @@ class Bucket(AWSObject):
         AuthenticatedRead,
         BucketOwnerRead,
         BucketOwnerFullControl,
+        LogDeliveryWrite,
     ]
 
     def __init__(self, name, **kwargs):


### PR DESCRIPTION
Valid value "LogDeliveryWrite" was missing based on
http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-accesscontrol
