### PR TITLE
Add ManagedPolicyArns property to AWS::IAM::Role

### DIFF
--- a/troposphere/iam.py
+++ b/troposphere/iam.py
@@ -3,7 +3,7 @@
 #
 # See LICENSE file for full license.
 
-from . import AWSObject, AWSProperty, Ref
+from . import AWSObject, AWSProperty, Ref, Join
 from .validators import integer, boolean
 try:
     from awacs.aws import Policy

--- a/troposphere/iam.py
+++ b/troposphere/iam.py
@@ -71,6 +71,7 @@ class Role(AWSObject):
 
     props = {
         'AssumeRolePolicyDocument': (policytypes, True),
+        'ManagedPolicyArns': ([basestring, Join], False),
         'Path': (basestring, True),
         'Policies': ([Policy], False),
     }


### PR DESCRIPTION
Add the ManagedPolicyArns property to the Role object, listed in AWS's docs here:
http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#cfn-iam-role-managepolicyarns