### PR TITLE
Add VpcConfig to AWS::Lambda::Function

### DIFF
--- a/troposphere/awslambda.py
+++ b/troposphere/awslambda.py
@@ -31,6 +31,14 @@ class Code(AWSProperty):
             )
 
 
+class VPCConfig(AWSProperty):
+
+    props = {
+        'SecurityGroupIds': (list, True),
+        'SubnetIds': (list, True),
+    }
+
+
 class EventSourceMapping(AWSObject):
     resource_type = "AWS::Lambda::EventSourceMapping"
 
@@ -54,6 +62,7 @@ class Function(AWSObject):
         'Role': (basestring, True),
         'Runtime': (basestring, True),
         'Timeout': (positive_integer, False),
+        'VpcConfig': (VPCConfig, False),
     }
 
 


### PR DESCRIPTION
Enable Lambda functions to access resources in a Virtual Private Cloud (VPC).

* Announcement: http://aws.amazon.com/about-aws/whats-new/2016/03/aws-cloudformation-updates-amazon-s3-aws-lambda-and-amazon-emr-resources-support/
* Documentation: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-vpcconfig