### PR TITLE
Logs SubscriptionFilter

### DIFF
--- a/troposphere/logs.py
+++ b/troposphere/logs.py
@@ -55,5 +55,5 @@ class SubscriptionFilter(AWSObject):
         'DestinationArn': (basestring, True),
         'FilterPattern': (basestring, True),
         'LogGroupName': (basestring, True),
-        'RoleArn': (basestring, True),
+        'RoleArn': (basestring, False),
     }


### PR DESCRIPTION
Hi,

From the doc: 
http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-subscriptionfilter.html

    An IAM role that grants CloudWatch Logs permission to put data into the specified Amazon Kinesis stream. For Lambda and CloudWatch Logs destinations, don't specify this property because CloudWatch Logs gets the necessary permissions from the destination resource.

    Required: No

    Type: String

    Update requires: Replacement


AWS::Logs::SubscriptionFilter RoleArn is mandatory in the library but not on AWS and gives you an error:  destinationArn for vendor lambda cannot be used with roleArn