### PR TITLE
Fixing UpdatePolicy validation

### DIFF
--- a/examples/Autoscaling.py
+++ b/examples/Autoscaling.py
@@ -1,9 +1,10 @@
 from troposphere import Base64, Join
-from troposphere import Parameter, Ref, Template, UpdatePolicy
+from troposphere import Parameter, Ref, Template
 from troposphere import cloudformation, autoscaling
 from troposphere.autoscaling import AutoScalingGroup, Tag
 from troposphere.autoscaling import LaunchConfiguration
 from troposphere.elasticloadbalancing import LoadBalancer
+from troposphere.policies import UpdatePolicy, AutoScalingRollingUpdate
 import troposphere.ec2 as ec2
 import troposphere.elasticloadbalancing as elb
 
@@ -226,11 +227,12 @@ AutoscalingGroup = t.add_resource(AutoScalingGroup(
     AvailabilityZones=[Ref(VPCAvailabilityZone1), Ref(VPCAvailabilityZone2)],
     HealthCheckType="EC2",
     UpdatePolicy=UpdatePolicy(
-        'AutoScalingRollingUpdate',
-        PauseTime='PT5M',
-        MinInstancesInService="1",
-        MaxBatchSize='1',
-        WaitOnResourceSignals=True
+        AutoScalingRollingUpdate=AutoScalingRollingUpdate(
+            PauseTime='PT5M',
+            MinInstancesInService="1",
+            MaxBatchSize='1',
+            WaitOnResourceSignals=True
+        )
     )
 ))
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,9 +1,8 @@
 import json
 import unittest
 from troposphere import awsencode, AWSObject, AWSProperty, Output, Parameter
-from troposphere import Template, UpdatePolicy, Ref
+from troposphere import Template, Ref
 from troposphere.ec2 import Instance, SecurityGroupRule
-from troposphere.autoscaling import AutoScalingGroup
 from troposphere.elasticloadbalancing import HealthCheck
 from troposphere.validators import positive_integer
 
@@ -135,106 +134,6 @@ class TestHealthCheck(unittest.TestCase):
                 Timeout='4',
                 UnhealthyThreshold='9'
             )
-
-
-class TestUpdatePolicy(unittest.TestCase):
-
-    def test_pausetime(self):
-        with self.assertRaises(ValueError):
-            UpdatePolicy('AutoScalingRollingUpdate', PauseTime='90')
-
-    def test_type(self):
-        with self.assertRaises(ValueError):
-            UpdatePolicy('MyCoolPolicy')
-
-    def test_works(self):
-        policy = UpdatePolicy(
-            'AutoScalingRollingUpdate',
-            PauseTime='PT1M5S',
-            MinInstancesInService='2',
-            MaxBatchSize='1',
-        )
-        self.assertEqual(policy.PauseTime, 'PT1M5S')
-
-    def test_mininstances(self):
-        group = AutoScalingGroup(
-            'mygroup',
-            LaunchConfigurationName="I'm a test",
-            MaxSize="1",
-            MinSize="1",
-            UpdatePolicy=UpdatePolicy(
-                'AutoScalingRollingUpdate',
-                PauseTime='PT1M5S',
-                MinInstancesInService='1',
-                MaxBatchSize='1',
-            )
-        )
-        with self.assertRaises(ValueError):
-            self.assertTrue(group.validate())
-
-    def test_mininstances_maxsize_is_ref(self):
-        paramMaxSize = Parameter(
-            "ParamMaxSize",
-            Type="String"
-        )
-        group = AutoScalingGroup(
-            'mygroup',
-            LaunchConfigurationName="I'm a test",
-            MaxSize=Ref(paramMaxSize),
-            MinSize="2",
-            UpdatePolicy=UpdatePolicy(
-                'AutoScalingRollingUpdate',
-                PauseTime='PT1M5S',
-                MinInstancesInService='2',
-                MaxBatchSize="1",
-            )
-        )
-        self.assertTrue(group.validate())
-
-    def test_mininstances_mininstancesinservice_is_ref(self):
-        paramMinInstancesInService = Parameter(
-            "ParamMinInstancesInService",
-            Type="String"
-        )
-        group = AutoScalingGroup(
-            'mygroup',
-            LaunchConfigurationName="I'm a test",
-            MaxSize="4",
-            MinSize="2",
-            UpdatePolicy=UpdatePolicy(
-                'AutoScalingRollingUpdate',
-                PauseTime='PT1M5S',
-                MinInstancesInService=Ref(paramMinInstancesInService),
-                MaxBatchSize="2",
-            )
-        )
-        self.assertTrue(group.validate())
-
-    def test_working(self):
-        group = AutoScalingGroup(
-            'mygroup',
-            LaunchConfigurationName="I'm a test",
-            MaxSize="4",
-            MinSize="2",
-            UpdatePolicy=UpdatePolicy(
-                'AutoScalingRollingUpdate',
-                PauseTime='PT1M5S',
-                MinInstancesInService='2',
-                MaxBatchSize='1',
-            )
-        )
-        self.assertTrue(group.validate())
-
-    def test_updatepolicy_noproperty(self):
-        t = UpdatePolicy('AutoScalingRollingUpdate', PauseTime='PT1M0S')
-        d = json.loads(json.dumps(t, cls=awsencode))
-        with self.assertRaises(KeyError):
-            d['Properties']
-
-    def test_updatepolicy_dictname(self):
-        t = UpdatePolicy('AutoScalingRollingUpdate', PauseTime='PT1M0S')
-        d = json.loads(json.dumps(t, cls=awsencode))
-        self.assertIn('AutoScalingRollingUpdate', d)
 
 
 class TestOutput(unittest.TestCase):

--- a/troposphere/autoscaling.py
+++ b/troposphere/autoscaling.py
@@ -123,18 +123,24 @@ class AutoScalingGroup(AWSObject):
         if 'UpdatePolicy' in self.resource:
             update_policy = self.resource['UpdatePolicy']
 
-            isMinRef = isinstance(update_policy.MinInstancesInService, Ref)
-            isMaxRef = isinstance(self.MaxSize, Ref)
+            if 'AutoScalingRollingUpdate' in update_policy.properties:
+                rolling_update = update_policy.AutoScalingRollingUpdate
 
-            if not (isMinRef or isMaxRef):
-                minCount = int(update_policy.MinInstancesInService)
-                maxCount = int(self.MaxSize)
+                isMinRef = isinstance(
+                    rolling_update.MinInstancesInService,
+                    Ref
+                )
+                isMaxRef = isinstance(self.MaxSize, Ref)
 
-                if minCount >= maxCount:
-                    raise ValueError(
-                        "The UpdatePolicy attribute "
-                        "MinInstancesInService must be less than the "
-                        "autoscaling group's MaxSize")
+                if not (isMinRef or isMaxRef):
+                    maxCount = int(self.MaxSize)
+                    minCount = int(rolling_update.MinInstancesInService)
+
+                    if minCount >= maxCount:
+                        raise ValueError(
+                            "The UpdatePolicy attribute "
+                            "MinInstancesInService must be less than the "
+                            "autoscaling group's MaxSize")
         return True
 
 


### PR DESCRIPTION
Fixes validation using UpdatePolicy introduced to 0.7.0, which had an API-breaking change, but didn't update validation. Also removed the root UpdatePolicy class so not to lead to confusion.

Without this, any use of the new UpdatePolicy will fail to serialize to JSON.