### PR TITLE
Add Compress to CloudFront

### DIFF
--- a/troposphere/cloudfront.py
+++ b/troposphere/cloudfront.py
@@ -26,6 +26,7 @@ class CacheBehavior(AWSProperty):
     props = {
         'AllowedMethods': ([basestring], False),
         'CachedMethods': ([basestring], False),
+        'Compress': (boolean, False),
         'TargetOriginId': (basestring, True),
         'ForwardedValues': (ForwardedValues, True),
         'TrustedSigners': ([basestring], False),
@@ -42,6 +43,7 @@ class DefaultCacheBehavior(AWSProperty):
     props = {
         'AllowedMethods': ([basestring], False),
         'CachedMethods': ([basestring], False),
+        'Compress': (boolean, False),
         'TargetOriginId': (basestring, True),
         'ForwardedValues': (ForwardedValues, True),
         'TrustedSigners': (list, False),


### PR DESCRIPTION
Turns on gzip compression for CloudFront resources.

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-defaultcachebehavior.html
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-cachebehavior.html