### PR TITLE
Fix Bucket AccessControl to allow Ref

### DIFF
--- a/troposphere/s3.py
+++ b/troposphere/s3.py
@@ -232,7 +232,8 @@ class Bucket(AWSObject):
             raise TypeError("You must provide a bucket name")
         super(Bucket, self).__init__(name, **kwargs)
 
-        if 'AccessControl' in kwargs:
+        if 'AccessControl' in kwargs and \
+                isinstance(kwargs['AccessControl'], basestring):
             if kwargs['AccessControl'] not in self.access_control_types:
                 raise ValueError('AccessControl must be one of "%s"' % (
                     ', '.join(self.access_control_types)))


### PR DESCRIPTION
The current implementation will break when attempting to "Ref" the AccessControl to a stack parameter.