### PR TITLE
Create Documentation To Help Contributors

### DIFF
--- a/docs/CONTRIBUTE.md
+++ b/docs/CONTRIBUTE.md
@@ -16,9 +16,6 @@ The latest test scripts can be found at https://travis-ci.org/cloudtools/troposp
 If you look at the details of a job, you can see what automated tests
 will be run against any commits to the project.
 
-
-pip install --upgrade pip setuptools wheel
-
 1. Create a virtualenv (e.g. `virtualenv ~/virtualenv/troposphere`)
 1. Activate it: `source ~/virtualenv/troposphere/bin/activate`
 1. Install modules and upgrade tools:

--- a/docs/CONTRIBUTE.md
+++ b/docs/CONTRIBUTE.md
@@ -1,0 +1,20 @@
+# How to Contribute to Troposphere
+
+## tl;dr
+1. Fork https://github.com/cloudtools/troposphere
+1. Make the code better
+1. Make the code pass tests
+1. Create a Pull Request
+
+## How to Get Help
+
+See README.md at top of the project for developer mailing list.
+
+## How to Test Your Code
+
+1. Create a virtualenv (e.g. `virtualenv troposphere-env`)
+1. Install modules
+  1. `pip install pep8`
+  1. `pip install pyflakes`
+  1. `pip install awacs`
+1. Run `python -m unittest discover tests`

--- a/docs/CONTRIBUTE.md
+++ b/docs/CONTRIBUTE.md
@@ -12,9 +12,29 @@ See README.md at top of the project for developer mailing list.
 
 ## How to Test Your Code
 
-1. Create a virtualenv (e.g. `virtualenv troposphere-env`)
-1. Install modules
-  1. `pip install pep8`
-  1. `pip install pyflakes`
-  1. `pip install awacs`
-1. Run `python -m unittest discover tests`
+The latest test scripts can be found at https://travis-ci.org/cloudtools/troposphere.
+If you look at the details of a job, you can see what automated tests
+will be run against any commits to the project.
+
+
+pip install --upgrade pip setuptools wheel
+
+1. Create a virtualenv (e.g. `virtualenv ~/virtualenv/troposphere`)
+1. Activate it: `source ~/virtualenv/troposphere/bin/activate`
+1. Install modules and upgrade tools:
+  1. `pip install --upgrade pip setuptools wheel
+  1. `pip install --upgrade pep8 pyflakes`
+  1. ?? `pip install awacs`
+1. Run tests:
+  1. `pep8 .`
+  1. `pyflakes .`
+  1. `python setup.py test`
+
+Tests are run against Python 2.7, 3.3, 3.4, and 3.5.
+
+## Contributing Example Code
+
+New example code should go into `troposphere/examples`. The expected
+CloudFormation Template should be stored in `troposphere/tests/examples_output/`.
+When tests are run the output of the code in the examples directory will
+be comprared with the expected results in the example_ouput directory.


### PR DESCRIPTION
"Explicit is better than implicit."

I got all of the instructions in this documentation commit by following the bread crumbs for the cloudtools/troposphere GitHub repository. It was not hard, but it wasn't as easy as reading a markdown document. My hope is that this commit will make it easier for more people to contribute quality code to this project.

Since there was no `docs` directory, I made an aesthetic choice to put the `CONTRIBUTE.md` file into a sub-directory. I am open to moving it.