### PR TITLE
Adding IsMultiRegionTrail support

### DIFF
--- a/troposphere/cloudtrail.py
+++ b/troposphere/cloudtrail.py
@@ -11,6 +11,7 @@ class Trail(AWSObject):
         'EnableLogFileValidation': (boolean, False),
         'IncludeGlobalServiceEvents': (boolean, False),
         'IsLogging': (boolean, True),
+        'IsMultiRegionTrail': (boolean, False),
         'KMSKeyId': (basestring, False),
         'S3BucketName': (basestring, True),
         'S3KeyPrefix': (basestring, False),


### PR DESCRIPTION
Troposphere's CloudTrail is missing one of the parameters listed in the CloudFormation reference <http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudtrail-trail.html#cfn-cloudtrail-trail-s3bucketname>.

This pull request adds this parameter. 

The code has been tested manually. 