### PR TITLE
EMR: fix EBS configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -129,6 +129,7 @@ Currently supported AWS resource types
 - AWS::ElasticBeanstalk
 - AWS::ElasticLoadBalancing
 - AWS::Elasticsearch
+- AWS::EMR
 - AWS::IAM
 - AWS::KINESIS
 - AWS::KMS

--- a/tests/examples_output/EMR_Cluster.template
+++ b/tests/examples_output/EMR_Cluster.template
@@ -83,7 +83,7 @@
                                 "echo",
                                 "Hello World"
                             ],
-                            "Path": "/bin/sh"
+                            "Path": "file:/bin/sh"
                         }
                     }
                 ],
@@ -115,21 +115,21 @@
                         ]
                     }
                 ],
-                "EbsConfiguration": {
-                    "EbsBlockDeviceConfig": [
-                        {
-                            "VolumeSpecification": {
-                                "SizeInGB": "100",
-                                "VolumeType": "standard"
-                            },
-                            "VolumesPerInstance": "1"
-                        }
-                    ],
-                    "EbsOptimized": "true"
-                },
                 "Instances": {
                     "CoreInstanceGroup": {
                         "BidPrice": "20",
+                        "EbsConfiguration": {
+                            "EbsBlockDeviceConfigs": [
+                                {
+                                    "VolumeSpecification": {
+                                        "SizeInGB": "100",
+                                        "VolumeType": "gp2"
+                                    },
+                                    "VolumesPerInstance": "1"
+                                }
+                            ],
+                            "EbsOptimized": "true"
+                        },
                         "InstanceCount": "1",
                         "InstanceType": "m3.xlarge",
                         "Market": "SPOT",

--- a/tests/examples_output/EMR_Cluster.template
+++ b/tests/examples_output/EMR_Cluster.template
@@ -5,18 +5,6 @@
             "Description": "Name of an existing EC2 KeyPair to enable SSH to the instances",
             "Type": "AWS::EC2::KeyPair::KeyName"
         },
-        "ManagedMasterSecurityGroup": {
-            "Description": "Security Group (managed by EMR) for master instances",
-            "Type": "AWS::EC2::SecurityGroup::Id"
-        },
-        "ManagedSlaveSecurityGroup": {
-            "Description": "Security Group (managed by EMR) for slave instances",
-            "Type": "AWS::EC2::SecurityGroup::Id"
-        },
-        "ServiceAccessSecurityGroup": {
-            "Description": "Security Group providing service access to EMR",
-            "Type": "AWS::EC2::SecurityGroup::Id"
-        },
         "Subnet": {
             "Description": "Subnet ID for creating the EMR cluster",
             "Type": "AWS::EC2::Subnet::Id"
@@ -80,10 +68,10 @@
                         "Name": "Dummy bootstrap action",
                         "ScriptBootstrapAction": {
                             "Args": [
-                                "echo",
-                                "Hello World"
+                                "dummy",
+                                "parameter"
                             ],
-                            "Path": "file:/bin/sh"
+                            "Path": "file:/usr/share/aws/emr/scripts/install-hue"
                         }
                     }
                 ],
@@ -117,12 +105,12 @@
                 ],
                 "Instances": {
                     "CoreInstanceGroup": {
-                        "BidPrice": "20",
+                        "BidPrice": "0.1",
                         "EbsConfiguration": {
                             "EbsBlockDeviceConfigs": [
                                 {
                                     "VolumeSpecification": {
-                                        "SizeInGB": "100",
+                                        "SizeInGB": "10",
                                         "VolumeType": "gp2"
                                     },
                                     "VolumesPerInstance": "1"
@@ -131,13 +119,19 @@
                             "EbsOptimized": "true"
                         },
                         "InstanceCount": "1",
-                        "InstanceType": "m3.xlarge",
+                        "InstanceType": "m4.large",
                         "Market": "SPOT",
                         "Name": "Core Instance"
                     },
+                    "Ec2KeyName": {
+                        "Ref": "KeyName"
+                    },
+                    "Ec2SubnetId": {
+                        "Ref": "Subnet"
+                    },
                     "MasterInstanceGroup": {
                         "InstanceCount": "1",
-                        "InstanceType": "m3.xlarge",
+                        "InstanceType": "m4.large",
                         "Market": "ON_DEMAND",
                         "Name": "Master Instance"
                     }

--- a/troposphere/emr.py
+++ b/troposphere/emr.py
@@ -82,10 +82,41 @@ def market_validator(x):
     return x
 
 
+def volume_type_validator(x):
+    valid_values = ['standard', 'io1', 'gp2']
+    if x not in valid_values:
+        raise ValueError("VolumeType must be one of: %s" %
+                         ', '.join(valid_values))
+    return x
+
+
+class VolumeSpecification(AWSProperty):
+    props = {
+        'Iops': (integer, False),
+        'SizeInGB': (integer, True),
+        'VolumeType': (volume_type_validator, True)
+    }
+
+
+class EbsBlockDeviceConfigs(AWSProperty):
+    props = {
+        'VolumeSpecification': (VolumeSpecification, True),
+        'VolumesPerInstance': (integer, False)
+    }
+
+
+class EbsConfiguration(AWSProperty):
+    props = {
+        'EbsBlockDeviceConfigs': ([EbsBlockDeviceConfigs], False),
+        'EbsOptimized': (boolean, False)
+    }
+
+
 class InstanceGroupConfigProperty(AWSProperty):
     props = {
         'BidPrice': (basestring, False),
         'Configurations': ([Configuration], False),
+        'EbsConfiguration': (EbsConfiguration, False),
         'InstanceCount': (positive_integer, True),
         'InstanceType': (basestring, True),
         'Market': (market_validator, False),
@@ -116,36 +147,6 @@ class JobFlowInstancesConfig(AWSProperty):
     }
 
 
-def volume_type_validator(x):
-    valid_values = ['standard', 'io1']
-    if x not in valid_values:
-        raise ValueError("VolumeType must be one of: %s" %
-                         ', '.join(valid_values))
-    return x
-
-
-class VolumeSpecification(AWSProperty):
-    props = {
-        'Iops': (integer, False),
-        'SizeInGB': (integer, True),
-        'VolumeType': (volume_type_validator, True)
-    }
-
-
-class EbsBlockDeviceConfig(AWSProperty):
-    props = {
-        'VolumeSpecification': (VolumeSpecification, True),
-        'VolumesPerInstance': (integer, False)
-    }
-
-
-class EbsConfiguration(AWSProperty):
-    props = {
-        'EbsBlockDeviceConfig': ([EbsBlockDeviceConfig], False),
-        'EbsOptimized': (boolean, False)
-    }
-
-
 class Cluster(AWSObject):
     resource_type = "AWS::EMR::Cluster"
 
@@ -154,7 +155,6 @@ class Cluster(AWSObject):
         'Applications': ([Application], False),
         'BootstrapActions': ([BootstrapActionConfig], False),
         'Configurations': ([Configuration], False),
-        'EbsConfiguration': (EbsConfiguration, False),
         'Instances': (JobFlowInstancesConfig, True),
         'JobFlowRole': (basestring, True),
         'LogUri': (basestring, False),


### PR DESCRIPTION
When I tried to create an EMR cluster with EBS volumes, my CloudFormation template yesterday failed.  After creating an AWS support ticket, it appeared the AWS documentation was wrong (EbsConfiguration cannot be specified on Cluster level, but needs to be specified in InstanceGroupConfigProperty).  The documentation has meanwhile been fixed and can be found on http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-emr-cluster-jobflowinstancesconfig-instancegroupconfig.html

The code below reflects this update.