### PR TITLE
Provide Valid Lambda Function Memory Values for use in Parameters

### DIFF
--- a/examples/Lambda.py
+++ b/examples/Lambda.py
@@ -1,6 +1,7 @@
+from troposphere.constants import NUMBER
 from troposphere import FindInMap, GetAtt, Join, Output
 from troposphere import Parameter, Ref, Template
-from troposphere.awslambda import Function, Code
+from troposphere.awslambda import Function, Code, MEMORY_VALUES
 from troposphere.cloudformation import CustomResource
 from troposphere.ec2 import Instance
 from troposphere.ec2 import SecurityGroup
@@ -30,6 +31,21 @@ InstanceType = t.add_parameter(Parameter(
 ExistingSecurityGroups = t.add_parameter(Parameter(
     "ExistingSecurityGroups",
     Type="List<AWS::EC2::SecurityGroup::Id>",
+))
+
+MemorySize = t.add_parameter(Parameter(
+    'LambdaMemorySize',
+    Type=NUMBER,
+    Description='Amount of memory to allocate to the Lambda Function',
+    Default='128',
+    AllowedValues=MEMORY_VALUES
+))
+
+Timeout = t.add_parameter(Parameter(
+    'LambdaTimeout',
+    Type=NUMBER,
+    Description='Timeout in seconds for the Lambda function',
+    Default='60'
 ))
 
 t.add_mapping("AWSInstanceType2Arch",
@@ -77,6 +93,8 @@ AppendItemToListFunction = t.add_resource(Function(
     Handler="index.handler",
     Role=GetAtt("LambdaExecutionRole", "Arn"),
     Runtime="nodejs",
+    MemorySize=Ref(MemorySize),
+    Timeout=Ref(Timeout)
 ))
 
 LambdaExecutionRole = t.add_resource(Role(

--- a/tests/examples_output/Lambda.template
+++ b/tests/examples_output/Lambda.template
@@ -83,6 +83,41 @@
             ],
             "Default": "t2.micro",
             "Type": "String"
+        },
+        "LambdaMemorySize": {
+            "AllowedValues": [
+                128,
+                192,
+                256,
+                320,
+                384,
+                448,
+                512,
+                576,
+                640,
+                704,
+                768,
+                832,
+                896,
+                960,
+                1024,
+                1088,
+                1152,
+                1216,
+                1280,
+                1344,
+                1408,
+                1472,
+                1536
+            ],
+            "Default": "128",
+            "Description": "Amount of memory to allocate to the Lambda Function",
+            "Type": "Number"
+        },
+        "LambdaTimeout": {
+            "Default": "60",
+            "Description": "Timeout in seconds for the Lambda function",
+            "Type": "Number"
         }
     },
     "Resources": {
@@ -121,13 +156,19 @@
                     }
                 },
                 "Handler": "index.handler",
+                "MemorySize": {
+                    "Ref": "LambdaMemorySize"
+                },
                 "Role": {
                     "Fn::GetAtt": [
                         "LambdaExecutionRole",
                         "Arn"
                     ]
                 },
-                "Runtime": "nodejs"
+                "Runtime": "nodejs",
+                "Timeout": {
+                    "Ref": "LambdaTimeout"
+                }
             },
             "Type": "AWS::Lambda::Function"
         },

--- a/troposphere/awslambda.py
+++ b/troposphere/awslambda.py
@@ -1,10 +1,7 @@
 from . import AWSObject, AWSProperty
 from .validators import positive_integer
 
-MEMORY_VALUES = [128, 192, 256, 320, 384, 448, 512,
-                 576, 640, 704, 768, 832, 896, 960, 1024,
-                 1088, 1152, 1216, 1280, 1344, 1408, 1472,
-                 1536]
+MEMORY_VALUES = [x for x in range(128, 1600, 64)]
 
 
 def validate_memory_size(memory_value):

--- a/troposphere/awslambda.py
+++ b/troposphere/awslambda.py
@@ -1,6 +1,23 @@
 from . import AWSObject, AWSProperty
 from .validators import positive_integer
 
+MEMORY_VALUES = [128, 192, 256, 320, 384, 448, 512,
+                 576, 640, 704, 768, 832, 896, 960, 1024,
+                 1088, 1152, 1216, 1280, 1344, 1408, 1472,
+                 1536]
+
+
+def validate_memory_size(memory_value):
+    """ Validate memory size for Lambda Function
+    :param memory_value: The memory size specified in the Function
+    :return: The provided memory size if it is valid
+    """
+    memory_value = int(positive_integer(memory_value))
+    if memory_value not in MEMORY_VALUES:
+        raise ValueError("Lambda Function memory size must be one of:\n %s" %
+                         ", ".join(str(mb) for mb in MEMORY_VALUES))
+    return memory_value
+
 
 class Code(AWSProperty):
     props = {
@@ -58,7 +75,7 @@ class Function(AWSObject):
         'Code': (Code, True),
         'Description': (basestring, False),
         'Handler': (basestring, True),
-        'MemorySize': (positive_integer, False),
+        'MemorySize': (validate_memory_size, False),
         'Role': (basestring, True),
         'Runtime': (basestring, True),
         'Timeout': (positive_integer, False),


### PR DESCRIPTION
This is a retry of PR435 after I thoroughly messed up the commit history there. This PR should be much cleaner.

Lambda functions can only have certain amounts of memory in multiples of 64
http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-memorysize

This commit allows MEMORY_VALUES to be used against Parameters' AllowedValues attribute, so that the Cloudformation web console form has a drop down selection of memory values in the same way it currently is in the Lambda web console.

I've updated the Lambda example to demonstrate.

I'm aware this could become unwieldy if AWS increase the amounts of memory available to Lambda functions, but if that occurs, this could be reverted or compared with any UI changes in the Lambda web console.

This also includes the updated validation as requested by phobologic