### PR TITLE
Comment attribute added to cloudwatch.Alarm

### DIFF
--- a/troposphere/cloudwatch.py
+++ b/troposphere/cloudwatch.py
@@ -33,4 +33,5 @@ class Alarm(AWSObject):
         'Statistic': (basestring, True),
         'Threshold': (basestring, True),
         'Unit': (basestring, False),
+        'Comment': (basestring, False),
     }


### PR DESCRIPTION
Not much to say, apart that I've added the Comment attribute to make Troposphere compatible py2json and json2py