### PR TITLE
ReplicationConfigurationRules Destination is now an object

### DIFF
--- a/troposphere/s3.py
+++ b/troposphere/s3.py
@@ -176,9 +176,16 @@ class NotificationConfiguration(AWSProperty):
     }
 
 
+class ReplicationConfigurationRulesDestination(AWSProperty):
+    props = {
+        'Bucket': (basestring, True),
+        'StorageClass': (basestring, False)
+    }
+
+
 class ReplicationConfigurationRules(AWSProperty):
     props = {
-        'Destination': (basestring, True),
+        'Destination': (ReplicationConfigurationRulesDestination, True),
         'Id': (basestring, False),
         'Prefix': (basestring, True),
         'Status': (basestring, True)


### PR DESCRIPTION
In [Amazon S3 ReplicationConfiguration Rules](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-replicationconfiguration-rules.html) the Destination field use to be a string but it's now an object with [2 documented fields](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-replicationconfiguration-rules-destination.html): Bucket and StorageClass.