### PR TITLE
Added to the constructor of the Projection class the optional argument '...

### DIFF
--- a/examples/DynamoDB_Table_With_GSI_And_NonKeyAttributes_Projection.py
+++ b/examples/DynamoDB_Table_With_GSI_And_NonKeyAttributes_Projection.py
@@ -1,0 +1,146 @@
+#!/usr/bin/python
+
+from troposphere import Template, Ref, Output, Parameter
+from troposphere.dynamodb import (Key, AttributeDefinition,
+                                  ProvisionedThroughput, Projection)
+from troposphere.dynamodb import Table, GlobalSecondaryIndex
+
+template = Template()
+
+template.add_description("Create a dynamodb table with a global secondary "
+                         "index")
+# N.B. If you remove the provisioning section this works for
+# LocalSecondaryIndexes aswell.
+
+readunits = template.add_parameter(Parameter(
+    "ReadCapacityUnits",
+    Description="Provisioned read throughput",
+    Type="Number",
+    Default="10",
+    MinValue="5",
+    MaxValue="10000",
+    ConstraintDescription="should be between 5 and 10000"
+))
+
+writeunits = template.add_parameter(Parameter(
+    "WriteCapacityUnits",
+    Description="Provisioned write throughput",
+    Type="Number",
+    Default="5",
+    MinValue="5",
+    MaxValue="10000",
+    ConstraintDescription="should be between 5 and 10000"
+))
+
+tableIndexName = template.add_parameter(Parameter(
+    "TableIndexName",
+    Description="Table: Primary Key Field",
+    Type="String",
+    Default="id",
+    AllowedPattern="[a-zA-Z0-9]*",
+    MinLength="1",
+    MaxLength="2048",
+    ConstraintDescription="must contain only alphanumberic characters"
+))
+
+tableIndexDataType = template.add_parameter(Parameter(
+    "TableIndexDataType",
+    Description=" Table: Primary Key Data Type",
+    Type="String",
+    Default="S",
+    AllowedPattern="[S|N|B]",
+    MinLength="1",
+    MaxLength="1",
+    ConstraintDescription="S for string data, N for numeric data, or B for "
+                          "binary data"
+))
+
+secondaryIndexHashName = template.add_parameter(Parameter(
+    "SecondaryIndexHashName",
+    Description="Secondary Index: Primary Key Field",
+    Type="String",
+    Default="tokenType",
+    AllowedPattern="[a-zA-Z0-9]*",
+    MinLength="1",
+    MaxLength="2048",
+    ConstraintDescription="must contain only alphanumberic characters"
+))
+
+secondaryIndexHashDataType = template.add_parameter(Parameter(
+    "SecondaryIndexHashDataType",
+    Description="Secondary Index: Primary Key Data Type",
+    Type="String",
+    Default="S",
+    AllowedPattern="[S|N|B]",
+    MinLength="1",
+    MaxLength="1",
+    ConstraintDescription="S for string data, N for numeric data, or B for "
+                          "binary data"
+))
+
+secondaryIndexRangeName = template.add_parameter(Parameter(
+    "refreshSecondaryIndexRangeName",
+    Description="Secondary Index: Range Key Field",
+    Type="String",
+    Default="tokenUpdatedTime",
+    AllowedPattern="[a-zA-Z0-9]*",
+    MinLength="1",
+    MaxLength="2048",
+    ConstraintDescription="must contain only alphanumberic characters"
+))
+
+secondaryIndexRangeDataType = template.add_parameter(Parameter(
+    "SecondaryIndexRangeDataType",
+    Description="Secondary Index: Range Key Data Type",
+    Type="String",
+    Default="S",
+    AllowedPattern="[S|N|B]",
+    MinLength="1",
+    MaxLength="1",
+    ConstraintDescription="S for string data, N for numeric data, or B for "
+                          "binary data"
+))
+
+
+GSITable = template.add_resource(Table(
+    "GSITable",
+    AttributeDefinitions=[
+        AttributeDefinition(Ref(tableIndexName), Ref(tableIndexDataType)),
+        AttributeDefinition(Ref(secondaryIndexHashName),
+                            Ref(secondaryIndexHashDataType)),
+        AttributeDefinition(Ref(secondaryIndexRangeName),
+                            Ref(secondaryIndexRangeDataType)),
+        AttributeDefinition("non_key_attribute_0", "S"),
+        AttributeDefinition("non_key_attribute_1", "S")
+    ],
+    KeySchema=[
+        Key(Ref(tableIndexName), "HASH")
+    ],
+    ProvisionedThroughput=ProvisionedThroughput(
+        Ref(readunits),
+        Ref(writeunits)
+    ),
+    GlobalSecondaryIndexes=[
+        GlobalSecondaryIndex(
+            "SecondaryIndex",
+            [
+                Key(Ref(secondaryIndexHashName), "HASH"),
+                Key(Ref(secondaryIndexRangeName), "RANGE")
+            ],
+            Projection("INCLUDE", ["non_key_attribute_0"]),
+            ProvisionedThroughput(
+                Ref(readunits),
+                Ref(writeunits)
+            )
+        )
+    ]
+))
+
+template.add_output(Output(
+    "GSITable",
+    Value=Ref(GSITable),
+    Description="Table with a Global Secondary Index",
+))
+
+
+print(template.to_json())

--- a/tests/examples_output/DynamoDB_Table_With_GSI_And_NonKeyAttributes_Projection.template
+++ b/tests/examples_output/DynamoDB_Table_With_GSI_And_NonKeyAttributes_Projection.template
@@ -1,0 +1,173 @@
+{
+    "Description": "Create a dynamodb table with a global secondary index",
+    "Outputs": {
+        "GSITable": {
+            "Description": "Table with a Global Secondary Index",
+            "Value": {
+                "Ref": "GSITable"
+            }
+        }
+    },
+    "Parameters": {
+        "ReadCapacityUnits": {
+            "ConstraintDescription": "should be between 5 and 10000",
+            "Default": "10",
+            "Description": "Provisioned read throughput",
+            "MaxValue": "10000",
+            "MinValue": "5",
+            "Type": "Number"
+        },
+        "SecondaryIndexHashDataType": {
+            "AllowedPattern": "[S|N|B]",
+            "ConstraintDescription": "S for string data, N for numeric data, or B for binary data",
+            "Default": "S",
+            "Description": "Secondary Index: Primary Key Data Type",
+            "MaxLength": "1",
+            "MinLength": "1",
+            "Type": "String"
+        },
+        "SecondaryIndexHashName": {
+            "AllowedPattern": "[a-zA-Z0-9]*",
+            "ConstraintDescription": "must contain only alphanumberic characters",
+            "Default": "tokenType",
+            "Description": "Secondary Index: Primary Key Field",
+            "MaxLength": "2048",
+            "MinLength": "1",
+            "Type": "String"
+        },
+        "SecondaryIndexRangeDataType": {
+            "AllowedPattern": "[S|N|B]",
+            "ConstraintDescription": "S for string data, N for numeric data, or B for binary data",
+            "Default": "S",
+            "Description": "Secondary Index: Range Key Data Type",
+            "MaxLength": "1",
+            "MinLength": "1",
+            "Type": "String"
+        },
+        "TableIndexDataType": {
+            "AllowedPattern": "[S|N|B]",
+            "ConstraintDescription": "S for string data, N for numeric data, or B for binary data",
+            "Default": "S",
+            "Description": " Table: Primary Key Data Type",
+            "MaxLength": "1",
+            "MinLength": "1",
+            "Type": "String"
+        },
+        "TableIndexName": {
+            "AllowedPattern": "[a-zA-Z0-9]*",
+            "ConstraintDescription": "must contain only alphanumberic characters",
+            "Default": "id",
+            "Description": "Table: Primary Key Field",
+            "MaxLength": "2048",
+            "MinLength": "1",
+            "Type": "String"
+        },
+        "WriteCapacityUnits": {
+            "ConstraintDescription": "should be between 5 and 10000",
+            "Default": "5",
+            "Description": "Provisioned write throughput",
+            "MaxValue": "10000",
+            "MinValue": "5",
+            "Type": "Number"
+        },
+        "refreshSecondaryIndexRangeName": {
+            "AllowedPattern": "[a-zA-Z0-9]*",
+            "ConstraintDescription": "must contain only alphanumberic characters",
+            "Default": "tokenUpdatedTime",
+            "Description": "Secondary Index: Range Key Field",
+            "MaxLength": "2048",
+            "MinLength": "1",
+            "Type": "String"
+        }
+    },
+    "Resources": {
+        "GSITable": {
+            "Properties": {
+                "AttributeDefinitions": [
+                    {
+                        "AttributeName": {
+                            "Ref": "TableIndexName"
+                        },
+                        "AttributeType": {
+                            "Ref": "TableIndexDataType"
+                        }
+                    },
+                    {
+                        "AttributeName": {
+                            "Ref": "SecondaryIndexHashName"
+                        },
+                        "AttributeType": {
+                            "Ref": "SecondaryIndexHashDataType"
+                        }
+                    },
+                    {
+                        "AttributeName": {
+                            "Ref": "refreshSecondaryIndexRangeName"
+                        },
+                        "AttributeType": {
+                            "Ref": "SecondaryIndexRangeDataType"
+                        }
+                    },
+                    {
+                        "AttributeName": "non_key_attribute_0",
+                        "AttributeType": "S"
+                    },
+                    {
+                        "AttributeName": "non_key_attribute_1",
+                        "AttributeType": "S"
+                    }
+                ],
+                "GlobalSecondaryIndexes": [
+                    {
+                        "IndexName": "SecondaryIndex",
+                        "KeySchema": [
+                            {
+                                "AttributeName": {
+                                    "Ref": "SecondaryIndexHashName"
+                                },
+                                "KeyType": "HASH"
+                            },
+                            {
+                                "AttributeName": {
+                                    "Ref": "refreshSecondaryIndexRangeName"
+                                },
+                                "KeyType": "RANGE"
+                            }
+                        ],
+                        "Projection": {
+                            "NonKeyAttributes": [
+                                "non_key_attribute_0"
+                            ],
+                            "ProjectionType": "INCLUDE"
+                        },
+                        "ProvisionedThroughput": {
+                            "ReadCapacityUnits": {
+                                "Ref": "ReadCapacityUnits"
+                            },
+                            "WriteCapacityUnits": {
+                                "Ref": "WriteCapacityUnits"
+                            }
+                        }
+                    }
+                ],
+                "KeySchema": [
+                    {
+                        "AttributeName": {
+                            "Ref": "TableIndexName"
+                        },
+                        "KeyType": "HASH"
+                    }
+                ],
+                "ProvisionedThroughput": {
+                    "ReadCapacityUnits": {
+                        "Ref": "ReadCapacityUnits"
+                    },
+                    "WriteCapacityUnits": {
+                        "Ref": "WriteCapacityUnits"
+                    }
+                }
+            },
+            "Type": "AWS::DynamoDB::Table"
+        }
+    }
+}

--- a/troposphere/dynamodb.py
+++ b/troposphere/dynamodb.py
@@ -50,6 +50,7 @@ class Projection(AWSHelperFn):
     def JSONrepr(self):
         return self.data
 
+
 class GlobalSecondaryIndex(AWSHelperFn):
     def __init__(self, IndexName, KeySchema, Projection,
                  ProvisionedThroughput):

--- a/troposphere/dynamodb.py
+++ b/troposphere/dynamodb.py
@@ -40,14 +40,15 @@ class ProvisionedThroughput(AWSHelperFn):
 
 
 class Projection(AWSHelperFn):
-    def __init__(self, ProjectionType):
+    def __init__(self, ProjectionType, NonKeyAttributes=None):
         self.data = {
-            'ProjectionType': ProjectionType,
+            'ProjectionType': ProjectionType
         }
+        if NonKeyAttributes is not None:
+            self.data['NonKeyAttributes'] = NonKeyAttributes
 
     def JSONrepr(self):
         return self.data
-
 
 class GlobalSecondaryIndex(AWSHelperFn):
     def __init__(self, IndexName, KeySchema, Projection,


### PR DESCRIPTION
This change allows troposphere to create Secondary Global Indexes adding the NonKeyAttributes field in the Projection attribute. At this moment, the library only provides a way to define the ProjectionType.