### PR TITLE
Elastic Cache VpcSecurityGroupIds should be a list

### DIFF
--- a/troposphere/elasticache.py
+++ b/troposphere/elasticache.py
@@ -25,7 +25,7 @@ class CacheCluster(AWSObject):
         'PreferredAvailabilityZone': (basestring, False),
         'PreferredMaintenanceWindow': (basestring, False),
         'SnapshotArns': ([basestring, Ref], False),
-        'VpcSecurityGroupIds': ([basestring, Ref], False),
+        'VpcSecurityGroupIds': (list, False),
     }
 
 


### PR DESCRIPTION
See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-cache-cluster.html#cfn-elasticache-cachecluster-vpcsecuritygroupids
e.g.
```
"ElasticacheCluster": {
  "Type": "AWS::ElastiCache::CacheCluster",
  "Properties": {
    "AutoMinorVersionUpgrade": "true",
    "Engine": "memcached",
    "CacheNodeType": "cache.t1.micro",
    "NumCacheNodes": "1",
    "VpcSecurityGroupIds": [{"Fn::GetAtt": [ "ElasticacheSecurityGroup", "GroupId"]}]
  }
```