### PR TITLE
ElastiCache: NotificationTopicArn is a string not a list of strings. 

### DIFF
--- a/troposphere/elasticache.py
+++ b/troposphere/elasticache.py
@@ -100,7 +100,7 @@ class ReplicationGroup(AWSObject):
         'CacheSubnetGroupName': (basestring, False),
         'Engine': (basestring, True),
         'EngineVersion': (basestring, False),
-        'NotificationTopicArn': ([basestring, Ref], False),
+        'NotificationTopicArn': (basestring, False),
         'NumCacheClusters': (integer, True),
         'Port': (network_port, False),
         'PreferredCacheClusterAZs': ([basestring], False),


### PR DESCRIPTION
See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-replicationgroup.html#cfn-elasticache-replicationgroup-notificationtopicarn