### PR TITLE
Path is optional for Role and InstanceProfile

### DIFF
--- a/examples/IAM_Roles_and_InstanceProfiles.py
+++ b/examples/IAM_Roles_and_InstanceProfiles.py
@@ -1,0 +1,32 @@
+from troposphere import Template, Ref
+
+from troposphere.iam import Role, InstanceProfile
+
+from awacs.aws import Allow, Statement, Principal, Policy
+from awacs.sts import AssumeRole
+
+t = Template()
+
+t.add_description("AWS CloudFormation Sample Template: This template "
+                  "demonstrates the creation of IAM Roles and "
+                  "InstanceProfiles.")
+
+cfnrole = t.add_resource(Role(
+    "CFNRole",
+    AssumeRolePolicyDocument=Policy(
+        Statement=[
+            Statement(
+                Effect=Allow,
+                Action=[AssumeRole],
+                Principal=Principal("Service", ["ec2.amazonaws.com"])
+            )
+        ]
+    )
+))
+
+cfninstanceprofile = t.add_resource(InstanceProfile(
+    "CFNInstanceProfile",
+    Roles=[Ref(cfnrole)]
+))
+
+print(t.to_json())

--- a/tests/examples_output/IAM_Roles_and_InstanceProfiles.template
+++ b/tests/examples_output/IAM_Roles_and_InstanceProfiles.template
@@ -1,0 +1,35 @@
+{
+    "Description": "AWS CloudFormation Sample Template: This template demonstrates the creation of IAM Roles and InstanceProfiles.",
+    "Resources": {
+        "CFNInstanceProfile": {
+            "Properties": {
+                "Roles": [
+                    {
+                        "Ref": "CFNRole"
+                    }
+                ]
+            },
+            "Type": "AWS::IAM::InstanceProfile"
+        },
+        "CFNRole": {
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [
+                        {
+                            "Action": [
+                                "sts:AssumeRole"
+                            ],
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "ec2.amazonaws.com"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "Type": "AWS::IAM::Role"
+        }
+    }
+}

--- a/troposphere/iam.py
+++ b/troposphere/iam.py
@@ -62,7 +62,7 @@ class InstanceProfile(AWSObject):
     resource_type = "AWS::IAM::InstanceProfile"
 
     props = {
-        'Path': (basestring, True),
+        'Path': (basestring, False),
         'Roles': (list, True),
     }
 
@@ -73,7 +73,7 @@ class Role(AWSObject):
     props = {
         'AssumeRolePolicyDocument': (policytypes, True),
         'ManagedPolicyArns': ([basestring], False),
-        'Path': (basestring, True),
+        'Path': (basestring, False),
         'Policies': ([Policy], False),
     }
 


### PR DESCRIPTION
The `Path` property on IAM Roles and Instance Profiles is optional. I added an example that works when deploying to AWS and tweaked the appropriate bools to make this behaviour possible:

```bash
$ aws cloudformation create-stack --stack-name=test-no-path --template-body file://tests/examples_output/IAM_Roles_and_InstanceProfiles.template --capabilities "CAPABILITY_IAM"
{
    "StackId": "arn:aws:cloudformation:eu-west-1:MYACCOUNT:stack/test-no-path/GUID"
}
$ aws cloudformation describe-stacks
{
    "Stacks": [
        {
            "StackId": "arn:aws:cloudformation:eu-west-1:MYACCOUNT:stack/test-no-path/GUID", 
            "Description": "AWS CloudFormation Sample Template: This template demonstrates the creation of IAM Roles and InstanceProfiles.", 
            "Tags": [], 
            "CreationTime": "2015-08-17T14:09:59.837Z", 
            "Capabilities": [
                "CAPABILITY_IAM"
            ], 
            "StackName": "test-no-path", 
            "NotificationARNs": [], 
            "StackStatus": "CREATE_COMPLETE", 
            "DisableRollback": false
        }
    ]
}
```

As an aside this now lines up with the expected behaviour defined in the documentation for [Roles](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#cfn-iam-role-path). However, the documentation for [InstanceProfiles](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html#cfn-iam-instanceprofile-path) continues to say the `Path` is required even though the above implies that it's not (at least not in all cases). I'm assuming the documentation is out of date in this instance.