### PR TITLE
Add properties CharacterSetName, KmsKeyId, and StorageEncrypted to AWS::RDS::DBInstance

### DIFF
--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -41,3 +41,21 @@ class TestRDS(unittest.TestCase):
                 ' DBSnapshotIdentifier are required'
                 ):
             rds_instance.JSONrepr()
+
+    def test_it_rds_instances_require_encryption_if_kms_key_provided(self):
+        rds_instance = rds.DBInstance(
+            'SomeTitle',
+            AllocatedStorage=1,
+            DBInstanceClass='db.m1.small',
+            Engine='MySQL',
+            MasterUsername='SomeUsername',
+            MasterUserPassword='SomePassword',
+            KmsKeyId='arn:aws:kms:us-east-1:123456789012:key/'
+                     '12345678-1234-1234-1234-123456789012'
+        )
+
+        with self.assertRaisesRegexp(
+                ValueError,
+                'If KmsKeyId is provided, StorageEncrypted is required'
+                ):
+            rds_instance.JSONrepr()

--- a/troposphere/rds.py
+++ b/troposphere/rds.py
@@ -26,6 +26,7 @@ class DBInstance(AWSObject):
         'Engine': (basestring, True),
         'EngineVersion': (basestring, False),
         'Iops': (int, False),
+        'KmsKeyId': (basestring, False),
         'LicenseModel': (basestring, False),
         'MasterUsername': (basestring, False),
         'MasterUserPassword': (basestring, False),
@@ -36,6 +37,7 @@ class DBInstance(AWSObject):
         'PreferredMaintenanceWindow': (basestring, False),
         'PubliclyAccessible': (boolean, False),
         'SourceDBInstanceIdentifier': (basestring, False),
+        'StorageEncrypted': (boolean, False),
         'StorageType': (basestring, False),
         'Tags': (list, False),
         'VPCSecurityGroups': ([basestring, AWSHelperFn], False),
@@ -48,6 +50,13 @@ class DBInstance(AWSObject):
             raise ValueError(
                 'Either (MasterUsername and MasterUserPassword) or'
                 ' DBSnapshotIdentifier are required in type '
+                'AWS::RDS::DBInstance.'
+            )
+
+        if 'KmsKeyId' in self.properties and \
+            'StorageEncrypted' not in self.properties:
+            raise ValueError(
+                'If KmsKeyId is provided, StorageEncrypted is required '
                 'AWS::RDS::DBInstance.'
             )
 

--- a/troposphere/rds.py
+++ b/troposphere/rds.py
@@ -55,7 +55,7 @@ class DBInstance(AWSObject):
             )
 
         if 'KmsKeyId' in self.properties and \
-            'StorageEncrypted' not in self.properties:
+           'StorageEncrypted' not in self.properties:
             raise ValueError(
                 'If KmsKeyId is provided, StorageEncrypted is required '
                 'AWS::RDS::DBInstance.'

--- a/troposphere/rds.py
+++ b/troposphere/rds.py
@@ -16,6 +16,7 @@ class DBInstance(AWSObject):
         'AutoMinorVersionUpgrade': (boolean, False),
         'AvailabilityZone': (basestring, False),
         'BackupRetentionPeriod': (positive_integer, False),
+        'CharacterSetName': (basestring, False),
         'DBInstanceClass': (basestring, True),
         'DBInstanceIdentifier': (basestring, False),
         'DBName': (basestring, False),


### PR DESCRIPTION
See yesterday's AWS announcement for the new properties: [AWS CloudFormation Updates Support for RDS, EBS, and ElastiCache](https://aws.amazon.com/about-aws/whats-new/2015/04/aws-cloudformation-updates-support-for-rds-ebs-and-elasticache/) and the current [CloudFormation User Guide](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-ug.pdf).