### PR TITLE
ConfigurationTemplate is an Object

### DIFF
--- a/troposphere/elasticbeanstalk.py
+++ b/troposphere/elasticbeanstalk.py
@@ -35,7 +35,9 @@ class OptionSettings(AWSProperty):
     }
 
 
-class ConfigurationTemplate(AWSProperty):
+class ConfigurationTemplate(AWSObject):
+    type = "AWS::ElasticBeanstalk::ConfigurationTemplate"
+
     props = {
         'TemplateName': (basestring, True),
         'Description': (basestring, False),


### PR DESCRIPTION
ConfigurationTemplate objects are incorrectly marked as properties.

```
$ aws cloudformation validate-template --template-body file:///tmp/test_env.tmpl                                                                            

A client error (ValidationError) occurred when calling the ValidateTemplate operation: Invalid template resource property 'OptionSettings'
```
