### PR TITLE
Fixes #158

### DIFF
--- a/tests/test_asg.py
+++ b/tests/test_asg.py
@@ -1,0 +1,46 @@
+import unittest
+from troposphere.autoscaling import AutoScalingGroup
+
+
+class TestAutoScalingGroup(unittest.TestCase):
+    def test_exclusive(self):
+        group = AutoScalingGroup(
+            'mygroup',
+            InstanceId="i-1234",
+            LaunchConfigurationName="I'm a test",
+            MaxSize="1",
+            MinSize="1",
+        )
+        with self.assertRaises(ValueError):
+            self.assertTrue(group.validate())
+
+    def test_none(self):
+        group = AutoScalingGroup(
+            'mygroup',
+            MaxSize="1",
+            MinSize="1",
+        )
+        with self.assertRaises(ValueError):
+            self.assertTrue(group.validate())
+
+    def test_instanceid(self):
+        group = AutoScalingGroup(
+            'mygroup',
+            InstanceId="i-1234",
+            MaxSize="1",
+            MinSize="1",
+        )
+        self.assertTrue(group.validate())
+
+    def test_launchconfigurationname(self):
+        group = AutoScalingGroup(
+            'mygroup',
+            LaunchConfigurationName="I'm a test",
+            MaxSize="1",
+            MinSize="1",
+        )
+        self.assertTrue(group.validate())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/troposphere/autoscaling.py
+++ b/troposphere/autoscaling.py
@@ -107,7 +107,7 @@ class AutoScalingGroup(AWSObject):
         'HealthCheckGracePeriod': (int, False),
         'HealthCheckType': (basestring, False),
         'InstanceId': (basestring, False),
-        'LaunchConfigurationName': (basestring, True),
+        'LaunchConfigurationName': (basestring, False),
         'LoadBalancerNames': (list, False),
         'MaxSize': (integer, True),
         'MetricsCollection': ([MetricsCollection], False),
@@ -135,6 +135,16 @@ class AutoScalingGroup(AWSObject):
                         "The UpdatePolicy attribute "
                         "MinInstancesInService must be less than the "
                         "autoscaling group's MaxSize")
+        launch_config = self.properties.get('LaunchConfigurationName')
+        instance_id = self.properties.get('InstanceId')
+        if launch_config and instance_id:
+            raise ValueError("LaunchConfigurationName and InstanceId "
+                             "are mutually exclusive.")
+        if not launch_config and not instance_id:
+            raise ValueError("Must specify either LaunchConfigurationName or "
+                             "InstanceId: http://docs.aws.amazon.com/AWSCloud"
+                             "Formation/latest/UserGuide/aws-properties-as-gr"
+                             "oup.html#cfn-as-group-instanceid")
         return True
 
 


### PR DESCRIPTION
Makes InstanceId and LaunchConfigurationName mutually exclusive, and
conditionally requires one or the other.

http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-instanceid