### PR TITLE
Add Compress support on Cloudfront's CacheBehavior

### DIFF
--- a/troposphere/cloudfront.py
+++ b/troposphere/cloudfront.py
@@ -35,6 +35,7 @@ class CacheBehavior(AWSProperty):
         'MaxTTL': (integer, False),
         'PathPattern': (basestring, True),
         'SmoothStreaming': (boolean, False),
+        'Compress': (boolean, False),
     }
 
 
@@ -50,6 +51,7 @@ class DefaultCacheBehavior(AWSProperty):
         'DefaultTTL': (integer, False),
         'MaxTTL': (integer, False),
         'SmoothStreaming': (boolean, False),
+        'Compress': (boolean, False),
     }
 
 


### PR DESCRIPTION
Compress
Whether you want CloudFront to automatically compress certain files for this cache behavior. If so, specify true; if not, specify false. For more information, see Serving Compressed Files in the Amazon CloudFront Developer Guide.

Type: String

Default: None

Valid Values: true | false

Parent: DefaultCacheBehavior or CacheBehavior


Source : http://docs.aws.amazon.com/AmazonCloudFront/latest/APIReference/DistributionConfigDatatype.html