### PR TITLE
examples fix: users is list

### DIFF
--- a/examples/IAM_Users_Groups_and_Policies.py
+++ b/examples/IAM_Users_Groups_and_Policies.py
@@ -27,13 +27,13 @@ cfnkeys = t.add_resource(AccessKey(
 users = t.add_resource(UserToGroupAddition(
     "Users",
     GroupName=Ref(cfnusergroup),
-    Users=Ref(cfnuser),
+    Users=[Ref(cfnuser)],
 ))
 
 admins = t.add_resource(UserToGroupAddition(
     "Admins",
     GroupName=Ref(cfnadmingroup),
-    Users=Ref(cfnuser),
+    Users=[Ref(cfnuser)],
 ))
 
 t.add_resource(PolicyType(

--- a/tests/examples_output/IAM_Users_Groups_and_Policies.template
+++ b/tests/examples_output/IAM_Users_Groups_and_Policies.template
@@ -23,9 +23,11 @@
                 "GroupName": {
                     "Ref": "CFNAdminGroup"
                 },
-                "Users": {
-                    "Ref": "CFNUser"
-                }
+                "Users": [
+                    {
+                        "Ref": "CFNUser"
+                    }
+                ]
             },
             "Type": "AWS::IAM::UserToGroupAddition"
         },
@@ -78,9 +80,11 @@
                 "GroupName": {
                     "Ref": "CFNUserGroup"
                 },
-                "Users": {
-                    "Ref": "CFNUser"
-                }
+                "Users": [
+                    {
+                        "Ref": "CFNUser"
+                    }
+                ]
             },
             "Type": "AWS::IAM::UserToGroupAddition"
         }


### PR DESCRIPTION
this brings the example in line with
https://s3.amazonaws.com/cloudformation-templates-us-east-1/IAM_Users_Groups_and_Policies.template

The current example CFN template will fail if you try to create-stack (I modified it for my use and found this bug).  

FYI I wrote a test harness to validate the example templates against the AWS CLI, but the validate-template does not catch this bug.  Let me know if you're interested in having this test harness, unfortunately it introduces a need for the AWS CLI and real IAM credentials that has `cloudformation:ValidateTemplate` rights, so it might be too heavy to be useful.