### PR TITLE
Add CodePipeline support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,6 +113,7 @@ Currently supported AWS resource types
 - AWS::CloudTrail
 - AWS::CloudWatch
 - AWS::CodeDeploy
+- AWS::CodePipeline
 - AWS::DirectoryService
 - AWS::DynamoDB
 - AWS::EC2

--- a/examples/CodePipeline.py
+++ b/examples/CodePipeline.py
@@ -105,7 +105,8 @@ pipeline = t.add_resource(Pipeline(
     DisableInboundStageTransitions=[
         DisableInboundStageTransitions(
             StageName="Release",
-            Reason="Disabling the transition until integration tests are completed"
+            Reason="Disabling the transition until "
+                   "integration tests are completed"
         )
     ]
 ))

--- a/examples/CodePipeline.py
+++ b/examples/CodePipeline.py
@@ -1,0 +1,113 @@
+# Converted from CodePipeline example located at:
+# http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-pipeline.html
+
+from troposphere import Parameter, Ref, Template
+from troposphere.codepipeline import Pipeline, Stages, Actions, ActionTypeID, OutputArtifacts, InputArtifacts, \
+    ArtifactStore, DisableInboundStageTransitions
+
+t = Template()
+
+
+CodePipelineServiceRole = t.add_parameter(Parameter(
+    "CodePipelineServiceRole",
+    Description="The CodePipelineServiceRole ARN to use",
+    Type="String"
+))
+
+ArtifactStoreS3Location = t.add_parameter(Parameter(
+    "ArtifactStoreS3Location",
+    Description="This should be an S3 bucket resource or bucket name",
+    Type="String"
+))
+
+pipeline = t.add_resource(Pipeline(
+    "AppPipeline",
+    RoleArn=Ref(CodePipelineServiceRole),
+    Stages=[
+        Stages(
+            Name="Source",
+            Actions=[
+                Actions(
+                    Name="SourceAction",
+                    ActionTypeId=ActionTypeID(
+                        Category="Source",
+                        Owner="AWS",
+                        Version="1",
+                        Provider="S3"
+                    ),
+                    OutputArtifacts=[
+                        OutputArtifacts(
+                            Name="SourceOutput"
+                        )
+                    ],
+                    Configuration={
+                        "S3Bucket": { "Ref" : "SourceS3Bucket" },
+                        "S3ObjectKey": { "Ref" : "SourceS3ObjectKey" }
+                    },
+                    RunOrder="1"
+                )
+            ]
+        ),
+        Stages(
+            Name="Beta",
+            Actions=[
+                Actions(
+                    Name="BetaAction",
+                    InputArtifacts=[
+                        InputArtifacts(
+                            Name="SourceOutput"
+                        )
+                    ],
+                    ActionTypeId=ActionTypeID(
+                        Category="Deploy",
+                        Owner="AWS",
+                        Version="1",
+                        Provider="CodeDeploy"
+                    ),
+                    Configuration={
+                        "ApplicationName": { "Ref" : "ApplicationName" },
+                        "DeploymentGroupName": { "Ref" : "DeploymentGroupName" }
+                    },
+                    RunOrder="1"
+                )
+            ]
+        ),
+        Stages(
+            Name="Release",
+            Actions=[
+                Actions(
+                    Name="ReleaseAction",
+                    InputArtifacts=[
+                        InputArtifacts(
+                            Name="SourceOutput"
+                        )
+                    ],
+                    ActionTypeId=ActionTypeID(
+                        Category="Deploy",
+                        Owner="AWS",
+                        Version="1",
+                        Provider="CodeDeploy"
+                    ),
+                    Configuration={
+                        "ApplicationName": { "Ref" : "ApplicationName" },
+                        "DeploymentGroupName": { "Ref" : "DeploymentGroupName" }
+                    },
+                    RunOrder="1"
+                )
+            ]
+        )
+    ],
+    ArtifactStore=ArtifactStore(
+        Type="S3",
+        Location=Ref(ArtifactStoreS3Location)
+    ),
+    DisableInboundStageTransitions=[
+        DisableInboundStageTransitions(
+            StageName="Release",
+            Reason="Disabling the transition until integration tests are completed"
+        )
+    ]
+))
+
+
+print(t.to_json())

--- a/examples/CodePipeline.py
+++ b/examples/CodePipeline.py
@@ -1,9 +1,10 @@
 # Converted from CodePipeline example located at:
-# http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-pipeline.html
+# http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codepipeline-pipeline.html # noqa
 
 from troposphere import Parameter, Ref, Template
-from troposphere.codepipeline import Pipeline, Stages, Actions, ActionTypeID, OutputArtifacts, InputArtifacts, \
-    ArtifactStore, DisableInboundStageTransitions
+from troposphere.codepipeline import (
+    Pipeline, Stages, Actions, ActionTypeID, OutputArtifacts, InputArtifacts,
+    ArtifactStore, DisableInboundStageTransitions)
 
 t = Template()
 
@@ -41,8 +42,8 @@ pipeline = t.add_resource(Pipeline(
                         )
                     ],
                     Configuration={
-                        "S3Bucket": { "Ref" : "SourceS3Bucket" },
-                        "S3ObjectKey": { "Ref" : "SourceS3ObjectKey" }
+                        "S3Bucket": {"Ref": "SourceS3Bucket"},
+                        "S3ObjectKey": {"Ref": "SourceS3ObjectKey"}
                     },
                     RunOrder="1"
                 )
@@ -65,8 +66,8 @@ pipeline = t.add_resource(Pipeline(
                         Provider="CodeDeploy"
                     ),
                     Configuration={
-                        "ApplicationName": { "Ref" : "ApplicationName" },
-                        "DeploymentGroupName": { "Ref" : "DeploymentGroupName" }
+                        "ApplicationName": {"Ref": "ApplicationName"},
+                        "DeploymentGroupName": {"Ref": "DeploymentGroupName"}
                     },
                     RunOrder="1"
                 )
@@ -89,8 +90,8 @@ pipeline = t.add_resource(Pipeline(
                         Provider="CodeDeploy"
                     ),
                     Configuration={
-                        "ApplicationName": { "Ref" : "ApplicationName" },
-                        "DeploymentGroupName": { "Ref" : "DeploymentGroupName" }
+                        "ApplicationName": {"Ref": "ApplicationName"},
+                        "DeploymentGroupName": {"Ref": "DeploymentGroupName"}
                     },
                     RunOrder="1"
                 )

--- a/tests/examples_output/CodePipeline.template
+++ b/tests/examples_output/CodePipeline.template
@@ -1,0 +1,120 @@
+{
+    "Parameters": {
+        "ArtifactStoreS3Location": {
+            "Description": "This should be an S3 bucket resource or bucket name",
+            "Type": "String"
+        },
+        "CodePipelineServiceRole": {
+            "Description": "The CodePipelineServiceRole ARN to use",
+            "Type": "String"
+        }
+    },
+    "Resources": {
+        "AppPipeline": {
+            "Properties": {
+                "ArtifactStore": {
+                    "Location": {
+                        "Ref": "ArtifactStoreS3Location"
+                    },
+                    "Type": "S3"
+                },
+                "DisableInboundStageTransitions": [
+                    {
+                        "Reason": "Disabling the transition until integration tests are completed",
+                        "StageName": "Release"
+                    }
+                ],
+                "RoleArn": {
+                    "Ref": "CodePipelineServiceRole"
+                },
+                "Stages": [
+                    {
+                        "Actions": [
+                            {
+                                "ActionTypeId": {
+                                    "Category": "Source",
+                                    "Owner": "AWS",
+                                    "Provider": "S3",
+                                    "Version": "1"
+                                },
+                                "Configuration": {
+                                    "S3Bucket": {
+                                        "Ref": "SourceS3Bucket"
+                                    },
+                                    "S3ObjectKey": {
+                                        "Ref": "SourceS3ObjectKey"
+                                    }
+                                },
+                                "Name": "SourceAction",
+                                "OutputArtifacts": [
+                                    {
+                                        "Name": "SourceOutput"
+                                    }
+                                ],
+                                "RunOrder": "1"
+                            }
+                        ],
+                        "Name": "Source"
+                    },
+                    {
+                        "Actions": [
+                            {
+                                "ActionTypeId": {
+                                    "Category": "Deploy",
+                                    "Owner": "AWS",
+                                    "Provider": "CodeDeploy",
+                                    "Version": "1"
+                                },
+                                "Configuration": {
+                                    "ApplicationName": {
+                                        "Ref": "ApplicationName"
+                                    },
+                                    "DeploymentGroupName": {
+                                        "Ref": "DeploymentGroupName"
+                                    }
+                                },
+                                "InputArtifacts": [
+                                    {
+                                        "Name": "SourceOutput"
+                                    }
+                                ],
+                                "Name": "BetaAction",
+                                "RunOrder": "1"
+                            }
+                        ],
+                        "Name": "Beta"
+                    },
+                    {
+                        "Actions": [
+                            {
+                                "ActionTypeId": {
+                                    "Category": "Deploy",
+                                    "Owner": "AWS",
+                                    "Provider": "CodeDeploy",
+                                    "Version": "1"
+                                },
+                                "Configuration": {
+                                    "ApplicationName": {
+                                        "Ref": "ApplicationName"
+                                    },
+                                    "DeploymentGroupName": {
+                                        "Ref": "DeploymentGroupName"
+                                    }
+                                },
+                                "InputArtifacts": [
+                                    {
+                                        "Name": "SourceOutput"
+                                    }
+                                ],
+                                "Name": "ReleaseAction",
+                                "RunOrder": "1"
+                            }
+                        ],
+                        "Name": "Release"
+                    }
+                ]
+            },
+            "Type": "AWS::CodePipeline::Pipeline"
+        }
+    }
+}

--- a/troposphere/codepipeline.py
+++ b/troposphere/codepipeline.py
@@ -124,7 +124,8 @@ class Pipeline(AWSObject):
 
     props = {
         'ArtifactStore': (ArtifactStore, True),
-        'DisableInboundStageTransitions': ([DisableInboundStageTransitions], False),
+        'DisableInboundStageTransitions':
+            ([DisableInboundStageTransitions], False),
         'Name': (basestring, False),
         'RestartExecutionOnUpdate': (boolean, False),
         'RoleArn': (basestring, True),

--- a/troposphere/codepipeline.py
+++ b/troposphere/codepipeline.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2015, Mark Peek <mark@peek.org>
+# All rights reserved.
+#
+# See LICENSE file for full license.
+
+from . import AWSObject, AWSProperty
+from .validators import boolean, integer
+
+
+class ActionTypeID(AWSProperty):
+    props = {
+        'Category': (basestring, True),
+        'Owner': (basestring, True),
+        'Provider': (basestring, True),
+        'Version': (basestring, True)
+    }
+
+
+class ArtifactDetails(AWSProperty):
+    props = {
+        'MaximumCount': (integer, True),
+        'MinimumCount': (integer, True)
+    }
+
+
+class Blockers(AWSProperty):
+    props = {
+        'Name': (basestring, True),
+        'Type': (basestring, True)
+    }
+
+
+class ConfigurationProperties(AWSProperty):
+    props = {
+        'Description': (basestring, False),
+        'Key': (boolean, True),
+        'Name': (basestring, True),
+        'Queryable': (boolean, False),
+        'Required': (boolean, True),
+        'Secret': (boolean, True),
+        'Type': (basestring, False)
+    }
+
+
+class EncryptionKey(AWSProperty):
+    props = {
+        'Id': (basestring, True),
+        'Type': (basestring, True)
+    }
+
+
+class DisableInboundStageTransitions(AWSProperty):
+    props = {
+        'Reason': (basestring, True),
+        'StageName': (basestring, True)
+    }
+
+
+class InputArtifacts(AWSProperty):
+    props = {
+        'Name': (basestring, True)
+    }
+
+
+class OutputArtifacts(AWSProperty):
+    props = {
+        'Name': (basestring, True)
+    }
+
+
+class Settings(AWSProperty):
+    props = {
+        'EntityUrlTemplate': (basestring, False),
+        'ExecutionUrlTemplate': (basestring, False),
+        'RevisionUrlTemplate': (basestring, False),
+        'ThirdPartyConfigurationUrl': (basestring, False)
+    }
+
+
+class ArtifactStore(AWSProperty):
+    props = {
+        'EncryptionKey': (EncryptionKey, False),
+        'Location': (basestring, True),
+        'Type': (basestring, True)
+    }
+
+
+class Actions(AWSProperty):
+    props = {
+        'ActionTypeId': (ActionTypeID, True),
+        'Configuration': (dict, False),
+        'InputArtifacts': ([InputArtifacts], False),
+        'Name': (basestring, True),
+        'OutputArtifacts': ([OutputArtifacts], False),
+        'RoleArn': (basestring, False),
+        'RunOrder': (integer, False)
+    }
+
+
+class Stages(AWSProperty):
+    props = {
+        'Actions': ([Actions], True),
+        'Blockers': ([Blockers], False),
+        'Name': (basestring, True)
+    }
+
+
+class CustomActionType(AWSObject):
+    resource_type = "AWS::CodePipeline::CustomActionType"
+
+    props = {
+        'Category': (basestring, True),
+        'ConfigurationProperties': ([ConfigurationProperties], False),
+        'InputArtifactDetails': (ArtifactDetails, True),
+        'OutputArtifactDetails': (ArtifactDetails, True),
+        'Provider': (basestring, True),
+        'Settings': (Settings, False),
+        'Version': (basestring, False)
+    }
+
+
+class Pipeline(AWSObject):
+    resource_type = "AWS::CodePipeline::Pipeline"
+
+    props = {
+        'ArtifactStore': (ArtifactStore, True),
+        'DisableInboundStageTransitions': ([DisableInboundStageTransitions], False),
+        'Name': (basestring, False),
+        'RestartExecutionOnUpdate': (boolean, False),
+        'RoleArn': (basestring, True),
+        'Stages': ([Stages], True)
+    }


### PR DESCRIPTION
As of Dec 3 2015 CloudFormation supports CodePipeline http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/ReleaseHistory.html