### PR TITLE
Allow an optional resource_prefix in Template

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -36,6 +36,13 @@ class TestBasic(unittest.TestCase):
         instance = ExtendedInstance('ec2instance', attribute='value')
         self.assertEqual(instance.attribute, 'value')
 
+    def test_resource_prefix(self):
+        name = "FakeInstance"
+        prefix = "MyPrefix"
+        t = Template(prefix)
+        resource = t.add_resource(Instance(name))
+        self.assertEqual(resource.title, prefix + name)
+
 
 def call_correct(x):
     return x

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -369,7 +369,7 @@ class Template(object):
         'Outputs': (dict, False),
     }
 
-    def __init__(self):
+    def __init__(self, resource_prefix=None):
         self.description = None
         self.metadata = {}
         self.conditions = {}
@@ -378,6 +378,7 @@ class Template(object):
         self.parameters = {}
         self.resources = {}
         self.version = None
+        self.resource_prefix = resource_prefix
 
     def add_description(self, description):
         self.description = description
@@ -413,6 +414,8 @@ class Template(object):
         return self._update(self.parameters, parameter)
 
     def add_resource(self, resource):
+        if self.resource_prefix:
+            resource.title = "%s%s" % (self.resource_prefix, resource.title)
         return self._update(self.resources, resource)
 
     def add_version(self, version=None):


### PR DESCRIPTION
I find myself doing "MyStack" + <resource_name> really often in my
templates. It seemed like there would be a better way, and so I thought
I'd just try something.  I'm not 100% sold on this - it's a little
magical, but I thought I'd put it out there since it was such a simple
change and it could clean up a lot of boilerplate code.

The place where I can see this being problematic is when you later are
Ref() or GetAtt()'ing a resource that has had a prefix added to it.

Anyway, just an experiment. Be curious what people think about it.