### PR TITLE
Fixing Opsworks Naming

### DIFF
--- a/troposphere/opsworks.py
+++ b/troposphere/opsworks.py
@@ -96,7 +96,7 @@ class AutoScalingThresholds(AWSProperty):
         'InstanceCount': (integer, False),
         'LoadThreshold': (float, False),
         'MemoryThreshold': (float, False),
-        'ThresholdWaitTime': (integer, False),
+        'ThresholdsWaitTime': (integer, False),
     }
 
 


### PR DESCRIPTION
Amazon expects "ThresholdsWaitTime", not "ThresholdWaitTime".