### PR TITLE
Adding gsi and lsi functionality

### DIFF
--- a/examples/DynamoDB_Table.py
+++ b/examples/DynamoDB_Table.py
@@ -2,9 +2,8 @@
 # http://aws.amazon.com/cloudformation/aws-cloudformation-templates/
 
 from troposphere import Output, Parameter, Ref, Template
-from troposphere.dynamodb import Element, PrimaryKey, ProvisionedThroughput
+from troposphere.dynamodb import Key, AttributeDefinition, ProvisionedThroughput
 from troposphere.dynamodb import Table
-
 
 t = Template()
 
@@ -54,10 +53,16 @@ writeunits = t.add_parameter(Parameter(
 
 myDynamoDB = t.add_resource(Table(
     "myDynamoDBTable",
-    KeySchema=PrimaryKey(
-        HashKeyElement=Element(Ref(hashkeyname), Ref(hashkeytype))),
+    AttributeDefinitions=[
+        AttributeDefinition(Ref(hashkeyname), Ref(hashkeytype)),
+    ],
+    KeySchema=[
+        Key(Ref(hashkeyname), "HASH")
+    ],
     ProvisionedThroughput=ProvisionedThroughput(
-        Ref(readunits), Ref(writeunits)),
+        Ref(readunits),
+        Ref(writeunits)
+    )
 ))
 
 t.add_output(Output(

--- a/examples/DynamoDb_Table_With_GlobalSecondaryIndex.py
+++ b/examples/DynamoDb_Table_With_GlobalSecondaryIndex.py
@@ -1,0 +1,136 @@
+#!/usr/bin/python
+
+from troposphere import Template, Ref, Output, Join, GetAtt, Parameter
+from troposphere.dynamodb import Key, AttributeDefinition, ProvisionedThroughput, Projection
+from troposphere.dynamodb import Table, GlobalSecondaryIndex
+
+template = Template()
+
+template.add_description("Create a dynamodb table with a global secondary index")
+#N.B. If you remove the provisioning section this works for LocalSecondaryIndexes aswell.
+
+readunits = template.add_parameter(Parameter(
+    "ReadCapacityUnits",
+    Description="Provisioned read throughput",
+    Type="Number",
+    Default="10",
+    MinValue="5",
+    MaxValue="10000",
+    ConstraintDescription="should be between 5 and 10000"
+))
+
+writeunits = template.add_parameter(Parameter(
+    "WriteCapacityUnits",
+    Description="Provisioned write throughput",
+    Type="Number",
+    Default="5",
+    MinValue="5",
+    MaxValue="10000",
+    ConstraintDescription="should be between 5 and 10000"
+))
+
+tableIndexName = template.add_parameter(Parameter(
+    "TableIndexName",
+    Description="Table: Primary Key Field",
+    Type="String",
+    Default="id",
+    AllowedPattern="[a-zA-Z0-9]*",
+    MinLength="1",
+    MaxLength="2048",
+    ConstraintDescription="must contain only alphanumberic characters"
+))
+
+tableIndexDataType = template.add_parameter(Parameter(
+    "TableIndexDataType",
+    Description=" Table: Primary Key Data Type",
+    Type="String",
+    Default="S",
+    AllowedPattern="[S|N|B]",
+    MinLength="1",
+    MaxLength="1",
+    ConstraintDescription="S for string data, N for numeric data, or B for binary data"
+))
+
+secondaryIndexHashName = template.add_parameter(Parameter(
+    "SecondaryIndexHashName",
+    Description="Secondary Index: Primary Key Field",
+    Type="String",
+    Default="tokenType",
+    AllowedPattern="[a-zA-Z0-9]*",
+    MinLength="1",
+    MaxLength="2048",
+    ConstraintDescription="must contain only alphanumberic characters"
+))
+
+secondaryIndexHashDataType = template.add_parameter(Parameter(
+    "SecondaryIndexHashDataType",
+    Description="Secondary Index: Primary Key Data Type",
+    Type="String",
+    Default="S",
+    AllowedPattern="[S|N|B]",
+    MinLength="1",
+    MaxLength="1",
+    ConstraintDescription="S for string data, N for numeric data, or B for binary data"
+))
+
+secondaryIndexRangeName = template.add_parameter(Parameter(
+    "refreshSecondaryIndexRangeName",
+    Description="Secondary Index: Range Key Field",
+    Type="String",
+    Default="tokenUpdatedTime",
+    AllowedPattern="[a-zA-Z0-9]*",
+    MinLength="1",
+    MaxLength="2048",
+    ConstraintDescription="must contain only alphanumberic characters"
+))
+
+secondaryIndexRangeDataType = template.add_parameter(Parameter(
+    "SecondaryIndexRangeDataType",
+    Description="Secondary Index: Range Key Data Type",
+    Type="String",
+    Default="S",
+    AllowedPattern="[S|N|B]",
+    MinLength="1",
+    MaxLength="1",
+    ConstraintDescription="S for string data, N for numeric data, or B for binary data"
+))
+
+
+GSITable = template.add_resource(Table(
+    "GSITable",
+    AttributeDefinitions=[
+        AttributeDefinition(Ref(tableIndexName), Ref(tableIndexDataType)),
+        AttributeDefinition(Ref(secondaryIndexHashName), Ref(secondaryIndexHashDataType)),
+        AttributeDefinition(Ref(secondaryIndexRangeName), Ref(secondaryIndexRangeDataType))       
+    ],
+    KeySchema=[
+        Key(Ref(tableIndexName), "HASH")
+    ],
+    ProvisionedThroughput=ProvisionedThroughput(
+        Ref(readunits),
+        Ref(writeunits)
+    ),
+    GlobalSecondaryIndexes=[
+        GlobalSecondaryIndex(
+            "SecondaryIndex",
+            [
+                Key(Ref(secondaryIndexHashName), "HASH"),
+                Key(Ref(secondaryIndexRangeName), "RANGE")
+            ],
+            Projection("ALL"),
+            ProvisionedThroughput(
+                Ref(readunits),
+                Ref(writeunits)
+            )
+        )
+    ]
+))
+
+template.add_output(Output(
+    "GSITable",
+    Value=Ref(GSITable),
+    Description="Table with a Global Secondary Index",
+))
+
+
+print template.to_json()

--- a/troposphere/dynamodb.py
+++ b/troposphere/dynamodb.py
@@ -6,7 +6,7 @@
 from . import AWSHelperFn, AWSObject, AWSProperty
 
 
-class Element(AWSHelperFn):
+class AttributeDefinition(AWSHelperFn):
     def __init__(self, name, type):
         self.data = {
             'AttributeName': name,
@@ -17,11 +17,15 @@ class Element(AWSHelperFn):
         return self.data
 
 
-class PrimaryKey(AWSProperty):
-    props = {
-        'HashKeyElement': (Element, True),
-        'RangeKeyElement': (Element, False),
-    }
+class Key(AWSProperty):
+    def __init__(self, AttributeName, KeyType):
+        self.data = {
+            'AttributeName': AttributeName,
+            'KeyType': KeyType,
+        }
+
+    def JSONrepr(self):
+        return self.data
 
 
 class ProvisionedThroughput(AWSHelperFn):
@@ -35,11 +39,48 @@ class ProvisionedThroughput(AWSHelperFn):
         return self.data
 
 
+class Projection(AWSHelperFn):
+    def __init__(self, ProjectionType):
+        self.data = {
+            'ProjectionType': ProjectionType,
+        }
+
+    def JSONrepr(self):
+        return self.data
+
+class GlobalSecondaryIndex(AWSHelperFn):
+    def __init__(self, IndexName, KeySchema, Projection, ProvisionedThroughput):
+        self.data = {
+            'IndexName': IndexName,
+            'KeySchema': KeySchema,
+            'Projection': Projection,
+            'ProvisionedThroughput': ProvisionedThroughput,
+        }
+
+    def JSONrepr(self):
+        return self.data
+
+
+class LocalSecondaryIndex(AWSHelperFn):
+    def __init__(self, IndexName, KeySchema, Projection, ProvisionedThroughput):
+        self.data = {
+            'IndexName': IndexName,
+            'KeySchema': KeySchema,
+            'Projection': Projection,
+        }
+
+    def JSONrepr(self):
+        return self.data
+
+
 class Table(AWSObject):
     type = "AWS::DynamoDB::Table"
 
     props = {
-        'KeySchema': (PrimaryKey, True),
+        'KeySchema': ([Key], True),
         'ProvisionedThroughput': (ProvisionedThroughput, True),
+        'AttributeDefinitions': ([AttributeDefinition], False),
         'TableName': (basestring, False),
+        'GlobalSecondaryIndexes': ([GlobalSecondaryIndex], False),
+        'LocalSecondaryIndexes': ([LocalSecondaryIndex], False),
     }


### PR DESCRIPTION
I'm not sure this is complete, but I thought someone might find it useful.

This PR adds support for GlobalSecondaryIndexes & LocalSecondaryIndexes to the dynamo db feature.

To achieve this i had to make the KeySchema section comply with the current [spec](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-keyschema).