### PR TITLE
Fix Source object to take a list of SourceDetails

### DIFF
--- a/troposphere/config.py
+++ b/troposphere/config.py
@@ -26,7 +26,7 @@ class SourceDetails(AWSProperty):
 class Source(AWSProperty):
     props = {
         'Owner': (basestring, True),
-        'SourceDetails': (SourceDetails, False),
+        'SourceDetails': ([SourceDetails], False),
         'SourceIdentifier': (basestring, True),
     }
 


### PR DESCRIPTION
The documentation is unclear but the example (and my testing) shows that this is the correct syntax

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-configrule.html#cfn-config-configrule-source