### PR TITLE
Make AvailabilityZones parameter optional in AutoScalingGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add properties CharacterSetName, KmsKeyId, and StorageEncrypted to AWS::RDS::DBInstance [GH-224]
 - Add Route53 HostedZoneVPCs, HostedZoneTags, HealthCheckTags
 - Add new properties from 2015-04-16 CloudFormation release [GH-225]
+- Make AvailabilityZones parameter optional in AutoScalingGroup
 
 ## 0.7.2 (2015-03-23)
 - Support AWS helper functions in lists during validation [GH-179]

--- a/tests/test_asg.py
+++ b/tests/test_asg.py
@@ -26,6 +26,7 @@ class TestAutoScalingGroup(unittest.TestCase):
     def test_instanceid(self):
         group = AutoScalingGroup(
             'mygroup',
+            AvailabilityZones=['eu-west-1a', 'eu-west-1b'],
             InstanceId="i-1234",
             MaxSize="1",
             MinSize="1",
@@ -35,6 +36,7 @@ class TestAutoScalingGroup(unittest.TestCase):
     def test_launchconfigurationname(self):
         group = AutoScalingGroup(
             'mygroup',
+            AvailabilityZones=['eu-west-1a', 'eu-west-1b'],
             LaunchConfigurationName="I'm a test",
             MaxSize="1",
             MinSize="1",

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -80,6 +80,7 @@ class TestUpdatePolicy(unittest.TestCase):
         )
         group = AutoScalingGroup(
             'mygroup',
+            AvailabilityZones=['eu-west-1a', 'eu-west-1b'],
             LaunchConfigurationName="I'm a test",
             MaxSize=Ref(paramMaxSize),
             MinSize="2",
@@ -100,6 +101,7 @@ class TestUpdatePolicy(unittest.TestCase):
         )
         group = AutoScalingGroup(
             'mygroup',
+            AvailabilityZones=['eu-west-1a', 'eu-west-1b'],
             LaunchConfigurationName="I'm a test",
             MaxSize="4",
             MinSize="2",

--- a/troposphere/autoscaling.py
+++ b/troposphere/autoscaling.py
@@ -107,7 +107,7 @@ class AutoScalingGroup(AWSObject):
     resource_type = "AWS::AutoScaling::AutoScalingGroup"
 
     props = {
-        'AvailabilityZones': (list, True),
+        'AvailabilityZones': (list, False),
         'Cooldown': (integer, False),
         'DesiredCapacity': (integer, False),
         'HealthCheckGracePeriod': (int, False),
@@ -158,6 +158,14 @@ class AutoScalingGroup(AWSObject):
                              "InstanceId: http://docs.aws.amazon.com/AWSCloud"
                              "Formation/latest/UserGuide/aws-properties-as-gr"
                              "oup.html#cfn-as-group-instanceid")
+
+        availability_zones = self.properties.get('AvailabilityZones')
+        vpc_zone_identifier = self.properties.get('VPCZoneIdentifier')
+        if not availability_zones and not vpc_zone_identifier:
+            raise ValueError("Must specify AvailabilityZones and/or "
+                             "VPCZoneIdentifier: http://docs.aws.amazon.com/A"
+                             "WSCloudFormation/latest/UserGuide/aws-propertie"
+                             "s-as-group.html#cfn-as-group-vpczoneidentifier")
         return True
 
 


### PR DESCRIPTION
Currently, when creating an `AutoScalingGroup` object, the `AvailabilityZones` parameter is required. However, the [AWS documentation](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-availabilityzones) states: `Required: Conditional. If you don't specify the VPCZoneIdentifier property, you must specify this property.`

This change makes the `AvailabilityZones` parameter optional.