### PR TITLE
Update __init__.py

### DIFF
--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -26,7 +26,7 @@ AWS_REGION = 'AWS::Region'
 AWS_STACK_ID = 'AWS::StackId'
 AWS_STACK_NAME = 'AWS::StackName'
 
-valid_names = re.compile(r'^[a-zA-Z0-9]+$')
+valid_names = re.compile(r'^[a-zA-Z0-9\.\-\_]+$')
 
 
 class BaseAWSObject(object):


### PR DESCRIPTION
I noticed that troposphere does not allow non alphanumeric names for dynamodb table. I was trying to create a table with "test-app" and was getting the following error.

File "/usr/local/lib/python2.7/site-packages/troposphere/__init__.py", line 44, in __init__
    self.validate_title()
  File "/usr/local/lib/python2.7/site-packages/troposphere/__init__.py", line 159, in validate_title
    raise ValueError('Name "%s" not alphanumeric' % self.title)
ValueError: Name "test-app" not alphanumeric

However as per Amazon it is allowed to have dot, dash and underscrores in the table name. I think it should be fixed. Here is the link to what amazon says.  
http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html#limits-naming-rules