### PR TITLE
Typo in variable name

### DIFF
--- a/examples/CloudFront_S3.py
+++ b/examples/CloudFront_S3.py
@@ -19,7 +19,7 @@ t.add_description(
     "a stack from this template.")
 
 s3dnsname = t.add_parameter(Parameter(
-    "S3DNSNAme",
+    "S3DNSName",
     Description="The DNS name of an existing S3 bucket to use as the "
                 "Cloudfront distribution origin",
     Type="String",

--- a/tests/examples_output/CloudFront_S3.template
+++ b/tests/examples_output/CloudFront_S3.template
@@ -24,7 +24,7 @@
         }
     },
     "Parameters": {
-        "S3DNSNAme": {
+        "S3DNSName": {
             "Description": "The DNS name of an existing S3 bucket to use as the Cloudfront distribution origin",
             "Type": "String"
         }
@@ -44,7 +44,7 @@
                     "Origins": [
                         {
                             "DomainName": {
-                                "Ref": "S3DNSNAme"
+                                "Ref": "S3DNSName"
                             },
                             "Id": "Origin 1"
                         }


### PR DESCRIPTION
Minor typo in variable name.  "S3DNSNAme" -> "S3DNSName"