### PR TITLE
add ASG-style tag list helper class

### DIFF
--- a/troposphere/autoscaling.py
+++ b/troposphere/autoscaling.py
@@ -33,22 +33,23 @@ class Tag(AWSHelperFn):
     def JSONrepr(self):
         return self.data
 
+
 class Tags(AWSHelperFn):
-    defaultPropagateAtLaunch=True
-    manyType=[type([]), type(())]
+    defaultPropagateAtLaunch = True
+    manyType = [type([]), type(())]
 
     def __init__(self, **kwargs):
         self.tags = []
         for k, v in sorted(kwargs.iteritems()):
             if type(v) in self.manyType:
-              propagate=str(v[1]).lower()
-              v=v[0]
+                propagate = str(v[1]).lower()
+                v = v[0]
             else:
-              propagate=str(self.defaultPropagateAtLaunch).lower()
+                propagate = str(self.defaultPropagateAtLaunch).lower()
             self.tags.append({
                 'Key': k,
                 'Value': v,
-                'PropagateAtLaunch':propagate,
+                'PropagateAtLaunch': propagate,
             })
 
     def JSONrepr(self):


### PR DESCRIPTION
The troposphere.autoscaling.Tags helper class can be used much as the troposphere.Tags class, for the "Tags" field of an auto-scaling group.
The advantage is that you can set a default "PropagateAtLaunch" value (set to True in this case), and for each tag you can specifiy a different propagate property, using the following syntax: asg.Tags=autoscaling.Tags(Name='MyTag', Version=('10.20',False)).
The "MyTag" tag will have the "PropagateAtLaunch" property set to true, while the "Version" tag will have it set to false.
