### PR TITLE
Update not create

### DIFF
--- a/scripts/cfn
+++ b/scripts/cfn
@@ -23,7 +23,8 @@ def upload_template_to_s3(conn, region, bucket_name, key_name, template):
         elif region == 'eu-west-1':
             region = boto.s3.connection.Location.EU
 
-        cloudformation_bucket = conn.create_bucket(bucket_name, location=region)
+        cloudformation_bucket = conn.create_bucket(bucket_name,
+                                                   location=region)
     key = cloudformation_bucket.new_key(key_name)
     key.set_contents_from_string(template)
     cfn_template_url = "https://s3.amazonaws.com/%s/%s" % (
@@ -133,7 +134,8 @@ if __name__ == "__main__":
             # Upload to S3 and create the stack
             s3conn = boto.s3.connect_to_region(values.region)
             url = upload_template_to_s3(
-                s3conn, values.region, values.s3bucket, values.s3name, template)
+                s3conn, values.region, values.s3bucket,
+                values.s3name, template)
             kwargs['url'] = url
             del kwargs['template']
 

--- a/scripts/cfn
+++ b/scripts/cfn
@@ -45,10 +45,10 @@ def create_stack(
         parameters=params,
         capabilities=capabilities,
     )
-    
+
     try:
         stack_id = conn.create_stack(stackname, **kwargs)
-    
+
     except boto.exception.BotoServerError as e:
         # XXX - need to figure out why this isn't getting parsed from boto.
         print("Error: %s" %

--- a/scripts/cfn
+++ b/scripts/cfn
@@ -39,6 +39,7 @@ def create_stack(
     url=None,
     params=None,
     capabilities=None,
+    update=False,
 ):
     kwargs = dict(
         template_body=template,
@@ -48,15 +49,19 @@ def create_stack(
     )
 
     try:
-        stack_id = conn.create_stack(stackname, **kwargs)
-
+        if update:
+            stack_id = conn.update_stack(stackname, **kwargs)
+            action = 'Updated'
+        else:
+            stack_id = conn.create_stack(stackname, **kwargs)
+            action = 'Created'
+        print("%s stack %s: %s" % (action, stackname, stack_id))
     except boto.exception.BotoServerError as e:
         # XXX - need to figure out why this isn't getting parsed from boto.
         print("Error: %s" %
               (literal_eval(e.error_message)['Error']['Message'],))
         print("Exiting...")
         sys.exit(1)
-    print("Created stack %s: %s" % (stackname, stack_id))
 
 
 def build_s3_name(stack_name):
@@ -80,6 +85,8 @@ def describe_resources(conn, stackname):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-c", "--create", help="Create stack using template")
+    parser.add_argument("-u", "--update", action='store_true',
+                        help="Update stack instead of creating")
     parser.add_argument("-b", "--bucket", dest="s3bucket",
                         help="Upload template to S3 bucket")
     parser.add_argument("-d", "--debug", action='store_true',
@@ -128,6 +135,7 @@ if __name__ == "__main__":
             template=template,
             params=values.params,
             capabilities=values.capabilities,
+            update=values.update,
         )
 
         if values.s3bucket:

--- a/scripts/cfn
+++ b/scripts/cfn
@@ -68,8 +68,8 @@ def create_stack(
         parameters=params,
         capabilities=capabilities,
     )
-
     validate_template(conn, template=template, url=url)
+
     try:
         if update:
             stack_id = conn.update_stack(stackname, **kwargs)


### PR DESCRIPTION
Working with @markfalk discovered its easier to use this script if it has an update option.  This change includes these updates while maintaining backwards compatibility:

- Can now use `-u` or `--update` to trigger a cfn update action instead of a create action
- Fixes pep8 trailing whitespace
- Fixes pep8 line length to be < 80 chars