### PR TITLE
Apply 2to3 on cfn2py script

### DIFF
--- a/scripts/cfn2py
+++ b/scripts/cfn2py
@@ -5,6 +5,12 @@ import argparse
 import json
 import pprint
 
+# Cross python string check. Because we don't require six.
+try:
+    basestring
+except NameError:
+    basestring=str
+
 
 class object_registry(object):
     """Keep track of objects being created as Parameters or Resources
@@ -271,7 +277,7 @@ function_map = {
 
 def output_value(v):
     """Output a value which may be a string or a set of function calls."""
-    if isinstance(v, str):
+    if isinstance(v, basestring):
         return '"%s"' % (v.replace('\\', '\\\\').replace('\n', '\\n').replace("\"", "\\\""))
     elif isinstance(v, bool):
         return '%s' % (str(v))

--- a/scripts/cfn2py
+++ b/scripts/cfn2py
@@ -71,16 +71,16 @@ def do_header(d):
             if tropo_object not in seen:
                 seen.append(tropo_object)
                 print('from troposphere.%s import %s' % (mod, additional_imports(tropo_object)))
-    print()
-    print()
+    print("")
+    print("")
     print("t = Template()")
-    print()
+    print("")
 
 
 def do_awstemplateformatversion(d):
     """Output the template version"""
     print('t.add_version("%s")' % (d['AWSTemplateFormatVersion'], ))
-    print()
+    print("")
 
 
 def do_description(d):
@@ -98,7 +98,7 @@ def do_parameters(d):
         for pk, pv in v.items():
             print('    %s=%s,' % (pk, output_value(pv)))
         print("))")
-        print()
+        print("")
 
 
 def do_mappings(d):
@@ -108,7 +108,7 @@ def do_mappings(d):
         print('t.add_mapping("%s",' % (k,))
         pprint.pprint(v)
         print(")")
-        print()
+        print("")
 
 
 def generate_troposphere_object(typename):
@@ -243,7 +243,7 @@ def do_resources(d):
         if "DependsOn" in v:
             print('    %s=%s,' % ("DependsOn", output_value(v['DependsOn'])))
         print("))")
-        print()
+        print("")
 
 
 def handle_no_objects(name, values):
@@ -311,7 +311,7 @@ def do_outputs(d):
             else:
                 print('    %s=%s,' % (pk, output_value(pv)))
         print("))")
-        print()
+        print("")
 
 
 def do_trailer(d):

--- a/scripts/cfn2py
+++ b/scripts/cfn2py
@@ -40,7 +40,7 @@ object_functions = {
 }
 
 def additional_imports(o):
-    if object_functions.has_key(o):
+    if o in object_functions:
         return ", ".join([o] + object_functions[o])
     else:
         return o
@@ -49,12 +49,12 @@ def do_header(d):
     """Output a stock header for the new Python script and also try to
     figure out the Resource imports needed by the template.
     """
-    print 'from troposphere import Base64, Select, FindInMap, GetAtt, GetAZs, Join, Output'
-    print 'from troposphere import Parameter, Ref, Tags, Template'
-    print 'from troposphere.cloudformation import Init'
-    print 'from troposphere.cloudfront import Distribution, DistributionConfig'
-    print 'from troposphere.cloudfront import Origin, DefaultCacheBehavior'
-    print 'from troposphere.ec2 import PortRange'
+    print('from troposphere import Base64, Select, FindInMap, GetAtt, GetAZs, Join, Output')
+    print('from troposphere import Parameter, Ref, Tags, Template')
+    print('from troposphere.cloudformation import Init')
+    print('from troposphere.cloudfront import Distribution, DistributionConfig')
+    print('from troposphere.cloudfront import Origin, DefaultCacheBehavior')
+    print('from troposphere.ec2 import PortRange')
 
     # Loop over the resources to find imports
     if 'Resources' in d:
@@ -64,22 +64,22 @@ def do_header(d):
             (mod, tropo_object) = generate_troposphere_object(v['Type'])
             if tropo_object not in seen:
                 seen.append(tropo_object)
-                print 'from troposphere.%s import %s' % (mod, additional_imports(tropo_object))
-    print
-    print
-    print "t = Template()"
-    print
+                print('from troposphere.%s import %s' % (mod, additional_imports(tropo_object)))
+    print()
+    print()
+    print("t = Template()")
+    print()
 
 
 def do_awstemplateformatversion(d):
     """Output the template version"""
-    print 't.add_version("%s")' % (d['AWSTemplateFormatVersion'], )
-    print
+    print('t.add_version("%s")' % (d['AWSTemplateFormatVersion'], ))
+    print()
 
 
 def do_description(d):
     """Output the template Description"""
-    print 't.add_description("""\\\n%s""")' % (d['Description'], )
+    print('t.add_description("""\\\n%s""")' % (d['Description'], ))
 
 
 def do_parameters(d):
@@ -87,22 +87,22 @@ def do_parameters(d):
     params = d['Parameters']
     for k, v in params.items():
         object_name = objects.add(k)
-        print '%s = t.add_parameter(Parameter(' % (object_name,)
-        print '    "%s",' % (k, )
+        print('%s = t.add_parameter(Parameter(' % (object_name,))
+        print('    "%s",' % (k, ))
         for pk, pv in v.items():
-            print '    %s=%s,' % (pk, output_value(pv))
-        print "))"
-        print
+            print('    %s=%s,' % (pk, output_value(pv)))
+        print("))")
+        print()
 
 
 def do_mappings(d):
     """Output the template Mappings"""
     mappings = d['Mappings']
     for k, v in mappings.items():
-        print 't.add_mapping("%s",' % (k,)
+        print('t.add_mapping("%s",' % (k,))
         pprint.pprint(v)
-        print ")"
-        print
+        print(")")
+        print()
 
 
 def generate_troposphere_object(typename):
@@ -153,43 +153,43 @@ function_quirks = {
 }
 
 def do_output_function(k, f, v):
-    print '    %s=%s(' % (k, f)
+    print('    %s=%s(' % (k, f))
     for pk, pv in v.items():
-        if known_functions.has_key(pk):
+        if pk in known_functions:
             do_resources_content(pk, pv, "")
         else:
-            print "        %s=%s," % (pk, output_value(pv))
-    print '    ),'
+            print("        %s=%s," % (pk, output_value(pv)))
+    print('    ),')
 
 def do_output_quirk_list(k, f, v):
-    print '    %s=[' % (k)
+    print('    %s=[' % (k))
     for e in v:
-        print '    %s(' % (f)
+        print('    %s(' % (f))
         for pk, pv in e.items():
-            if known_functions.has_key(pk):
+            if pk in known_functions:
                 do_resources_content(pk, pv)
             else:
-                print "        %s=%s," % (pk, output_value(pv))
-        print '    ),'
-    print '    ],'
+                print("        %s=%s," % (pk, output_value(pv)))
+        print('    ),')
+    print('    ],')
 
 def do_output_quirk_mapping(k, v):
     m = function_quirks[k]
     for pk in m.keys():
-        print '    %s=%s(' % (k, pk)
+        print('    %s=%s(' % (k, pk))
         for e in m[pk]:
-            print "        %s," % (output_value(v[e]))
-        print '    ),'
+            print("        %s," % (output_value(v[e])))
+        print('    ),')
 
 def do_output_quirk_metadata(k, v):
     m = function_quirks[k]
     for pk in m.keys():
-        print '    Metadata=%s(' % (pk)
-        print "        %s," % (output_value(v))
-        print '    ),'
+        print('    Metadata=%s(' % (pk))
+        print("        %s," % (output_value(v)))
+        print('    ),')
 
 def do_resources_content(k, v, p=""):
-    if function_quirks.has_key(k):
+    if k in function_quirks:
         x = function_quirks[k];
         if(isinstance(x, dict)):
             if(p == "Metadata"):
@@ -214,30 +214,30 @@ def do_resources(d):
     for k, v in resources.items():
         object_name = objects.add(k)
         (_, tropo_object) = generate_troposphere_object(v['Type'])
-        if(top_level_aliases.has_key(tropo_object)):
+        if(tropo_object in top_level_aliases):
             tropo_object = top_level_aliases[tropo_object]
-        print '%s = t.add_resource(%s(' % (object_name, tropo_object)
-        print '    "%s",' % (k, )
-        for p in filter(lambda x: v.has_key(x), ['Metadata', 'Properties']):
+        print('%s = t.add_resource(%s(' % (object_name, tropo_object))
+        print('    "%s",' % (k, ))
+        for p in [x for x in ['Metadata', 'Properties'] if x in v]:
             for pk, pv in v[p].items():
                 if pk == "Tags":
-                    print '    Tags=Tags('
+                    print('    Tags=Tags(')
                     for d in pv:
-                        print "        %s=%s," % (
-                            d['Key'], output_value(d['Value']))
-                    print '    ),'
+                        print("        %s=%s," % (
+                            d['Key'], output_value(d['Value'])))
+                    print('    ),')
                 elif pk == 'PortRange':
-                    print "    %s=%s(%s)," % (pk, pk, output_dict(pv))
-                elif known_functions.has_key(pk):
+                    print("    %s=%s(%s)," % (pk, pk, output_dict(pv)))
+                elif pk in known_functions:
                     do_resources_content(pk, pv, p)
-                elif isinstance(pv, basestring):
-                    print '    %s="%s",' % (pk, pv)
+                elif isinstance(pv, str):
+                    print('    %s="%s",' % (pk, pv))
                 else:
-                    print '    %s=%s,' % (pk, output_value(pv))
-        if v.has_key("DependsOn"):
-            print '    %s=%s,' % ("DependsOn", output_value(v['DependsOn']))
-        print "))"
-        print
+                    print('    %s=%s,' % (pk, output_value(pv)))
+        if "DependsOn" in v:
+            print('    %s=%s,' % ("DependsOn", output_value(v['DependsOn'])))
+        print("))")
+        print()
 
 
 def handle_no_objects(name, values):
@@ -271,7 +271,7 @@ function_map = {
 
 def output_value(v):
     """Output a value which may be a string or a set of function calls."""
-    if isinstance(v, basestring):
+    if isinstance(v, str):
         return '"%s"' % (v.replace('\\', '\\\\').replace('\n', '\\n').replace("\"", "\\\""))
     elif isinstance(v, bool):
         return '%s' % (str(v))
@@ -297,20 +297,20 @@ def do_outputs(d):
     """Output the template Outputs"""
     outputs = d['Outputs']
     for k, v in outputs.items():
-        print '%s = t.add_output(Output(' % (k,)
-        print '    "%s",' % (k, )
+        print('%s = t.add_output(Output(' % (k,))
+        print('    "%s",' % (k, ))
         for pk, pv in v.items():
-            if isinstance(pv, basestring):
-                print '    %s="%s",' % (pk, pv)
+            if isinstance(pv, str):
+                print('    %s="%s",' % (pk, pv))
             else:
-                print '    %s=%s,' % (pk, output_value(pv))
-        print "))"
-        print
+                print('    %s=%s,' % (pk, output_value(pv)))
+        print("))")
+        print()
 
 
 def do_trailer(d):
     """Output a trailer section for the new Python script."""
-    print 'print(t.to_json())'
+    print('print(t.to_json())')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`script/cfn2py` doesn't work on python 3, generally because of `print` function
