### PR TITLE
Fix DBInstance constraints in order to allow the creation of RDS read-only replicas

### DIFF
--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -72,9 +72,9 @@ class TestRDS(unittest.TestCase):
 
         with self.assertRaisesRegexp(
                 ValueError,
-                'MultiAZ, DBSubnetGroupName, MasterUsername, '
-                'MasterUserPassword, PreferredBackupWindow, '
-                'DBSnapshotIdentifier, DBName, BackupRetentionPeriod '
+                'BackupRetentionPeriod, DBName, DBSnapshotIdentifier, '
+                'DBSubnetGroupName, MasterUserPassword, MasterUsername, '
+                'MultiAZ, PreferredBackupWindow '
                 'properties can\'t be provided when '
                 'SourceDBInstanceIdentifier is present '
                 'AWS::RDS::DBInstance.'

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -74,8 +74,9 @@ class TestRDS(unittest.TestCase):
                 ValueError,
                 'MultiAZ, DBSubnetGroupName, MasterUsername, '
                 'MasterUserPassword, PreferredBackupWindow, '
-                'DBSnapshotIdentifier, DBName, BackupRetentionPeriod properties'
-                ' can\'t be provided when  SourceDBInstanceIdentifier is '
-                'present AWS::RDS::DBInstance.'
+                'DBSnapshotIdentifier, DBName, BackupRetentionPeriod '
+                'properties can\'t be provided when '
+                'SourceDBInstanceIdentifier is present '
+                'AWS::RDS::DBInstance.'
                 ):
             rds_instance.JSONrepr()

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -41,3 +41,41 @@ class TestRDS(unittest.TestCase):
                 ' DBSnapshotIdentifier are required'
                 ):
             rds_instance.JSONrepr()
+
+    def test_it_allows_an_rds_replica(self):
+        rds_instance = rds.DBInstance(
+            'SomeTitle',
+            AllocatedStorage=1,
+            DBInstanceClass='db.m1.small',
+            Engine='MySQL',
+            SourceDBInstanceIdentifier='SomeSourceDBInstanceIdentifier'
+        )
+
+        rds_instance.JSONrepr()
+
+    def test_replica_settings_are_inherited(self):
+        rds_instance = rds.DBInstance(
+            'SomeTitle',
+            AllocatedStorage=1,
+            DBInstanceClass='db.m1.small',
+            Engine='MySQL',
+            SourceDBInstanceIdentifier='SomeSourceDBInstanceIdentifier',
+            BackupRetentionPeriod="1",
+            DBName="SomeName",
+            MasterUsername="SomeUsername",
+            MasterUserPassword="SomePassword",
+            PreferredBackupWindow="SomeBackupWindow",
+            MultiAZ=True,
+            DBSnapshotIdentifier="SomeDBSnapshotIdentifier",
+            DBSubnetGroupName="SomeDBSubnetGroupName",
+        )
+
+        with self.assertRaisesRegexp(
+                ValueError,
+                'MultiAZ, DBSubnetGroupName, MasterUsername, '
+                'MasterUserPassword, PreferredBackupWindow, '
+                'DBSnapshotIdentifier, DBName, BackupRetentionPeriod properties'
+                ' can\'t be provided when  SourceDBInstanceIdentifier is '
+                'present AWS::RDS::DBInstance.'
+                ):
+            rds_instance.JSONrepr()

--- a/troposphere/rds.py
+++ b/troposphere/rds.py
@@ -56,7 +56,7 @@ class DBInstance(AWSObject):
             if invalid_properties:
                 raise ValueError(
                     ('{0} properties can\'t be provided when '
-                     ' SourceDBInstanceIdentifier is present '
+                     'SourceDBInstanceIdentifier is present '
                      'AWS::RDS::DBInstance.'
                      ).format(', '.join(invalid_properties)))
 

--- a/troposphere/rds.py
+++ b/troposphere/rds.py
@@ -58,7 +58,7 @@ class DBInstance(AWSObject):
                     ('{0} properties can\'t be provided when '
                      'SourceDBInstanceIdentifier is present '
                      'AWS::RDS::DBInstance.'
-                     ).format(', '.join(invalid_properties)))
+                     ).format(', '.join(sorted(invalid_properties))))
 
         if ('DBSnapshotIdentifier' not in self.properties and
             'SourceDBInstanceIdentifier' not in self.properties) and \

--- a/troposphere/rds.py
+++ b/troposphere/rds.py
@@ -42,7 +42,25 @@ class DBInstance(AWSObject):
     }
 
     def validate(self):
-        if 'DBSnapshotIdentifier' not in self.properties and \
+        if 'SourceDBInstanceIdentifier' in self.properties:
+
+            invalid_replica_properties = (
+                'BackupRetentionPeriod', 'DBName', 'MasterUsername',
+                'MasterUserPassword', 'PreferredBackupWindow', 'MultiAZ',
+                'DBSnapshotIdentifier', 'DBSubnetGroupName',
+            )
+
+            invalid_properties = [s for s in self.properties.keys() if \
+                                  s in invalid_replica_properties]
+
+            if invalid_properties:
+                raise ValueError(('{0} properties can\'t be provided when '
+                    ' SourceDBInstanceIdentifier is present '
+                    'AWS::RDS::DBInstance.'
+                ).format(', '.join(invalid_properties)))
+
+        if ('DBSnapshotIdentifier' not in self.properties and
+            'SourceDBInstanceIdentifier' not in self.properties) and \
             ('MasterUsername' not in self.properties or
              'MasterUserPassword' not in self.properties):
             raise ValueError(

--- a/troposphere/rds.py
+++ b/troposphere/rds.py
@@ -50,14 +50,15 @@ class DBInstance(AWSObject):
                 'DBSnapshotIdentifier', 'DBSubnetGroupName',
             )
 
-            invalid_properties = [s for s in self.properties.keys() if \
+            invalid_properties = [s for s in self.properties.keys() if
                                   s in invalid_replica_properties]
 
             if invalid_properties:
-                raise ValueError(('{0} properties can\'t be provided when '
-                    ' SourceDBInstanceIdentifier is present '
-                    'AWS::RDS::DBInstance.'
-                ).format(', '.join(invalid_properties)))
+                raise ValueError(
+                    ('{0} properties can\'t be provided when '
+                     ' SourceDBInstanceIdentifier is present '
+                     'AWS::RDS::DBInstance.'
+                     ).format(', '.join(invalid_properties)))
 
         if ('DBSnapshotIdentifier' not in self.properties and
             'SourceDBInstanceIdentifier' not in self.properties) and \


### PR DESCRIPTION
 Based on (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-sourcedbinstanceidentifier) ``BackupRetentionPeriod``, ``DBName``, ``MasterUsername``, ``MasterUserPassword``, ``PreferredBackupWindow``, ``MultiAZ`` and ``DBSnapshotIdentifier`` can't be present when ``SourceDBInstanceIdentifier`` is specified.
 
Although CloudFormation validator doesn't fail, manual tests have proven that ``DBSubnetGroupName`` can't be present if ``SourceDBInstanceIdentifier`` is specified.

I've successfully deployed several read-replicas using this code.