### PR TITLE
SNS Topic fields are not required

### DIFF
--- a/troposphere/sns.py
+++ b/troposphere/sns.py
@@ -32,6 +32,6 @@ class Topic(AWSObject):
 
     props = {
         'DisplayName': (basestring, False),
-        'Subscription': ([Subscription], True),
+        'Subscription': ([Subscription], False),
         'TopicName': (basestring, False),
     }


### PR DESCRIPTION
Believe it or not, none of the SNS Topic fields are required. If nothing ...is specified, CF will generate a new based on the name of the stack.

This PR gets the definition matching the Doc:

http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sns-topic.html
