### PR TITLE
add FindInMap type check for AutoScalingGroup validation of group sizes

### DIFF
--- a/troposphere/autoscaling.py
+++ b/troposphere/autoscaling.py
@@ -3,7 +3,7 @@
 #
 # See LICENSE file for full license.
 
-from . import AWSHelperFn, AWSObject, AWSProperty, Ref
+from . import AWSHelperFn, AWSObject, AWSProperty, Ref, FindInMap
 from .validators import boolean, integer
 from . import cloudformation
 
@@ -138,7 +138,10 @@ class AutoScalingGroup(AWSObject):
                 )
                 isMaxRef = isinstance(self.MaxSize, Ref)
 
-                if not (isMinRef or isMaxRef):
+                isMinMap = isinstance(self.MinSize, FindInMap)
+                isMaxMap = isinstance(self.MaxSize, FindInMap)
+
+                if not (isMinRef or isMaxRef or isMinMap or isMaxMap):
                     maxCount = int(self.MaxSize)
                     minCount = int(rolling_update.MinInstancesInService)
 


### PR DESCRIPTION
The AutoScalingGroup validation already checks to see if the min/max sizes are instances of a `Ref` prior to casting them to integers and doing size validation. However, they could also be instances of `FindInMap`, which currently blows up on the integer cast if MaxSize is a `FindInMap`.

Thoughts?