### PR TITLE
Fix warning in description

### DIFF
--- a/examples/CloudFront_S3.py
+++ b/examples/CloudFront_S3.py
@@ -13,7 +13,7 @@ t.add_description(
     "AWS CloudFormation Sample Template CloudFront_S3: Sample template "
     "showing how to create an Amazon CloudFront distribution using an "
     "S3 origin. "
-    "**WARNING** This template creates a CloudFront distribution."
+    "**WARNING** This template creates a CloudFront distribution. "
     "You will be billed for the AWS resources used if you create "
     "a stack from this template.")
 

--- a/tests/examples_output/CloudFront_S3.template
+++ b/tests/examples_output/CloudFront_S3.template
@@ -1,5 +1,5 @@
 {
-    "Description": "AWS CloudFormation Sample Template CloudFront_S3: Sample template showing how to create an Amazon CloudFront distribution using an S3 origin. **WARNING** This template creates an Amazon EC2 instance. You will be billed for the AWS resources used if you create a stack from this template.", 
+    "Description": "AWS CloudFormation Sample Template CloudFront_S3: Sample template showing how to create an Amazon CloudFront distribution using an S3 origin. **WARNING** This template creates a CloudFront distribution. You will be billed for the AWS resources used if you create a stack from this template.", 
     "Outputs": {
         "DistributionId": {
             "Value": {


### PR DESCRIPTION
This example does not generate a EC2 instance so not sure why it carries this warning. I have updated it to reflect that it creates a CloudFrount distribution instead. 
