### PR TITLE
tail: only add unseen events

### DIFF
--- a/troposphere/utils.py
+++ b/troposphere/utils.py
@@ -37,5 +37,5 @@ def tail(conn, stack_name, log_func=_tail_print, sleep_time=5,
         for e in events:
             if e.event_id not in seen:
                 log_func(e)
-            seen.add(e.event_id)
+                seen.add(e.event_id)
         time.sleep(sleep_time)


### PR DESCRIPTION
Since you already know whether the even was seen or not, take advantage of that knowledge to avoid redundant work.