### PR TITLE
Remove duplicate security_group from port

### DIFF
--- a/troposphere/openstack/neutron.py
+++ b/troposphere/openstack/neutron.py
@@ -245,7 +245,6 @@ class Port(AWSObject):
     props = {
         'admin_state_up': (boolean, False),
         'allowed_address_pairs': (list, False),
-        'security_groups': (list, True),
         'device_id': (basestring, False),
         'fixed_ips': (list, False),
         'mac_address': (basestring, False),


### PR DESCRIPTION
In the OS::Neutron::Port resource, we had security_group defined
twice.

According to the OpenStack documentation (http://docs.openstack.org/developer/heat/template_guide/openstack.html#OS::Neutron::Port)
this resource is optional.

This fixes https://github.com/cloudtools/troposphere/issues/142
