### PR TITLE
Fix issue #320 (don't validate AWSHelperFns)

### DIFF
--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -1,5 +1,6 @@
 import unittest
 import troposphere.rds as rds
+from troposphere import If
 
 
 class TestRDS(unittest.TestCase):
@@ -150,6 +151,19 @@ class TestRDS(unittest.TestCase):
             MultiAZ=True)
         with self.assertRaisesRegexp(ValueError, "if MultiAZ is set to "):
             i.JSONrepr()
+
+    def test_az_and_multiaz_if(self):
+        i = rds.DBInstance(
+            "NoAZAndMultiAZIf",
+            MasterUsername="myuser",
+            MasterUserPassword="mypassword",
+            AllocatedStorage=10,
+            DBInstanceClass="db.m1.small",
+            Engine="postgres",
+            AvailabilityZone="us-east-1",
+            MultiAZ=If('MultiAZCondition', True, False)
+        )
+        i.JSONrepr()
 
     def test_io1_storage_type_and_iops(self):
         i = rds.DBInstance(

--- a/troposphere/rds.py
+++ b/troposphere/rds.py
@@ -192,8 +192,11 @@ class DBInstance(AWSObject):
                 'AWS::RDS::DBInstance.'
             )
 
-        if 'AvailabilityZone' in self.properties and \
-                self.properties.get('MultiAZ', None):
+        availability_zone = self.properties.get('AvailabilityZone', None)
+        multi_az = self.properties.get('MultiAZ', None)
+        if multi_az and not isinstance(multi_az, AWSHelperFn) and \
+                availability_zone and \
+                not isinstance(availability_zone, AWSHelperFn):
             raise ValueError("AvailabiltyZone cannot be set on DBInstance if "
                              "MultiAZ is set to true.")
 


### PR DESCRIPTION
Only check for the presence of both MultiAZ and AvailabilityZone when they are both not AWSHelperFn instances.
