### PR TITLE
Added Encrypted option to EBSBlockDevice property

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -63,6 +63,7 @@ class EIPAssociation(AWSObject):
 class EBSBlockDevice(AWSProperty):
     props = {
         'DeleteOnTermination': (boolean, False),
+        'Encrypted': (boolean, False),
         'Iops': (int, False),  # Conditional
         'SnapshotId': (basestring, False),  # Conditional
         'VolumeSize': (integer, False),  # Conditional


### PR DESCRIPTION
This is in accordance with http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-blockdev-template.html.