### PR TITLE
Re-written userdata from_file helper

### DIFF
--- a/tests/test_userdata.py
+++ b/tests/test_userdata.py
@@ -16,13 +16,13 @@ class TestUserdata(unittest.TestCase):
         dir = os.path.dirname(__file__)
         self.filepath = os.path.join(dir, 'userdata_test_scripts/')
 
-    def create_result(self, file):
+    def create_result(self, file, delimiter=""):
         file = os.path.join(self.filepath, file)
-        self.instance.UserData = userdata.from_file(file)
+        self.instance.UserData = userdata.from_file(file, delimiter)
         return json.dumps(self.instance.UserData, cls=awsencode)
 
-    def create_answer(self, command_list):
-        return json.dumps(Base64(Join(',', command_list)),
+    def create_answer(self, command_list, delimiter=""):
+        return json.dumps(Base64(Join(delimiter, command_list)),
                           cls=awsencode)
 
     def test_simple(self):

--- a/troposphere/helpers/userdata.py
+++ b/troposphere/helpers/userdata.py
@@ -3,29 +3,36 @@
 from troposphere import Base64, Join
 
 
-def from_file(filepath, whitespace=False):
-    """Imports userdata from a file.
+def from_file(filepath, delimiter='', blanklines=False):
+    """
+    Imports userdata from a file.
 
-    This function ignore blank lines within the file.
-    Special characters are automatically escaped.
+    :type filepath: string
+    :param filepath
+    The absolute path to the file.
 
-    Args:
-        filepath (string): The absolute path to the file
-        containing the userdata to be imported.
+    :type delimiter: string
+    :param: delimiter
+    Delimiter to use with the troposphere.Join().
 
-    Returns:
-        Base64 object: The Base64 object being passed a Join object
-        with strings.
-        If file not found, an empty string list is used.
+    :type blanklines: boolean
+    :param blanklines
+    If blank lines shoud be ignored
 
+    rtype: troposphere.Base64
+    :return The base64 representation of the file.
     """
 
     data = []
+
     try:
         with open(filepath, 'r') as f:
             for line in f:
+                if blanklines and line.strip('\n\r ') == '':
+                    continue
+
                 data.append(line)
     except IOError:
-        raise IOError('Error opening or reading file: ' + filepath)
+        raise IOError('Error opening or reading file: {}'.format(filepath))
 
-    return Base64(Join(',', data))
+    return Base64(Join(delimiter, data))


### PR DESCRIPTION
Rewritten the helper to be more flexible, what kind of delimiter you want to have. The default is now "", which reflects the most used use-case. It's also addresses the issue #465.