### PR TITLE
add ec2 required fields

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -240,7 +240,7 @@ class SecurityGroupEgress(AWSObject):
         'CidrIp': (basestring, False),
         'DestinationSecurityGroupId': (basestring, False),
         'FromPort': (network_port, True),
-        'GroupId': (basestring, False),
+        'GroupId': (basestring, True),
         'IpProtocol': (basestring, True),
         'ToPort': (network_port, True),
         #
@@ -413,7 +413,7 @@ class VPNGatewayRoutePropagation(AWSObject):
     resource_type = "AWS::EC2::VPNGatewayRoutePropagation"
 
     props = {
-        'RouteTableIds': ([basestring, Ref], False),
+        'RouteTableIds': ([basestring, Ref], True),
         'VpnGatewayId': (basestring, True),
     }
 


### PR DESCRIPTION
I'm going through some our scripts so I'll PR what I find wrong, mostly required parameters missing

http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-security-group-egress.html#cfn-ec2-securitygroupegress-groupid

http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpn-gatewayrouteprop.html#cfn-ec2-vpngatewayrouteprop-routetableids