### PR TITLE
Clear up Policy Resource vs Policy Property

### DIFF
--- a/troposphere/iam.py
+++ b/troposphere/iam.py
@@ -27,7 +27,9 @@ class AccessKey(AWSObject):
     }
 
 
-class PolicyProps(object):
+class Policy(AWSObject):
+    resource_type = "AWS::IAM::Policy"
+
     props = {
         'Groups': ([basestring, Ref], False),
         'PolicyDocument': (policytypes, True),
@@ -37,14 +39,15 @@ class PolicyProps(object):
     }
 
 
-class PolicyType(AWSObject, PolicyProps):
-    # This is a top-level resource
-    resource_type = "AWS::IAM::Policy"
+# For backwards compatibility
+PolicyType = Policy
 
 
-class Policy(AWSProperty, PolicyProps):
-    # This is for use in a list with Group (below)
-    pass
+class PolicyProperty(AWSProperty):
+    props = {
+        'PolicyDocument': (policytypes, True),
+        'PolicyName': (basestring, True),
+    }
 
 
 class Group(AWSObject):

--- a/troposphere/iam.py
+++ b/troposphere/iam.py
@@ -27,7 +27,7 @@ class AccessKey(AWSObject):
     }
 
 
-class Policy(AWSObject):
+class PolicyType(AWSObject):
     resource_type = "AWS::IAM::Policy"
 
     props = {
@@ -39,15 +39,13 @@ class Policy(AWSObject):
     }
 
 
-# For backwards compatibility
-PolicyType = Policy
-
-
-class PolicyProperty(AWSProperty):
+class Policy(AWSProperty):
     props = {
         'PolicyDocument': (policytypes, True),
         'PolicyName': (basestring, True),
     }
+
+PolicyProperty = Policy
 
 
 class Group(AWSObject):


### PR DESCRIPTION
I guess I sort of broke backwards compatibility by making 'Policy' the Resource, and PolicyProperty the property.  I can change that back, but it made sense to me.  Let me know if you guys think otherwise.