### PR TITLE
Allows default region when not provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add properties CharacterSetName, KmsKeyId, and StorageEncrypted to AWS::RDS::DBInstance [GH-224]
 - Add Route53 HostedZoneVPCs, HostedZoneTags, HealthCheckTags
 - Add new properties from 2015-04-16 CloudFormation release [GH-225]
+- Allow default region for GetAZs()
 
 ## 0.7.2 (2015-03-23)
 - Support AWS helper functions in lists during validation [GH-179]

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -235,7 +235,7 @@ class GetAtt(AWSHelperFn):
 
 
 class GetAZs(AWSHelperFn):
-    def __init__(self, region):
+    def __init__(self, region=""):
         self.data = {'Fn::GetAZs': region}
 
     def JSONrepr(self):


### PR DESCRIPTION
Per:
http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getavailabilityzones.html

You no longer need (not sure if you needed to before) to provide a
region to Fn::GetAZs.  This should allow that.