### PR TITLE
Validate the template against aws before stack creation

### DIFF
--- a/scripts/cfn
+++ b/scripts/cfn
@@ -31,6 +31,23 @@ def upload_template_to_s3(conn, region, bucket_name, key_name, template):
     return cfn_template_url
 
 
+def validate_template(conn, template=None, url=None):
+    """Validate the template"""
+    print("Validating Template")
+    try:
+        if url:
+            conn.validate_template(template_url=url)
+        else:
+            conn.validate_template(template_body=template)
+    except boto.exception.BotoServerError as e:
+        # XXX - need to figure out why this isn't getting parsed from boto.
+        print("Error: %s" %
+              (literal_eval(e.error_message)['Error']['Message'],))
+        print("Exiting...")
+        sys.exit(1)
+    print("Template Validated")
+
+
 def create_stack(
     conn,
     stackname,
@@ -45,10 +62,11 @@ def create_stack(
         parameters=params,
         capabilities=capabilities,
     )
-    
+    validate_template(conn, template=template, url=url)
+
     try:
         stack_id = conn.create_stack(stackname, **kwargs)
-    
+
     except boto.exception.BotoServerError as e:
         # XXX - need to figure out why this isn't getting parsed from boto.
         print("Error: %s" %

--- a/scripts/cfn
+++ b/scripts/cfn
@@ -38,8 +38,12 @@ def validate_template(conn, template=None, url=None):
     try:
         if url:
             conn.validate_template(template_url=url)
-        else:
+        elif template:
             conn.validate_template(template_body=template)
+        else:
+            print("Error: Must provide a template or template url")
+            print("Exiting...")
+            sys.exit(1)
     except boto.exception.BotoServerError as e:
         # XXX - need to figure out why this isn't getting parsed from boto.
         print("Error: %s" %

--- a/scripts/cfn
+++ b/scripts/cfn
@@ -23,7 +23,8 @@ def upload_template_to_s3(conn, region, bucket_name, key_name, template):
         elif region == 'eu-west-1':
             region = boto.s3.connection.Location.EU
 
-        cloudformation_bucket = conn.create_bucket(bucket_name, location=region)
+        cloudformation_bucket = conn.create_bucket(bucket_name,
+                                                   location=region)
     key = cloudformation_bucket.new_key(key_name)
     key.set_contents_from_string(template)
     cfn_template_url = "https://s3.amazonaws.com/%s/%s" % (
@@ -151,7 +152,8 @@ if __name__ == "__main__":
             # Upload to S3 and create the stack
             s3conn = boto.s3.connect_to_region(values.region)
             url = upload_template_to_s3(
-                s3conn, values.region, values.s3bucket, values.s3name, template)
+                s3conn, values.region, values.s3bucket,
+                values.s3name, template)
             kwargs['url'] = url
             del kwargs['template']
 


### PR DESCRIPTION
Working with @markfalk discovered its helpful to have AWS validate the template before stack creation. This change includes these updates while maintaining backwards compatibility:

- Can now use -u or --update to trigger a cfn update action instead of a create action
- Fixes pep8 trailing whitespace
- Fixes pep8 line length to be < 80 chars