### PR TITLE
Add validation for AZMode property on CacheCluster objects

### DIFF
--- a/troposphere/elasticache.py
+++ b/troposphere/elasticache.py
@@ -32,6 +32,21 @@ class CacheCluster(AWSObject):
         'VpcSecurityGroupIds': ([basestring, Ref, GetAtt], False),
     }
 
+    def validate(self):
+        # Check that AZMode is "cross-az" if more than one Availability zone
+        # is specified in PreferredAvailabilityZones
+        preferred_azs = self.properties.get('PreferredAvailabilityZones')
+        if preferred_azs is not None and len(preferred_azs) > 1:
+            if self.properties.get('AZMode') != 'cross-az':
+                raise ValueError('AZMode must be "cross-az" if more than one a'
+                                 'vailability zone is specified in PreferredAv'
+                                 'ailabilityZones: http://docs.aws.amazon.com/'
+                                 'AWSCloudFormation/latest/UserGuide/aws-prope'
+                                 'rties-elasticache-cache-cluster.html#cfn-ela'
+                                 'sticache-cachecluster-azmode')
+
+        return True
+
 
 class ParameterGroup(AWSObject):
     resource_type = "AWS::ElastiCache::ParameterGroup"


### PR DESCRIPTION
Regarding the `AZMode` property on CacheCluster objects, the [AWS documentation](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-cache-cluster.html#cfn-elasticache-cachecluster-azmode) states :

```
If you specify multiple Availability Zones in the PreferredAvailabilityZones
property, you must specify cross Availability Zones for this property.
```

This patch introduces validation on the CacheCluster object and ensures that `AZMode` is set to `cross-az` if more than one Availability Zone is specified in the `PreferredAvailabilityZones` property.

