### PR TITLE
Convert fake AWSHelperFns into AWSProperties

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -3,7 +3,7 @@
 #
 # See LICENSE file for full license.
 
-from . import AWSHelperFn, AWSObject, AWSProperty
+from . import AWSObject, AWSProperty
 from .validators import (
     boolean, integer, integer_range, network_port, positive_integer
 )
@@ -15,12 +15,19 @@ except ImportError:
     policytypes = dict,
 
 
-class Tag(AWSHelperFn):
-    def __init__(self, key, value):
-        self.data = {'Key': key, 'Value': value}
+class Tag(AWSProperty):
+    props = {
+        'Key': (basestring, True),
+        'Value': (basestring, True)
+    }
 
-    def JSONrepr(self):
-        return self.data
+    def __init__(self, key=None, value=None, **kwargs):
+        # provided for backward compatibility
+        if key is not None:
+            kwargs['Key'] = key
+        if value is not None:
+            kwargs['Value'] = value
+        super(Tag, self).__init__(**kwargs)
 
 
 class CustomerGateway(AWSObject):

--- a/troposphere/emr.py
+++ b/troposphere/emr.py
@@ -3,16 +3,23 @@
 #
 # See LICENSE file for full license.
 
-from . import AWSObject, AWSProperty, AWSHelperFn
+from . import AWSObject, AWSProperty
 from .validators import (boolean, integer, positive_integer)
 
 
-class KeyValue(AWSHelperFn):
-    def __init__(self, key, value):
-        self.data = {'Key': key, 'Value': value}
+class KeyValue(AWSProperty):
+    props = {
+        'Key': (basestring, True),
+        'Value': (basestring, True)
+    }
 
-    def JSONrepr(self):
-        return self.data
+    def __init__(self, key=None, value=None, **kwargs):
+        # provided for backward compatibility
+        if key is not None:
+            kwargs['Key'] = key
+        if value is not None:
+            kwargs['Value'] = value
+        super(KeyValue, self).__init__(**kwargs)
 
 
 def additional_info_validator(xs):

--- a/troposphere/route53.py
+++ b/troposphere/route53.py
@@ -3,22 +3,30 @@
 #
 # See LICENSE file for full license.
 
-from . import AWSHelperFn, AWSObject, AWSProperty, Tags
-from .validators import integer, positive_integer, network_port
+from . import AWSObject, AWSProperty, Tags
+from .validators import integer, positive_integer, network_port, boolean
 
 
-class AliasTarget(AWSHelperFn):
-    def __init__(self, hostedzoneid, dnsname, evaluatetargethealth=None):
-        self.data = {
-            'HostedZoneId': hostedzoneid,
-            'DNSName': dnsname,
-        }
+class AliasTarget(AWSProperty):
+    props = {
+        'HostedZoneId': (basestring, True),
+        'DNSName': (basestring, True),
+        'EvaluateTargetHealth': (boolean, False)
+    }
 
+    def __init__(self,
+                 hostedzoneid=None,
+                 dnsname=None,
+                 evaluatetargethealth=None,
+                 **kwargs):
+        # provided for backward compatibility
+        if hostedzoneid is not None:
+            kwargs['HostedZoneId'] = hostedzoneid
+        if dnsname is not None:
+            kwargs['DNSName'] = dnsname
         if evaluatetargethealth is not None:
-            self.data['EvaluateTargetHealth'] = evaluatetargethealth
-
-    def JSONrepr(self):
-        return self.data
+            kwargs['EvaluateTargetHealth'] = evaluatetargethealth
+        super(AliasTarget, self).__init__(**kwargs)
 
 
 class GeoLocation(AWSProperty):


### PR DESCRIPTION
This updates 3 objects that were incorrectly subclassing AWSHelperFn. They are now subclassing AWSProperty as intended. This should be backward compatible.