### PR TITLE
Add undocumented ACM Certificate properties for ViewerCertificate

### DIFF
--- a/troposphere/cloudfront.py
+++ b/troposphere/cloudfront.py
@@ -113,8 +113,11 @@ class ViewerCertificate(AWSProperty):
     props = {
         'CloudFrontDefaultCertificate': (boolean, False),
         'IamCertificateId': (basestring, False),
+        'ACMCertificateArn': (basestring, False),
         'MinimumProtocolVersion': (basestring, False),
         'SslSupportMethod': (basestring, False),
+        'Certificate': (basestring, False),
+        'CertificateSource': (basestring, False),
     }
 
 


### PR DESCRIPTION
I'm doing some testing, but this appears to be an undocumented feature of the ViewerCertificate.  I have these resources to back me up from the Ruby and Java SDKs:

- [Ruby SDK](http://docs.aws.amazon.com/sdkforruby/api/Aws/CloudFront/Types/ViewerCertificate.html)
- [Java SDK](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/cloudfront/model/ViewerCertificate.html)

For reference, here are the docs I was using originally where it is not mentioned:

[CloudFront DistributionConfiguration ViewerCertificate](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distributionconfig-viewercertificate.html#cfn-cloudfront-distributionconfig-viewercertificate-iamcertificateid)