### PR TITLE
Allow setting a different region for S3 upload

### DIFF
--- a/scripts/cfn
+++ b/scripts/cfn
@@ -112,7 +112,7 @@ if __name__ == "__main__":
                         help="stack parameters in key=value form")
     parser.add_argument("-r", "--region", default="us-east-1",
                         help="Region (default %(default)s)")
-    parser.add_argument("-s", "--s3-region", default="us-east-1",
+    parser.add_argument("-s", "--s3-region", default=None,
                         dest="s3region",
                         help="S3 Region (default %(default)s)")
     parser.add_argument("-R", "--resources", action='store_true',
@@ -138,6 +138,9 @@ if __name__ == "__main__":
     if values.debug:
         import logging
         logging.basicConfig(filename="boto.log", level=logging.DEBUG)
+
+    if not values.s3region:
+        values.s3region = values.region
 
     conn = boto.cloudformation.connect_to_region(values.region)
 

--- a/scripts/cfn
+++ b/scripts/cfn
@@ -134,11 +134,7 @@ if __name__ == "__main__":
 
         if values.s3bucket:
             # Upload to S3 and create the stack
-            s3conn = None
-            if values.s3region != values.region:
-                s3conn = boto.s3.connect_to_region(values.s3region)
-            else:
-                s3conn = boto.s3.connect_to_region(values.region)
+            s3conn = boto.s3.connect_to_region(values.s3region)
             url = upload_template_to_s3(
                 s3conn, values.region, values.s3bucket, values.s3name, template)
             kwargs['url'] = url

--- a/scripts/cfn
+++ b/scripts/cfn
@@ -114,7 +114,7 @@ if __name__ == "__main__":
                         help="Region (default %(default)s)")
     parser.add_argument("-s", "--s3-region", default=None,
                         dest="s3region",
-                        help="S3 Region (default %(default)s)")
+                        help="S3 Region (default us-east-1)")
     parser.add_argument("-R", "--resources", action='store_true',
                         help="describe stack resources, list resources for "
                              "all stacks if no stack is specified")

--- a/scripts/cfn
+++ b/scripts/cfn
@@ -89,6 +89,9 @@ if __name__ == "__main__":
                         help="stack parameters in key=value form")
     parser.add_argument("-r", "--region", default="us-east-1",
                         help="Region (default %(default)s)")
+    parser.add_argument("-s", "--s3-region", default="us-east-1",
+                        dest="s3region",
+                        help="S3 Region (default %(default)s)")
     parser.add_argument("-R", "--resources", action='store_true',
                         help="describe stack resources, list resources for "
                              "all stacks if no stack is specified")
@@ -131,7 +134,11 @@ if __name__ == "__main__":
 
         if values.s3bucket:
             # Upload to S3 and create the stack
-            s3conn = boto.s3.connect_to_region(values.region)
+            s3conn = None
+            if values.s3region != values.region:
+                s3conn = boto.s3.connect_to_region(values.s3region)
+            else:
+                s3conn = boto.s3.connect_to_region(values.region)
             url = upload_template_to_s3(
                 s3conn, values.region, values.s3bucket, values.s3name, template)
             kwargs['url'] = url


### PR DESCRIPTION
It would be nice if uploading to S3 could be set to a different region than the stack that is being created. This adds a single option to so so with either `-s` or `--s3-region` and maintains backwards compatibility.