### PR TITLE
Leverage S3 bucket name validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - pip install --upgrade pip setuptools wheel
 
 install:
-  - pip install --upgrade pep8 pyflakes
+  - pip install --upgrade pep8 pyflakes==1.1.0
 
 before_script:
   - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then 2to3 -n -w --no-diffs troposphere examples/CustomResource.py; fi

--- a/examples/S3_Bucket.py
+++ b/examples/S3_Bucket.py
@@ -14,7 +14,7 @@ t.add_description(
     "You will be billed for the AWS resources used if you create "
     "a stack from this template.")
 
-s3bucket = t.add_resource(Bucket("S3Bucket", AccessControl=PublicRead,))
+s3bucket = t.add_resource(Bucket("s3bucket", AccessControl=PublicRead,))
 
 t.add_output(Output(
     "BucketName",

--- a/examples/S3_Bucket_With_Versioning.py
+++ b/examples/S3_Bucket_With_Versioning.py
@@ -15,7 +15,7 @@ t.add_description(
     "a stack from this template.")
 
 s3bucket = t.add_resource(Bucket(
-    "S3Bucket",
+    "s3bucket",
     AccessControl=PublicRead,
     VersioningConfiguration=VersioningConfiguration(
         Status="Enabled",

--- a/examples/S3_Website_Bucket_With_Retain_On_Delete.py
+++ b/examples/S3_Website_Bucket_With_Retain_On_Delete.py
@@ -17,7 +17,7 @@ t.add_description(
     "a stack from this template.")
 
 s3bucket = t.add_resource(Bucket(
-    "S3Bucket",
+    "s3bucket",
     AccessControl=PublicRead,
     WebsiteConfiguration=WebsiteConfiguration(
         IndexDocument="index.html",

--- a/tests/examples_output/S3_Bucket.template
+++ b/tests/examples_output/S3_Bucket.template
@@ -4,12 +4,12 @@
         "BucketName": {
             "Description": "Name of S3 bucket to hold website content",
             "Value": {
-                "Ref": "S3Bucket"
+                "Ref": "s3bucket"
             }
         }
     },
     "Resources": {
-        "S3Bucket": {
+        "s3bucket": {
             "Properties": {
                 "AccessControl": "PublicRead"
             },

--- a/tests/examples_output/S3_Bucket_With_Versioning.template
+++ b/tests/examples_output/S3_Bucket_With_Versioning.template
@@ -4,12 +4,12 @@
         "BucketName": {
             "Description": "Name of S3 bucket to hold website content",
             "Value": {
-                "Ref": "S3Bucket"
+                "Ref": "s3bucket"
             }
         }
     },
     "Resources": {
-        "S3Bucket": {
+        "s3bucket": {
             "Properties": {
                 "AccessControl": "PublicRead",
                 "VersioningConfiguration": {

--- a/tests/examples_output/S3_Website_Bucket_With_Retain_On_Delete.template
+++ b/tests/examples_output/S3_Website_Bucket_With_Retain_On_Delete.template
@@ -10,7 +10,7 @@
                         "http://",
                         {
                             "Fn::GetAtt": [
-                                "S3Bucket",
+                                "s3bucket",
                                 "DomainName"
                             ]
                         }
@@ -22,14 +22,14 @@
             "Description": "URL for website hosted on S3",
             "Value": {
                 "Fn::GetAtt": [
-                    "S3Bucket",
+                    "s3bucket",
                     "WebsiteURL"
                 ]
             }
         }
     },
     "Resources": {
-        "S3Bucket": {
+        "s3bucket": {
             "Properties": {
                 "AccessControl": "PublicRead",
                 "WebsiteConfiguration": {

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -63,7 +63,10 @@ class TestValidators(unittest.TestCase):
     def test_s3_bucket_name(self):
         for b in ['a'*3, 'a'*63, 'wick3d-sweet.bucket']:
             s3_bucket_name(b)
-        for b in ['a'*2, 'a'*64, 'invalid_bucket']:
+        for b in ['a'*2, 'a'*64, 'invalid_bucket', 'InvalidBucket']:
+            with self.assertRaises(ValueError):
+                s3_bucket_name(b)
+        for b in ['.invalid', 'invalid.', 'invalid..bucket']:
             with self.assertRaises(ValueError):
                 s3_bucket_name(b)
 

--- a/troposphere/s3.py
+++ b/troposphere/s3.py
@@ -253,6 +253,9 @@ class Bucket(AWSObject):
                 raise ValueError('AccessControl must be one of "%s"' % (
                     ', '.join(self.access_control_types)))
 
+    def validate_title(self):
+        s3_bucket_name(self.title)
+
 
 class BucketPolicy(AWSObject):
     resource_type = "AWS::S3::BucketPolicy"

--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -54,6 +54,9 @@ def network_port(x):
 
 
 def s3_bucket_name(b):
+    if '..' in b:
+        raise ValueError("%s is not a valid s3 bucket name" % b)
+
     s3_bucket_name_re = compile(r'^[a-z\d][a-z\d\.-]{1,61}[a-z\d]$')
     if s3_bucket_name_re.match(b):
         return b


### PR DESCRIPTION
The `Bucket` class extends from a base class `BaseAWSObject` that validates (during object initialization) the resource title using a regular expression that is too strict for S3 buckets. For example, the name "my-bucket" is perfectly valid, however Troposphere reports an error.

```
Name "my-bucket" not alphanumeric: ValueError
Traceback (most recent call last):
...
  File "/var/task/troposphere/s3.py", line 222, in __init__
    super(Bucket, self).__init__(name, **kwargs)
  File "/var/task/troposphere/__init__.py", line 44, in __init__
    self.validate_title()
  File "/var/task/troposphere/__init__.py", line 159, in validate_title
    raise ValueError('Name "%s" not alphanumeric' % self.title)
ValueError: Name "my-bucket" not alphanumeric
```

Adding a `validate_title()` method to the `Bucket` class overrides this with correct behavior that leverages the existing `s3_bucket_name()` validator.

This correction caused a number of test cases to break, as they were improperly using a bucket name with capital letters. These test cases have been fixed. I also added more test cases to catch situations where the bucket name starts or ends with a period, or contains consecutive periods.
http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html

Finally, it seems pyflakes 1.2.0 does not work, so I pinned the version to 1.1.0 to help Travis CI pass... not sure if there was a more appropriate solution to that problem.