### PR TITLE
Elasticache VpcSecurityGroupIds should accept GetAtt

### DIFF
--- a/troposphere/elasticache.py
+++ b/troposphere/elasticache.py
@@ -3,7 +3,7 @@
 #
 # See LICENSE file for full license.
 
-from . import AWSObject, Ref
+from . import AWSObject, Ref, GetAtt
 from .validators import boolean, integer
 
 
@@ -25,7 +25,7 @@ class CacheCluster(AWSObject):
         'PreferredAvailabilityZone': (basestring, False),
         'PreferredMaintenanceWindow': (basestring, False),
         'SnapshotArns': ([basestring, Ref], False),
-        'VpcSecurityGroupIds': ([basestring, Ref], False),
+        'VpcSecurityGroupIds': ([basestring, Ref, GetAtt], False),
     }
 
 


### PR DESCRIPTION
According to the latest docs for `Elasticache` the `VpcSecurityGroupIds` is `GetAtt` from the `SecurityGroup` not `Ref`.

I've left `Ref` as not to break people that are using it.

http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-cache-cluster.html#cfn-elasticache-cachecluster-vpcsecuritygroupids

