### PR TITLE
Missing OriginPath in cloudfront.py

### DIFF
--- a/troposphere/cloudfront.py
+++ b/troposphere/cloudfront.py
@@ -64,7 +64,7 @@ class CustomOrigin(AWSProperty):
 class Origin(AWSProperty):
     props = {
         'DomainName': (basestring, True),
-        'OriginPath' : (basestring, False),
+        'OriginPath': (basestring, False),
         'Id': (basestring, True),
         'S3OriginConfig': (S3Origin, False),
         'CustomOriginConfig': (CustomOrigin, False),

--- a/troposphere/cloudfront.py
+++ b/troposphere/cloudfront.py
@@ -64,6 +64,7 @@ class CustomOrigin(AWSProperty):
 class Origin(AWSProperty):
     props = {
         'DomainName': (basestring, True),
+        'OriginPath' : (basestring, False),
         'Id': (basestring, True),
         'S3OriginConfig': (S3Origin, False),
         'CustomOriginConfig': (CustomOrigin, False),


### PR DESCRIPTION
Origin object is missing OriginPath attribute, as described here: http://docs.aws.amazon.com/AmazonCloudFront/latest/APIReference/DistributionConfigDatatype.html