### PR TITLE
Fixing LaunchSpecifications should be an array

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -498,7 +498,7 @@ class LaunchSpecifications(AWSProperty):
 class SpotFleetRequestConfigData(AWSProperty):
     props = {
         'IamFleetRole': (basestring, True),
-        'LaunchSpecifications': (LaunchSpecifications, True),
+        'LaunchSpecifications': ([LaunchSpecifications], True),
         'SpotPrice': (basestring, True),
         'TargetCapacity': (positive_integer, True),
         'TerminateInstancesWithExpiration': (boolean, False),


### PR DESCRIPTION
Fixing TypeError: <class 'troposphere.ec2.SpotFleetRequestConfigData'>: None.LaunchSpecifications is <type 'list'>, expected <class 'troposphere.ec2.LaunchSpecifications'>

Since LaunchSpecifications should be an array.

http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-spotfleet-spotfleetrequestconfigdata.html#cfn-ec2-spotfleet-spotfleetrequestconfigdata-launchspecifications