### PR TITLE
Possible fix for #354

### DIFF
--- a/tests/test_loggroup.py
+++ b/tests/test_loggroup.py
@@ -1,0 +1,16 @@
+import unittest
+from troposphere import Template, Retain
+from troposphere.logs import LogGroup
+
+
+class TestLogGroup(unittest.TestCase):
+    def test_loggroup_deletionpolicy_is_preserved(self):
+        log_group = LogGroup(
+            "LogGroupWithDeletionPolicy",
+            DeletionPolicy=Retain
+        )
+        self.assertIn('DeletionPolicy', log_group.JSONrepr())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_loggroup.py
+++ b/tests/test_loggroup.py
@@ -1,5 +1,5 @@
 import unittest
-from troposphere import Template, Retain
+from troposphere import Retain
 from troposphere.logs import LogGroup
 
 

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -165,7 +165,10 @@ class BaseAWSObject(object):
         if self.properties:
             return self.resource
         elif hasattr(self, 'resource_type'):
-            return {k: v for k, v in self.resource.items() if k != 'Properties'}
+            return {
+                k: v for k, v in self.resource.items()
+                if k != 'Properties'
+            }
         else:
             return {}
 

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -160,7 +160,6 @@ class BaseAWSObject(object):
                 raise ValueError(
                     "Resource %s required in type %s" % (k, rtype))
         self.validate()
-        # If no other properties are set, only return the Type.
         # Mainly used to not have an empty "Properties".
         if self.properties:
             return self.resource

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -165,7 +165,7 @@ class BaseAWSObject(object):
         if self.properties:
             return self.resource
         elif hasattr(self, 'resource_type'):
-            return {'Type': self.resource_type}
+            return {k: v for k, v in self.resource.items() if k != 'Properties'}
         else:
             return {}
 


### PR DESCRIPTION
This is more explicit about only filtering out 'Properties' to avoid `DeletionPolicy` getting removed for LogGroup in #354 
Not sure if this has any unintended side effects, but I ran the tests and they passed.