### PR TITLE
Add Alias Resource to awslambda

### DIFF
--- a/troposphere/awslambda.py
+++ b/troposphere/awslambda.py
@@ -67,3 +67,14 @@ class Permission(AWSObject):
         'SourceAccount': (basestring, False),
         'SourceArn': (basestring, False),
     }
+
+
+class Alias(AWSObject):
+    resource_type = "AWS::Lambda::Alias"
+
+    props = {
+        'Description': (basestring, False),
+        'FunctionName': (basestring, True),
+        'FunctionVersion': (basestring, True),
+        'Name': (basestring, True),
+    }


### PR DESCRIPTION
Create an alias that points to a Lambda function version that you specify.

Announcement: http://aws.amazon.com/about-aws/whats-new/2016/03/aws-cloudformation-updates-amazon-s3-aws-lambda-and-amazon-emr-resources-support/
Documentation: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-alias.html