### PR TITLE
Add Version Resource to awslambda

### DIFF
--- a/troposphere/awslambda.py
+++ b/troposphere/awslambda.py
@@ -67,3 +67,13 @@ class Permission(AWSObject):
         'SourceAccount': (basestring, False),
         'SourceArn': (basestring, False),
     }
+
+
+class Version(AWSObject):
+    resource_type = "AWS::Lambda::Version"
+
+    props = {
+        'CodeSha256': (basestring, False),
+        'Description': (basestring, False),
+        'FunctionName': (basestring, True),
+    }


### PR DESCRIPTION
Publish a version of a Lambda function.

Announcement: http://aws.amazon.com/about-aws/whats-new/2016/03/aws-cloudformation-updates-amazon-s3-aws-lambda-and-amazon-emr-resources-support/
Documentation: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-version.html