### PR TITLE
Action on Failure Fix

### DIFF
--- a/troposphere/emr.py
+++ b/troposphere/emr.py
@@ -191,7 +191,7 @@ class HadoopJarStepConfig(AWSProperty):
 
 
 def action_on_failure_validator(x):
-    valid_values = ['CONTINUE', 'CONTINUE_AND_WAIT']
+    valid_values = ['CONTINUE', 'CANCEL_AND_WAIT']
     if x not in valid_values:
         raise ValueError("ActionOnFailure must be one of: %s" %
                          ', '.join(valid_values))


### PR DESCRIPTION
The documentation lies, here's the error message I just got from CloudFormation:
"CloudFormation currently only supports long-running clusters, set ActionOnFailure to CANCEL_AND_WAIT or CONTINUE"