### PR TITLE
Adding AWS::CloudFormation::Init ConfigSets support

### DIFF
--- a/examples/CloudFormation_Init_ConfigSet.py
+++ b/examples/CloudFormation_Init_ConfigSet.py
@@ -1,0 +1,97 @@
+from troposphere import Base64, Join, Output, GetAtt, Tags
+from troposphere import Parameter, Ref, Template
+from troposphere import cloudformation
+import troposphere.ec2 as ec2
+
+t = Template()
+
+t.add_description("Configures an EC2 instance using cfn-init configsets")
+
+key_name = t.add_parameter(Parameter(
+    'KeyName',
+    Type='AWS::EC2::KeyPair::KeyName',
+    Description='Name of an existing EC2 KeyPair to enable SSH access'
+))
+
+ami_id = t.add_parameter(Parameter(
+    'AmiId',
+    Type='String',
+    Default='ami-98aa1cf0'
+))
+
+security_group = t.add_resource(ec2.SecurityGroup(
+    'SecurityGroup',
+    GroupDescription='Allows SSH access from anywhere',
+    SecurityGroupIngress=[
+        ec2.SecurityGroupRule(
+            IpProtocol='tcp',
+            FromPort=22,
+            ToPort=22,
+            CidrIp='0.0.0.0/0'
+        )
+    ],
+    Tags=Tags(
+        Name='ops.cfninit-sg'
+    )
+))
+
+ec2_instance = t.add_resource(ec2.Instance(
+    'Ec2Instance',
+    ImageId=Ref(ami_id),
+    InstanceType='t1.micro',
+    KeyName=Ref(key_name),
+    SecurityGroups=[Ref(security_group)],
+    IamInstanceProfile='PullCredentials',
+    UserData=Base64(Join('', [
+        '#!/bin/bash\n',
+        'sudo apt-get update\n',
+        'sudo apt-get -y install python-setuptools\n',
+        'sudo apt-get -y install python-pip\n',
+        'sudo pip install https://s3.amazonaws.com/cloudformation-examples/',
+        'aws-cfn-bootstrap-latest.tar.gz\n',
+        'cfn-init -s \'', Ref('AWS::StackName'),
+        '\' -r Ec2Instance -c ascending'
+    ])),
+    Metadata=cloudformation.Metadata(
+        cloudformation.Init(
+            cloudformation.InitConfigSets(
+                ascending=['config1', 'config2'],
+                descending=['config2', 'config1']
+            ),
+            config1=cloudformation.InitConfig(
+                commands={
+                    'test': {
+                        'command': 'echo "$CFNTEST" > text.txt',
+                        'env': {
+                            'CFNTEST': 'I come from config1.'
+                        },
+                        'cwd': '~'
+                    }
+                }
+            ),
+            config2=cloudformation.InitConfig(
+                commands={
+                    'test': {
+                        'command': 'echo "$CFNTEST" > text.txt',
+                        'env': {
+                            'CFNTEST': 'I come from config2.'
+                        },
+                        'cwd': '~'
+                    }
+                }
+            )
+        )
+    ),
+    Tags=Tags(
+        Name='ops.cfninit',
+        env='ops'
+    )
+))
+
+t.add_output(Output(
+    'PublicIp',
+    Description='Public IP of the newly created EC2 instance',
+    Value=GetAtt(ec2_instance, 'PublicIp')
+))
+
+print(t.to_json())

--- a/tests/examples_output/CloudFormation_Init_ConfigSet.template
+++ b/tests/examples_output/CloudFormation_Init_ConfigSet.template
@@ -1,0 +1,130 @@
+{
+    "Description": "Configures an EC2 instance using cfn-init configsets",
+    "Outputs": {
+        "PublicIp": {
+            "Description": "Public IP of the newly created EC2 instance",
+            "Value": {
+                "Fn::GetAtt": [
+                    "Ec2Instance",
+                    "PublicIp"
+                ]
+            }
+        }
+    },
+    "Parameters": {
+        "AmiId": {
+            "Default": "ami-98aa1cf0",
+            "Type": "String"
+        },
+        "KeyName": {
+            "Description": "Name of an existing EC2 KeyPair to enable SSH access",
+            "Type": "AWS::EC2::KeyPair::KeyName"
+        }
+    },
+    "Resources": {
+        "Ec2Instance": {
+            "Metadata": {
+                "AWS::CloudFormation::Init": {
+                    "config1": {
+                        "commands": {
+                            "test": {
+                                "command": "echo \"$CFNTEST\" > text.txt",
+                                "cwd": "~",
+                                "env": {
+                                    "CFNTEST": "I come from config1."
+                                }
+                            }
+                        }
+                    },
+                    "config2": {
+                        "commands": {
+                            "test": {
+                                "command": "echo \"$CFNTEST\" > text.txt",
+                                "cwd": "~",
+                                "env": {
+                                    "CFNTEST": "I come from config2."
+                                }
+                            }
+                        }
+                    },
+                    "configSets": {
+                        "ascending": [
+                            "config1",
+                            "config2"
+                        ],
+                        "descending": [
+                            "config2",
+                            "config1"
+                        ]
+                    }
+                }
+            },
+            "Properties": {
+                "IamInstanceProfile": "PullCredentials",
+                "ImageId": {
+                    "Ref": "AmiId"
+                },
+                "InstanceType": "t1.micro",
+                "KeyName": {
+                    "Ref": "KeyName"
+                },
+                "SecurityGroups": [
+                    {
+                        "Ref": "SecurityGroup"
+                    }
+                ],
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "ops.cfninit"
+                    },
+                    {
+                        "Key": "env",
+                        "Value": "ops"
+                    }
+                ],
+                "UserData": {
+                    "Fn::Base64": {
+                        "Fn::Join": [
+                            "",
+                            [
+                                "#!/bin/bash\n",
+                                "sudo apt-get update\n",
+                                "sudo apt-get -y install python-setuptools\n",
+                                "sudo apt-get -y install python-pip\n",
+                                "sudo pip install https://s3.amazonaws.com/cloudformation-examples/",
+                                "aws-cfn-bootstrap-latest.tar.gz\n",
+                                "cfn-init -s '",
+                                {
+                                    "Ref": "AWS::StackName"
+                                },
+                                "' -r Ec2Instance -c ascending"
+                            ]
+                        ]
+                    }
+                }
+            },
+            "Type": "AWS::EC2::Instance"
+        },
+        "SecurityGroup": {
+            "Properties": {
+                "GroupDescription": "Allows SSH access from anywhere",
+                "SecurityGroupIngress": [
+                    {
+                        "CidrIp": "0.0.0.0/0",
+                        "FromPort": 22,
+                        "IpProtocol": "tcp",
+                        "ToPort": 22
+                    }
+                ],
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "ops.cfninit-sg"
+                    }
+                ]
+            },
+            "Type": "AWS::EC2::SecurityGroup"
+        }
+    }
+}

--- a/troposphere/autoscaling.py
+++ b/troposphere/autoscaling.py
@@ -74,9 +74,15 @@ class Metadata(AWSHelperFn):
     def __init__(self, init, authentication=None):
         self.validate(init, authentication)
         # get keys and values from init and authentication
-        # safe to use cause its always one key
-        initKey, initValue = init.data.popitem()
-        self.data = {initKey: initValue}
+
+        # if there's only one data point, then we know its the default
+        # cfn-init; where the key is 'config'
+        if len(init.data) == 1:
+            initKey, initValue = init.data.popitem()
+            self.data = {initKey: initValue}
+        else:
+            self.data = init.data
+
         if authentication:
             authKey, authValue = authentication.data.popitem()
             self.data[authKey] = authValue


### PR DESCRIPTION
Current CFN Init capabilities only allow for a single "config" property
on the `cloudformation.Init` class. This PR adds support for configSets
according to:

http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-init.html

Took some of what @mbrossard had in #70 and ran with it.