### PR TITLE
Add __add__ method to Tags object to allow concatenation

### DIFF
--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -360,6 +360,15 @@ class Tags(AWSHelperFn):
                 'Value': v,
             })
 
+    # allow concatenation of the Tags object via '+' operator
+    def __add__(self, newtags):
+        self.tags.append(newtags.tags)
+        return self
+
+    #def __str__(self):
+    #    for tag in self.tags:
+    #    return "({0},{1})".format()
+
     def JSONrepr(self):
         return self.tags
 

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -362,8 +362,9 @@ class Tags(AWSHelperFn):
 
     # allow concatenation of the Tags object via '+' operator
     def __add__(self, newtags):
-        self.tags.append(newtags.tags)
-        return self
+        for tag in self.tags:
+            newtags.tags.append(tag)
+        return newtags
 
     def JSONrepr(self):
         return self.tags

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -365,7 +365,6 @@ class Tags(AWSHelperFn):
         self.tags.append(newtags.tags)
         return self
 
-
     def JSONrepr(self):
         return self.tags
 

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -365,9 +365,6 @@ class Tags(AWSHelperFn):
         self.tags.append(newtags.tags)
         return self
 
-    #def __str__(self):
-    #    for tag in self.tags:
-    #    return "({0},{1})".format()
 
     def JSONrepr(self):
         return self.tags

--- a/troposphere/autoscaling.py
+++ b/troposphere/autoscaling.py
@@ -54,13 +54,13 @@ class Tags(AWSHelperFn):
 
     # append tags to list
     def __add__(self, newtags):
-
-        for k, v in newtags.tags:
-            self.tags.append({
+        for k, v in self.tags:
+            newtags.tags.append({
                 'Key': v.data.Key,
                 'Value': v.data.Value,
                 'PropagateAtLaunch': True,
                 })
+        return newtags
 
     def JSONrepr(self):
         return self.tags

--- a/troposphere/autoscaling.py
+++ b/troposphere/autoscaling.py
@@ -52,6 +52,16 @@ class Tags(AWSHelperFn):
                 'PropagateAtLaunch': propagate,
             })
 
+    # append tags to list
+    def __add__(self, newtags):
+
+        for k, v in newtags.tags:
+            self.tags.append({
+                'Key': v.data.Key,
+                'Value': v.data.Value,
+                'PropagateAtLaunch': True,
+                })
+
     def JSONrepr(self):
         return self.tags
 


### PR DESCRIPTION
## Requirement

To be able to define a common list of stack tags and be able to apply them to a set of resource tags, eg:

```
CommonTags=Tags(Bar='foo')
Tags=CommonTags + Tags(Foo='Bar')
```


## Summary

Added a `__add__` method to the `Tags` class to facilitate using the append / concatenate operator `+` or `+=` to join(append) multiple Tags objects together thus allow things like `CommonTags` to be applied to a custom resource specific list of `Tags`.

Internally this uses the `tags` list/array within the `Tags` object.





