### PR TITLE
Add rds snapshot on delete example

### DIFF
--- a/examples/RDS_Snapshot_On_Delete.py
+++ b/examples/RDS_Snapshot_On_Delete.py
@@ -1,12 +1,8 @@
 # Converted from RDS_Snapshot_On_Delete.template located at:
 # http://aws.amazon.com/cloudformation/aws-cloudformation-templates/
 
-from troposphere import Base64, Select, FindInMap, GetAtt, GetAZs, Join, Output
-from troposphere import Parameter, Ref, Tags, Template
-from troposphere.cloudformation import Init
-from troposphere.cloudfront import Distribution, DistributionConfig
-from troposphere.cloudfront import Origin, DefaultCacheBehavior
-from troposphere.ec2 import PortRange
+from troposphere import GetAtt, Join, Output
+from troposphere import Template
 from troposphere.rds import DBInstance
 
 

--- a/examples/RDS_Snapshot_On_Delete.py
+++ b/examples/RDS_Snapshot_On_Delete.py
@@ -10,8 +10,13 @@ t = Template()
 
 t.add_version("2010-09-09")
 
-t.add_description("""\
-AWS CloudFormation Sample Template RDS_Snapshot_On_Delete: Sample template showing how to create an RDS DBInstance that is snapshotted on stack deletion. **WARNING** This template creates an Amazon RDS database instance. When the stack is deleted a database snpshot will be left in your account. You will be billed for the AWS resources used if you create a stack from this template.""")
+t.add_description(
+    "AWS CloudFormation Sample Template RDS_Snapshot_On_Delete: Sample "
+    "template showing how to create an RDS DBInstance that is snapshotted on "
+    "stack deletion. **WARNING** This template creates an Amazon RDS database "
+    "instance. When the stack is deleted a database snpshot will be left in "
+    "your account. You will be billed for the AWS resources used if you "
+    "create a stack from this template.")
 MyDB = t.add_resource(DBInstance(
     "MyDB",
     Engine="MySQL",
@@ -25,7 +30,13 @@ MyDB = t.add_resource(DBInstance(
 JDBCConnectionString = t.add_output(Output(
     "JDBCConnectionString",
     Description="JDBC connection string for the database",
-    Value=Join("", ["jdbc:mysql://", GetAtt(MyDB, "Endpoint.Address"), ":", GetAtt(MyDB, "Endpoint.Port"), "/MyDatabase"]),
+    Value=Join("", [
+        "jdbc:mysql://",
+        GetAtt(MyDB, "Endpoint.Address"),
+        ":",
+        GetAtt(MyDB, "Endpoint.Port"),
+        "/MyDatabase"
+    ]),
 ))
 
 print(t.to_json())

--- a/examples/RDS_Snapshot_On_Delete.py
+++ b/examples/RDS_Snapshot_On_Delete.py
@@ -1,0 +1,35 @@
+# Converted from RDS_Snapshot_On_Delete.template located at:
+# http://aws.amazon.com/cloudformation/aws-cloudformation-templates/
+
+from troposphere import Base64, Select, FindInMap, GetAtt, GetAZs, Join, Output
+from troposphere import Parameter, Ref, Tags, Template
+from troposphere.cloudformation import Init
+from troposphere.cloudfront import Distribution, DistributionConfig
+from troposphere.cloudfront import Origin, DefaultCacheBehavior
+from troposphere.ec2 import PortRange
+from troposphere.rds import DBInstance
+
+
+t = Template()
+
+t.add_version("2010-09-09")
+
+t.add_description("""\
+AWS CloudFormation Sample Template RDS_Snapshot_On_Delete: Sample template showing how to create an RDS DBInstance that is snapshotted on stack deletion. **WARNING** This template creates an Amazon RDS database instance. When the stack is deleted a database snpshot will be left in your account. You will be billed for the AWS resources used if you create a stack from this template.""")
+MyDB = t.add_resource(DBInstance(
+    "MyDB",
+    Engine="MySQL",
+    MasterUsername="myName",
+    MasterUserPassword="myPassword",
+    AllocatedStorage="5",
+    DBInstanceClass="db.m1.small",
+    DBName="MyDatabase",
+))
+
+JDBCConnectionString = t.add_output(Output(
+    "JDBCConnectionString",
+    Description="JDBC connection string for the database",
+    Value=Join("", ["jdbc:mysql://", GetAtt(MyDB, "Endpoint.Address"), ":", GetAtt(MyDB, "Endpoint.Port"), "/MyDatabase"]),
+))
+
+print(t.to_json())

--- a/tests/examples_output/RDS_Snapshot_On_Delete.template
+++ b/tests/examples_output/RDS_Snapshot_On_Delete.template
@@ -1,0 +1,44 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "AWS CloudFormation Sample Template RDS_Snapshot_On_Delete: Sample template showing how to create an RDS DBInstance that is snapshotted on stack deletion. **WARNING** This template creates an Amazon RDS database instance. When the stack is deleted a database snpshot will be left in your account. You will be billed for the AWS resources used if you create a stack from this template.",
+    "Outputs": {
+        "JDBCConnectionString": {
+            "Description": "JDBC connection string for the database",
+            "Value": {
+                "Fn::Join": [
+                    "",
+                    [
+                        "jdbc:mysql://",
+                        {
+                            "Fn::GetAtt": [
+                                "MyDB",
+                                "Endpoint.Address"
+                            ]
+                        },
+                        ":",
+                        {
+                            "Fn::GetAtt": [
+                                "MyDB",
+                                "Endpoint.Port"
+                            ]
+                        },
+                        "/MyDatabase"
+                    ]
+                ]
+            }
+        }
+    },
+    "Resources": {
+        "MyDB": {
+            "Properties": {
+                "AllocatedStorage": "5",
+                "DBInstanceClass": "db.m1.small",
+                "DBName": "MyDatabase",
+                "Engine": "MySQL",
+                "MasterUserPassword": "myPassword",
+                "MasterUsername": "myName"
+            },
+            "Type": "AWS::RDS::DBInstance"
+        }
+    }
+}


### PR DESCRIPTION
This PR adds an example for Amazon RDS DB instance with a deletion policy as follows.

* http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/sample-templates-services-us-west-2.html
* https://s3-us-west-2.amazonaws.com/cloudformation-templates-us-west-2/RDS_Snapshot_On_Delete.template
