### PR TITLE
DynamoDB Table Names Are Too Restrictive

### DIFF
--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -40,7 +40,7 @@ class BaseAWSObject(object):
 
         # unset/None is also legal
         if title and not self.valid_names.match(title):
-            raise ValueError('Name "%s" not alphanumeric' % title)
+            raise ValueError('Name "%s" is not valid ()' % (title, self.valid_names.pattern))
 
         # Create the list of properties set on this object by the user
         self.properties = {}

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -25,10 +25,10 @@ AWS_REGION = 'AWS::Region'
 AWS_STACK_ID = 'AWS::StackId'
 AWS_STACK_NAME = 'AWS::StackName'
 
-valid_names = re.compile(r'^[a-zA-Z0-9]+$')
-
 
 class BaseAWSObject(object):
+    valid_names = re.compile(r'^[a-zA-Z0-9]+$')
+
     def __init__(self, title, template=None, **kwargs):
         self.title = title
         self.template = template
@@ -39,7 +39,7 @@ class BaseAWSObject(object):
                            'Condition', 'CreationPolicy']
 
         # unset/None is also legal
-        if title and not valid_names.match(title):
+        if title and not self.valid_names.match(title):
             raise ValueError('Name "%s" not alphanumeric' % title)
 
         # Create the list of properties set on this object by the user

--- a/troposphere/dynamodb.py
+++ b/troposphere/dynamodb.py
@@ -3,6 +3,8 @@
 #
 # See LICENSE file for full license.
 
+import re
+
 from . import AWSHelperFn, AWSObject, AWSProperty
 
 
@@ -78,6 +80,8 @@ class LocalSecondaryIndex(AWSHelperFn):
 
 class Table(AWSObject):
     resource_type = "AWS::DynamoDB::Table"
+
+    valid_names = re.compile(r'^[a-zA-Z0-9._-]+$')
 
     props = {
         'KeySchema': ([Key], True),


### PR DESCRIPTION
According to the docs, valid characters for DynamoDB table names include underscore, hyphen, and period.

http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html

But Troposphere v0.7.1 restricts table names to alphanumeric only:

```
  File "dynamodb.py", line 124, in print_tables
    table = Table(table_name)
  File "/usr/local/lib/python2.7/site-packages/troposphere/__init__.py", line 43, in __init__
    raise ValueError('Name "%s" not alphanumeric' % title)
ValueError: Name "my_table" not alphanumeric
```

Troposphere is preventing access (not just creation) to any table with a hyphen, underscore or period, all of which are valid.
