### PR TITLE
Add support for VPC Flow Logs

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -75,6 +75,18 @@ class EIPAssociation(AWSObject):
     }
 
 
+class FlowLog(AWSObject):
+    resource_type = "AWS::EC2::FlowLog"
+
+    props = {
+        'DeliverLogsPermissionArn': (basestring, True),
+        'LogGroupName': (basestring, True),
+        'ResourceId': (basestring, True),
+        'ResourceType': (basestring, True),
+        'TrafficType': (basestring, True),
+    }
+
+
 class NatGateway(AWSObject):
     resource_type = "AWS::EC2::NatGateway"
 


### PR DESCRIPTION
* https://aws.amazon.com/about-aws/whats-new/2016/06/aws-cloudformation-adds-support-for-amazon-vpc-flow-logs-amazon-kinesis-firehose-streams-and-other-updates/
* http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-flowlog.html