### PR TITLE
Update codedeploy.pp

### DIFF
--- a/troposphere/codedeploy.py
+++ b/troposphere/codedeploy.py
@@ -25,7 +25,7 @@ class S3Location(AWSProperty):
         'BundleType': (basestring, True),
         'ETag': (basestring, False),
         'Key': (basestring, True),
-        'Version': (basestring, True),
+        'Version': (basestring, False),
     }
 
 


### PR DESCRIPTION
As per the docs, S3Location Version Property is not a default requirement. 
http://docs.aws.amazon.com/codedeploy/latest/APIReference/API_S3Location.html