### PR TITLE
CustomResource including example, updated todo in readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+.idea
 
 # Vim
 *.sw*

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - pip install --use-mirrors pep8 pyflakes
 
 before_script:
-  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then 2to3 -n -w --no-diffs troposphere; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then 2to3 -n -w --no-diffs troposphere examples/CustomResource.py; fi
   - pep8 --version
   - pep8 .
   - pyflakes .

--- a/README.rst
+++ b/README.rst
@@ -152,9 +152,6 @@ Currently supported OpenStack resource types
 Todo:
 
 - Add additional validity checks
-- Add missing AWS resource types:
-
-  - AWS::CloudFormation::CustomResource
 
 Duplicating a single instance sample would look like this
 =========================================================

--- a/examples/CustomResource.py
+++ b/examples/CustomResource.py
@@ -1,0 +1,30 @@
+from troposphere import Join, Ref, Template
+from troposphere.cloudformation import AWSCustomObject
+
+
+class CustomPlacementGroup(AWSCustomObject):
+    resource_type = "Custom::PlacementGroup"
+
+    props = {
+        'ServiceToken': (basestring, True),
+        'PlacementGroupName': (basestring, True)
+    }
+
+t = Template()
+
+t.add_description(
+    "Example template showing how a Lambda Function CustomResource might look"
+    "For information on AWS Lambda-backed Custom Resources see:"
+    "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/"
+    "template-custom-resources-lambda.html"
+)
+
+placementgroup_a = t.add_resource(CustomPlacementGroup(
+    "ClusterGroup",
+    ServiceToken=Join("", ["arn:aws:lambda:", Ref("AWS::Region"), ":",
+                           Ref("AWS::AccountId"),
+                           ":function:cfnPlacementGroup"]),
+    PlacementGroupName="ExampleClusterGroup",
+))
+
+print(t.to_json())

--- a/tests/examples_output/CustomResource.template
+++ b/tests/examples_output/CustomResource.template
@@ -1,0 +1,27 @@
+{
+    "Description": "Example template showing how a Lambda Function CustomResource might lookFor information on AWS Lambda-backed Custom Resources see:http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-custom-resources-lambda.html",
+    "Resources": {
+        "ClusterGroup": {
+            "Properties": {
+                "PlacementGroupName": "ExampleClusterGroup",
+                "ServiceToken": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            "arn:aws:lambda:",
+                            {
+                                "Ref": "AWS::Region"
+                            },
+                            ":",
+                            {
+                                "Ref": "AWS::AccountId"
+                            },
+                            ":function:cfnPlacementGroup"
+                        ]
+                    ]
+                }
+            },
+            "Type": "Custom::PlacementGroup"
+        }
+    }
+}

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -131,6 +131,13 @@ class BaseAWSObject(object):
                 self._raise_type(name, value, expected_type)
 
         type_name = getattr(self, 'resource_type', self.__class__.__name__)
+
+        if type_name == 'AWS::CloudFormation::CustomResource' or \
+                type_name.startswith('Custom::'):
+            # Add custom resource arguments to the dict without any further
+            # validation. The properties of a CustomResource is not known.
+            return self.properties.__setitem__(name, value)
+
         raise AttributeError("%s object does not support attribute %s" %
                              (type_name, name))
 
@@ -193,6 +200,7 @@ class AWSAttribute(BaseAWSObject):
     http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/
     aws-product-attribute-reference.html
     """
+
     def __init__(self, title=None, **kwargs):
         super(AWSAttribute, self).__init__(title, **kwargs)
 

--- a/troposphere/cloudformation.py
+++ b/troposphere/cloudformation.py
@@ -3,7 +3,7 @@
 #
 # See LICENSE file for full license.
 
-from . import AWSHelperFn, AWSObject, AWSProperty, Ref
+from . import AWSHelperFn, AWSObject, AWSProperty, Ref, BaseAWSObject
 from .validators import integer, boolean, encoding
 
 
@@ -15,6 +15,18 @@ class Stack(AWSObject):
         'Parameters': (dict, False),
         'TemplateURL': (basestring, True),
         'TimeoutInMinutes': (integer, False),
+    }
+
+
+class AWSCustomObject(BaseAWSObject):
+    dictname = 'Properties'
+
+
+class CustomResource(AWSCustomObject):
+    resource_type = "AWS::CloudFormation::CustomResource"
+
+    props = {
+        'ServiceToken': (basestring, True)
     }
 
 


### PR DESCRIPTION
CustomResource added - I've used it in my own work and found that it's great for implementing resource types currently not supported by CloudFormation (for instance PlacementGroup's).
Known limitations: The CustomResource properties are not checked.

It's my first PR, so I very well might have missed something.