### PR TITLE
Add property for Subnet: MapPublicIpOnLaunch

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -303,6 +303,7 @@ class Subnet(AWSObject):
         'CidrBlock': (basestring, True),
         'Tags': (list, False),
         'VpcId': (basestring, True),
+	'MapPublicIpOnLaunch': (boolean, False),
     }
 
 

--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -303,7 +303,7 @@ class Subnet(AWSObject):
         'CidrBlock': (basestring, True),
         'Tags': (list, False),
         'VpcId': (basestring, True),
-	'MapPublicIpOnLaunch': (boolean, False),
+        'MapPublicIpOnLaunch': (boolean, False),
     }
 
 


### PR DESCRIPTION
Noticed this feature existed in the [CloudFormation Docs](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-subnet.html) but not here, so I added it! Simplest change ever :)