### PR TITLE
extended title validation

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2,7 +2,7 @@ import unittest
 from troposphere import Parameter, Ref
 from troposphere.validators import boolean, integer, integer_range
 from troposphere.validators import positive_integer, network_port
-from troposphere.validators import s3_bucket_name, encoding, status, iam_path
+from troposphere.validators import s3_bucket_name, encoding, status, iam_path, iam_names, iam_role_name, iam_group_name
 
 
 class TestValidators(unittest.TestCase):
@@ -79,12 +79,33 @@ class TestValidators(unittest.TestCase):
             with self.assertRaises(ValueError):
                 status(s)
 
+    def test_iam_names(self):
+        for s in ['foobar.+=@-,', 'BARfoo789.+=@-,']:
+            iam_names(s)
+        for s in ['foo%', 'bar$']:
+            with self.assertRaises(ValueError):
+                iam_names(s)
+
     def test_iam_path(self):
-        for s in ['a'*30, 'a'*512]:
+        for s in ['/%s/' % ('a'*30), '/%s/' % ('a'*510)]:
             iam_path(s)
-        for s in ['a'*513, 'a'*1025]:
+        for s in ['/%s/' % ('a'*511), '/%s/' % ('a'*1025)]:
             with self.assertRaises(ValueError):
                 iam_path(s)
+
+    def test_iam_role_name(self):
+        for s in ['a'*30, 'a'*64]:
+            iam_role_name(s)
+        for s in ['a'*65, 'a'*128]:
+            with self.assertRaises(ValueError):
+                iam_role_name(s)
+
+    def test_iam_group_name(self):
+        for s in ['a'*64, 'a'*128]:
+            iam_group_name(s)
+        for s in ['a'*129, 'a'*256]:
+            with self.assertRaises(ValueError):
+                iam_group_name(s)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2,7 +2,7 @@ import unittest
 from troposphere import Parameter, Ref
 from troposphere.validators import boolean, integer, integer_range
 from troposphere.validators import positive_integer, network_port
-from troposphere.validators import s3_bucket_name, encoding, status
+from troposphere.validators import s3_bucket_name, encoding, status, iam_path
 
 
 class TestValidators(unittest.TestCase):
@@ -79,6 +79,12 @@ class TestValidators(unittest.TestCase):
             with self.assertRaises(ValueError):
                 status(s)
 
+    def test_iam_path(self):
+        for s in ['a'*30, 'a'*512]:
+            iam_path(s)
+        for s in ['a'*513, 'a'*1025]:
+            with self.assertRaises(ValueError):
+                iam_path(s)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2,7 +2,9 @@ import unittest
 from troposphere import Parameter, Ref
 from troposphere.validators import boolean, integer, integer_range
 from troposphere.validators import positive_integer, network_port
-from troposphere.validators import s3_bucket_name, encoding, status, iam_path, iam_names, iam_role_name, iam_group_name
+from troposphere.validators import s3_bucket_name, encoding, status
+from troposphere.validators import iam_path, iam_names, iam_role_name
+from troposphere.validators import iam_group_name
 
 
 class TestValidators(unittest.TestCase):

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -38,8 +38,11 @@ class BaseAWSObject(object):
                            'Metadata', 'UpdatePolicy',
                            'Condition', 'CreationPolicy']
 
-        # unset/None is also legal
-        if title and not valid_names.match(title):
+        # some objects allow more characters than others
+        if title and 'validate_title' in dir(self):
+            self.validate_title()
+        elif title and not valid_names.match(title):
+            # unset/None is also legal
             raise ValueError('Name "%s" not alphanumeric' % title)
 
         # Create the list of properties set on this object by the user

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -38,12 +38,9 @@ class BaseAWSObject(object):
                            'Metadata', 'UpdatePolicy',
                            'Condition', 'CreationPolicy']
 
-        # some objects allow more characters than others
-        if title and 'validate_title' in dir(self):
+        # try to validate the title if its there
+        if self.title is not None:
             self.validate_title()
-        elif title and not valid_names.match(title):
-            # unset/None is also legal
-            raise ValueError('Name "%s" not alphanumeric' % title)
 
         # Create the list of properties set on this object by the user
         self.properties = {}
@@ -146,6 +143,10 @@ class BaseAWSObject(object):
                                                           name,
                                                           type(value),
                                                           expected_type))
+
+    def validate_title(self):
+        if not valid_names.match(self.title):
+            raise ValueError('Name "%s" not alphanumeric' % self.title)
 
     def validate(self):
         pass

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -39,7 +39,7 @@ class BaseAWSObject(object):
                            'Condition', 'CreationPolicy']
 
         # try to validate the title if its there
-        if self.title is not None:
+        if self.title:
             self.validate_title()
 
         # Create the list of properties set on this object by the user

--- a/troposphere/iam.py
+++ b/troposphere/iam.py
@@ -4,7 +4,7 @@
 # See LICENSE file for full license.
 
 from . import AWSObject, AWSProperty, Ref
-from .validators import integer, boolean, status, iam_path
+from .validators import integer, boolean, status, iam_path, iam_role_name, iam_group_name
 try:
     from awacs.aws import Policy
     policytypes = (dict, Policy)
@@ -49,6 +49,9 @@ PolicyProperty = Policy
 
 
 class Group(AWSObject):
+    def validate_title(self):
+        iam_group_name(self.title)
+
     resource_type = "AWS::IAM::Group"
 
     props = {
@@ -68,6 +71,9 @@ class InstanceProfile(AWSObject):
 
 
 class Role(AWSObject):
+    def validate_title(self):
+        iam_role_name(self.title)
+
     resource_type = "AWS::IAM::Role"
 
     props = {

--- a/troposphere/iam.py
+++ b/troposphere/iam.py
@@ -4,7 +4,7 @@
 # See LICENSE file for full license.
 
 from . import AWSObject, AWSProperty, Ref
-from .validators import integer, boolean, status
+from .validators import integer, boolean, status, iam_path
 try:
     from awacs.aws import Policy
     policytypes = (dict, Policy)
@@ -53,7 +53,7 @@ class Group(AWSObject):
 
     props = {
         'ManagedPolicyArns': ([basestring], False),
-        'Path': (basestring, False),
+        'Path': (iam_path, False),
         'Policies': ([Policy], False),
     }
 
@@ -62,7 +62,7 @@ class InstanceProfile(AWSObject):
     resource_type = "AWS::IAM::InstanceProfile"
 
     props = {
-        'Path': (basestring, False),
+        'Path': (iam_path, False),
         'Roles': (list, True),
     }
 
@@ -73,7 +73,7 @@ class Role(AWSObject):
     props = {
         'AssumeRolePolicyDocument': (policytypes, True),
         'ManagedPolicyArns': ([basestring], False),
-        'Path': (basestring, False),
+        'Path': (iam_path, False),
         'Policies': ([Policy], False),
     }
 
@@ -89,7 +89,7 @@ class User(AWSObject):
     resource_type = "AWS::IAM::User"
 
     props = {
-        'Path': (basestring, False),
+        'Path': (iam_path, False),
         'Groups': ([basestring, Ref], False),
         'ManagedPolicyArns': ([basestring], False),
         'LoginProfile': (LoginProfile, False),
@@ -112,7 +112,7 @@ class ManagedPolicy(AWSObject):
     props = {
         'Description': (basestring, False),
         'Groups': ([basestring, Ref], False),
-        'Path': (basestring, False),
+        'Path': (iam_path, False),
         'PolicyDocument': (policytypes, True),
         'Roles': ([basestring, Ref], False),
         'Users': ([basestring, Ref], False),

--- a/troposphere/iam.py
+++ b/troposphere/iam.py
@@ -4,7 +4,9 @@
 # See LICENSE file for full license.
 
 from . import AWSObject, AWSProperty, Ref
-from .validators import integer, boolean, status, iam_path, iam_role_name, iam_group_name
+from .validators import integer, boolean, status
+from .validators import iam_path, iam_role_name, iam_group_name
+
 try:
     from awacs.aws import Policy
     policytypes = (dict, Policy)

--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -73,3 +73,8 @@ def status(status):
     if status not in valid_statuses:
         raise ValueError('Status needs to be one of %r' % valid_statuses)
     return status
+
+def iam_path(path):
+    if len(path) > 512:
+        raise ValueError('IAM path may not exceed 512 characters')
+    return path

--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -4,6 +4,7 @@
 # See LICENSE file for full license.
 from re import compile
 
+
 def boolean(x):
     if x in [True, 1, '1', 'true', 'True']:
         return "true"
@@ -73,12 +74,14 @@ def status(status):
         raise ValueError('Status needs to be one of %r' % valid_statuses)
     return status
 
+
 def iam_names(b):
     iam_name_re = compile(r'^[a-zA-Z0-9_\.\+\=\@\-\,]+$')
     if iam_name_re.match(b):
         return b
     else:
         raise ValueError("%s is not a valid iam name" % b)
+
 
 def iam_path(path):
     if len(path) > 512:
@@ -89,11 +92,13 @@ def iam_path(path):
         raise ValueError("%s is not a valid iam path name" % path)
     return path
 
+
 def iam_role_name(role_name):
     if len(role_name) > 64:
         raise ValueError('IAM Role Name may not exceed 64 characters')
     iam_names(role_name)
     return role_name
+
 
 def iam_group_name(group_name):
     if len(group_name) > 128:

--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -2,7 +2,7 @@
 # All rights reserved.
 #
 # See LICENSE file for full license.
-
+from re import compile
 
 def boolean(x):
     if x in [True, 1, '1', 'true', 'True']:
@@ -53,7 +53,6 @@ def network_port(x):
 
 
 def s3_bucket_name(b):
-    from re import compile
     s3_bucket_name_re = compile(r'^[a-z\d][a-z\d\.-]{1,61}[a-z\d]$')
     if s3_bucket_name_re.match(b):
         return b
@@ -74,7 +73,30 @@ def status(status):
         raise ValueError('Status needs to be one of %r' % valid_statuses)
     return status
 
+def iam_names(b):
+    iam_name_re = compile(r'^[a-zA-Z0-9_\.\+\=\@\-\,]+$')
+    if iam_name_re.match(b):
+        return b
+    else:
+        raise ValueError("%s is not a valid iam name" % b)
+
 def iam_path(path):
     if len(path) > 512:
-        raise ValueError('IAM path may not exceed 512 characters')
+        raise ValueError('IAM path %s may not exceed 512 characters', path)
+
+    iam_path_re = compile(r'^\/.*\/$|^\/$')
+    if not iam_path_re.match(path):
+        raise ValueError("%s is not a valid iam path name" % path)
     return path
+
+def iam_role_name(role_name):
+    if len(role_name) > 64:
+        raise ValueError('IAM Role Name may not exceed 64 characters')
+    iam_names(role_name)
+    return role_name
+
+def iam_group_name(group_name):
+    if len(group_name) > 128:
+        raise ValueError('IAM Role Name may not exceed 128 characters')
+    iam_names(group_name)
+    return group_name


### PR DESCRIPTION
This PR adds the option to have custom title validators, as the default one is often to restrictive (AWS allows more characters)
Also there are some new checks for IAM Objects which help you catching errors before you run the CF template.