### PR TITLE
only validate elasticache az choices if azs is a list

### DIFF
--- a/troposphere/elasticache.py
+++ b/troposphere/elasticache.py
@@ -37,7 +37,7 @@ class CacheCluster(AWSObject):
         # Check that AZMode is "cross-az" if more than one Availability zone
         # is specified in PreferredAvailabilityZones
         preferred_azs = self.properties.get('PreferredAvailabilityZones')
-        if preferred_azs is not None and len(preferred_azs) > 1:
+        if preferred_azs is not None and isinstance(preferred_azs, list) and len(preferred_azs) > 1:
             if self.properties.get('AZMode') != 'cross-az':
                 raise ValueError('AZMode must be "cross-az" if more than one a'
                                  'vailability zone is specified in PreferredAv'

--- a/troposphere/elasticache.py
+++ b/troposphere/elasticache.py
@@ -37,7 +37,9 @@ class CacheCluster(AWSObject):
         # Check that AZMode is "cross-az" if more than one Availability zone
         # is specified in PreferredAvailabilityZones
         preferred_azs = self.properties.get('PreferredAvailabilityZones')
-        if preferred_azs is not None and isinstance(preferred_azs, list) and len(preferred_azs) > 1:
+        if preferred_azs is not None and \
+                isinstance(preferred_azs, list) and \
+                len(preferred_azs) > 1:
             if self.properties.get('AZMode') != 'cross-az':
                 raise ValueError('AZMode must be "cross-az" if more than one a'
                                  'vailability zone is specified in PreferredAv'


### PR DESCRIPTION
If PreferredAvailabilityZones is an If or some other conditional, this validation is invalid, so skip it unless PreferredAvailabilityZones is a list.

Example:

```
t = Template()
number_cache_nodes = t.add_parameter(...)

t.add_condition("HasOneCache", Equals(
    Ref(number_cache_nodes),
    "1"
))

ec = t.add_resource(CacheCluster(
    "CacheCluster",
    ..snip..
    AZMode=If("HasOneCache", "single-az", "cross-az"),
    PreferredAvailabilityZone=If("HasOneCache", Ref(availability_zone), Ref("AWS::NoValue")),
    PreferredAvailabilityZones=If("HasOneCache", Ref("AWS::NoValue"), [Ref(availability_zone),Ref(availability_zone2)]),
))
```