### PR TITLE
Support AWS helper functions in lists during validation

### DIFF
--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -105,9 +105,11 @@ class BaseAWSObject(object):
                     self._raise_type(name, value, expected_type)
 
                 # Iterate over the list and make sure it matches our
-                # type checks
+                # type checks (as above accept AWSHelperFn because
+                # we can't do the validation ourselves)
                 for v in value:
-                    if not isinstance(v, tuple(expected_type)):
+                    if not isinstance(v, tuple(expected_type)) \
+                           and not isinstance(v, AWSHelperFn):
                         self._raise_type(name, v, expected_type)
                 # Validated so assign it
                 return self.properties.__setitem__(name, value)

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -109,7 +109,7 @@ class BaseAWSObject(object):
                 # we can't do the validation ourselves)
                 for v in value:
                     if not isinstance(v, tuple(expected_type)) \
-                           and not isinstance(v, AWSHelperFn):
+                       and not isinstance(v, AWSHelperFn):
                         self._raise_type(name, v, expected_type)
                 # Validated so assign it
                 return self.properties.__setitem__(name, value)


### PR DESCRIPTION
Hi,

I found some places were a list of basestring is expected but where a Ref function call would be used (e.g. the buckets value in an AuthenticationBlock). This is similar to what we do a few line above for a non-list type.

Sincerely,
--
Mathias