### PR TITLE
Tune validation logic and test cases for S3 bucket names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - pip install --upgrade pip setuptools wheel
 
 install:
-  - pip install --upgrade pep8 pyflakes
+  - pip install --upgrade pep8 pyflakes==1.1.0
 
 before_script:
   - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then 2to3 -n -w --no-diffs troposphere examples/CustomResource.py; fi

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -63,7 +63,10 @@ class TestValidators(unittest.TestCase):
     def test_s3_bucket_name(self):
         for b in ['a'*3, 'a'*63, 'wick3d-sweet.bucket']:
             s3_bucket_name(b)
-        for b in ['a'*2, 'a'*64, 'invalid_bucket']:
+        for b in ['a'*2, 'a'*64, 'invalid_bucket', 'InvalidBucket']:
+            with self.assertRaises(ValueError):
+                s3_bucket_name(b)
+        for b in ['.invalid', 'invalid.', 'invalid..bucket']:
             with self.assertRaises(ValueError):
                 s3_bucket_name(b)
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -69,6 +69,9 @@ class TestValidators(unittest.TestCase):
         for b in ['.invalid', 'invalid.', 'invalid..bucket']:
             with self.assertRaises(ValueError):
                 s3_bucket_name(b)
+        for b in ['1.2.3.4', '11.22.33.44', '111.222.333.444']:
+            with self.assertRaises(ValueError):
+                s3_bucket_name(b)
 
     def test_encoding(self):
         for e in ['plain', 'base64']:

--- a/troposphere/s3.py
+++ b/troposphere/s3.py
@@ -241,10 +241,13 @@ class Bucket(AWSObject):
     ]
 
     def __init__(self, name=None, **kwargs):
+
+        # note: 'name' is the resource title, not the bucket name
+
         if not name and 'title' in kwargs:
             name = kwargs.pop('title')
         if not name:
-            raise TypeError("You must provide a bucket name")
+            raise TypeError("You must provide a title for the bucket resource")
         super(Bucket, self).__init__(name, **kwargs)
 
         if 'AccessControl' in kwargs and \

--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -54,7 +54,16 @@ def network_port(x):
 
 
 def s3_bucket_name(b):
+
+    # consecutive periods not allowed
+
     if '..' in b:
+        raise ValueError("%s is not a valid s3 bucket name" % b)
+
+    # IP addresses not allowed
+
+    ip_re = compile(r'^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$')
+    if ip_re.match(b):
         raise ValueError("%s is not a valid s3 bucket name" % b)
 
     s3_bucket_name_re = compile(r'^[a-z\d][a-z\d\.-]{1,61}[a-z\d]$')

--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -54,6 +54,9 @@ def network_port(x):
 
 
 def s3_bucket_name(b):
+    if '..' in b:
+        raise ValueError("%s is not a valid s3 bucket name" % b)
+
     s3_bucket_name_re = compile(r'^[a-z\d][a-z\d\.-]{1,61}[a-z\d]$')
     if s3_bucket_name_re.match(b):
         return b


### PR DESCRIPTION
Outline of changes:
- added validation to disallow consecutive periods in bucket name
- added validation to disallow bucket names that look like an IP address
- updated `Bucket` initialization to clarify resource title vs. bucket name, to help avoid more confusion about that in the future
- updated test cases to catch bucket names with capital letters, starting/ending with a period, containing consecutive periods, use of IP addresses

Also, it seems pyflakes 1.2.0 does not work, so I pinned the version to 1.1.0 to help Travis CI pass... not sure if there was a more appropriate solution to that problem.