### PR TITLE
Fixed CreationPolicy

### DIFF
--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -1,0 +1,64 @@
+import json
+import unittest
+
+from troposphere import awsencode
+from troposphere.policies import CreationPolicy, ResourceSignal, UpdatePolicy, AutoScalingRollingUpdate
+
+class TestCreationPolicy(unittest.TestCase):
+
+    def test_pausetime(self):
+        with self.assertRaises(ValueError):
+            CreationPolicy(ResourceSignal = ResourceSignal(Count = 2,Timeout = '90'))
+
+    def test_works(self):
+        policy = CreationPolicy(
+            ResourceSignal = ResourceSignal(
+                Count = 2,
+                Timeout = 'PT10M'
+            )
+        )
+        self.assertEqual(policy.ResourceSignal.Count, 2)
+        self.assertEqual(policy.ResourceSignal.Timeout, 'PT10M')
+
+    def test_json(self):
+        policy = CreationPolicy(
+            ResourceSignal = ResourceSignal(
+                Count = 2,
+                Timeout = 'PT10M'
+            )
+        )
+        p = json.loads(json.dumps(policy, cls=awsencode))
+        self.assertEqual(p['ResourceSignal']['Count'], 2)
+        self.assertEqual(p['ResourceSignal']['Timeout'], 'PT10M')
+
+
+class TestUpdatePolicy(unittest.TestCase):
+
+    def test_pausetime(self):
+        with self.assertRaises(ValueError):
+            UpdatePolicy(AutoScalingRollingUpdate = AutoScalingRollingUpdate(PauseTime = '90'))
+
+    def test_works(self):
+        p = UpdatePolicy(
+            AutoScalingRollingUpdate = AutoScalingRollingUpdate(
+                MaxBatchSize = 2,
+                MinInstancesInService = 1,
+                PauseTime = 'PT90S',
+                WaitOnResourceSignals = True))
+        self.assertEqual(p.AutoScalingRollingUpdate.MaxBatchSize, 2)
+        self.assertEqual(p.AutoScalingRollingUpdate.MinInstancesInService, 1)
+        self.assertEqual(p.AutoScalingRollingUpdate.PauseTime, 'PT90S')
+        self.assertTrue(p.AutoScalingRollingUpdate.WaitOnResourceSignals)
+
+    def test_json(self):
+        p = UpdatePolicy(
+            AutoScalingRollingUpdate = AutoScalingRollingUpdate(
+                MaxBatchSize = 2,
+                MinInstancesInService = 1,
+                PauseTime = 'PT90S',
+                WaitOnResourceSignals = True))
+        p = json.loads(json.dumps(p, cls=awsencode))
+        self.assertEqual(p['AutoScalingRollingUpdate']['MaxBatchSize'], 2)
+        self.assertEqual(p['AutoScalingRollingUpdate']['MinInstancesInService'], 1)
+        self.assertEqual(p['AutoScalingRollingUpdate']['PauseTime'], 'PT90S')
+        self.assertTrue(p['AutoScalingRollingUpdate']['WaitOnResourceSignals'])

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -36,7 +36,7 @@ class BaseAWSObject(object):
         self.propnames = self.props.keys()
         self.attributes = ['DependsOn', 'DeletionPolicy',
                            'Metadata', 'UpdatePolicy',
-                           'Condition']
+                           'Condition', 'CreationPolicy']
 
         # unset/None is also legal
         if title and not valid_names.match(title):
@@ -171,6 +171,18 @@ class AWSProperty(BaseAWSObject):
 
     def __init__(self, title=None, **kwargs):
         super(AWSProperty, self).__init__(title, **kwargs)
+
+
+class AWSAttribute(BaseAWSObject):
+    dictname = None
+
+    """
+    Used for CloudFormation Resource Attribute objects
+    http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/
+    aws-product-attribute-reference.html
+    """
+    def __init__(self, title=None, **kwargs):
+        super(AWSAttribute, self).__init__(title, **kwargs)
 
 
 def validate_pausetime(pausetime):

--- a/troposphere/policies.py
+++ b/troposphere/policies.py
@@ -1,4 +1,4 @@
-from . import BaseAWSObject, AWSProperty, validate_pausetime
+from . import BaseAWSObject, AWSProperty, AWSAttribute, validate_pausetime
 from .validators import positive_integer, integer, boolean
 
 
@@ -18,7 +18,7 @@ class AutoScalingScheduledAction(AWSProperty):
     }
 
 
-class UpdatePolicy(BaseAWSObject):
+class UpdatePolicy(AWSAttribute):
     props = {
         'AutoScalingRollingUpdate': (AutoScalingRollingUpdate, False),
         'AutoScalingScheduledAction': (AutoScalingScheduledAction, False),
@@ -32,7 +32,7 @@ class ResourceSignal(AWSProperty):
     }
 
 
-class CreationPolicy(BaseAWSObject):
+class CreationPolicy(AWSAttribute):
     props = {
         'ResourceSignal': (ResourceSignal, True),
     }


### PR DESCRIPTION
Added AWSAttribute class
Switched CreationPolicy and UpdatePolicy to use AWS Attribute class
Added unit tests for CreationPolicy and UpdatePolicy

resolves https://github.com/cloudtools/troposphere/issues/154
