### PR TITLE
Correct EC2 SpotFleet LaunchSpecifications

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -480,6 +480,7 @@ class IamInstanceProfile(AWSProperty):
         'Arn': (basestring, False),
     }
 
+
 class LaunchSpecifications(AWSProperty):
     props = {
         'BlockDeviceMappings': ([BlockDeviceMapping], False),

--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -475,11 +475,16 @@ class SecurityGroups(AWSProperty):
     }
 
 
+class IamInstanceProfile(AWSProperty):
+    props = {
+        'Arn': (basestring, False),
+    }
+
 class LaunchSpecifications(AWSProperty):
     props = {
         'BlockDeviceMappings': ([BlockDeviceMapping], False),
         'EbsOptimized': (boolean, False),
-        'IamInstanceProfile': (basestring, False),
+        'IamInstanceProfile': (IamInstanceProfile, False),
         'ImageId': (basestring, True),
         'InstanceType': (basestring, True),
         'KernelId': (basestring, False),

--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -498,7 +498,7 @@ class LaunchSpecifications(AWSProperty):
 class SpotFleetRequestConfigData(AWSProperty):
     props = {
         'IamFleetRole': (basestring, True),
-        'LaunchSpecifications': (LaunchSpecifications, True),
+        'LaunchSpecifications': ([LaunchSpecifications], True),
         'SpotPrice': (basestring, True),
         'TargetCapacity': (positive_integer, True),
         'TerminateInstancesWithExpiration': (boolean, False),


### PR DESCRIPTION
LaunchSpecifications should be an array, as in the reference documentation
http://docs.aws.amazon.com/fr_fr/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-spotfleet-spotfleetrequestconfigdata.html