### PR TITLE
Add support for RDS StorageType

### DIFF
--- a/troposphere/rds.py
+++ b/troposphere/rds.py
@@ -35,6 +35,7 @@ class DBInstance(AWSObject):
         'PreferredMaintenanceWindow': (basestring, False),
         'PubliclyAccessible': (boolean, False),
         'SourceDBInstanceIdentifier': (basestring, False),
+        'StorageType': (basestring, False),
         'Tags': (list, False),
         'VPCSecurityGroups': ([basestring, AWSHelperFn], False),
     }


### PR DESCRIPTION
This parameter specifies the storage type to be associated with a DBInstance.
