### PR TITLE
Added missing S3OriginConfig parameter

### DIFF
--- a/examples/CloudFront_S3.py
+++ b/examples/CloudFront_S3.py
@@ -6,6 +6,7 @@ from troposphere import Parameter, Ref, Template
 from troposphere.cloudfront import Distribution, DistributionConfig
 from troposphere.cloudfront import Origin, DefaultCacheBehavior
 from troposphere.cloudfront import ForwardedValues
+from troposphere.cloudfront import S3Origin
 
 
 t = Template()
@@ -28,7 +29,8 @@ s3dnsname = t.add_parameter(Parameter(
 myDistribution = t.add_resource(Distribution(
     "myDistribution",
     DistributionConfig=DistributionConfig(
-        Origins=[Origin(Id="Origin 1", DomainName=Ref(s3dnsname))],
+        Origins=[Origin(Id="Origin 1", DomainName=Ref(s3dnsname),
+                        S3OriginConfig=S3Origin())],
         DefaultCacheBehavior=DefaultCacheBehavior(
             TargetOriginId="Origin 1",
             ForwardedValues=ForwardedValues(

--- a/tests/examples_output/CloudFront_S3.template
+++ b/tests/examples_output/CloudFront_S3.template
@@ -46,7 +46,8 @@
                             "DomainName": {
                                 "Ref": "S3DNSName"
                             },
-                            "Id": "Origin 1"
+                            "Id": "Origin 1",
+                            "S3OriginConfig": {}
                         }
                     ]
                 }


### PR DESCRIPTION
According to [AWS CloudFormation docs](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-origin.html#cfn-cloudfront-origin-s3origin) the parameter S3OriginConfig is mandatory for a S3 backed origin.