### PR TITLE
add `AutoScalingReplacingUpdate` to `UpdatePolicy`

### DIFF
--- a/examples/Autoscaling.py
+++ b/examples/Autoscaling.py
@@ -4,7 +4,7 @@ from troposphere import cloudformation, autoscaling
 from troposphere.autoscaling import AutoScalingGroup, Tag
 from troposphere.autoscaling import LaunchConfiguration
 from troposphere.elasticloadbalancing import LoadBalancer
-from troposphere.policies import UpdatePolicy, AutoScalingRollingUpdate
+from troposphere.policies import UpdatePolicy, AutoScalingRollingUpdate, AutoScalingReplacingUpdate
 import troposphere.ec2 as ec2
 import troposphere.elasticloadbalancing as elb
 
@@ -227,6 +227,9 @@ AutoscalingGroup = t.add_resource(AutoScalingGroup(
     AvailabilityZones=[Ref(VPCAvailabilityZone1), Ref(VPCAvailabilityZone2)],
     HealthCheckType="EC2",
     UpdatePolicy=UpdatePolicy(
+        AutoScalingReplacingUpdate=AutoScalingReplacingUpdate(
+            WillReplace=True,
+        ),
         AutoScalingRollingUpdate=AutoScalingRollingUpdate(
             PauseTime='PT5M',
             MinInstancesInService="1",

--- a/examples/Autoscaling.py
+++ b/examples/Autoscaling.py
@@ -4,7 +4,9 @@ from troposphere import cloudformation, autoscaling
 from troposphere.autoscaling import AutoScalingGroup, Tag
 from troposphere.autoscaling import LaunchConfiguration
 from troposphere.elasticloadbalancing import LoadBalancer
-from troposphere.policies import UpdatePolicy, AutoScalingRollingUpdate, AutoScalingReplacingUpdate
+from troposphere.policies import (
+    AutoScalingReplacingUpdate, AutoScalingRollingUpdate, UpdatePolicy
+)
 import troposphere.ec2 as ec2
 import troposphere.elasticloadbalancing as elb
 

--- a/tests/examples_output/Autoscaling.template
+++ b/tests/examples_output/Autoscaling.template
@@ -128,6 +128,9 @@
             },
             "Type": "AWS::AutoScaling::AutoScalingGroup",
             "UpdatePolicy": {
+                "AutoScalingReplacingUpdate": {
+                    "WillReplace": "true"
+                },
                 "AutoScalingRollingUpdate": {
                     "MaxBatchSize": "1",
                     "MinInstancesInService": "1",

--- a/troposphere/policies.py
+++ b/troposphere/policies.py
@@ -19,10 +19,17 @@ class AutoScalingScheduledAction(AWSProperty):
     }
 
 
+class AutoScalingReplacingUpdate(AWSProperty):
+    props = {
+        'WillReplace': (boolean, False),
+    }
+
+
 class UpdatePolicy(AWSAttribute):
     props = {
         'AutoScalingRollingUpdate': (AutoScalingRollingUpdate, False),
         'AutoScalingScheduledAction': (AutoScalingScheduledAction, False),
+        'AutoScalingReplacingUpdate': (AutoScalingReplacingUpdate, False),
     }
 
 


### PR DESCRIPTION
- fixes cloudtools/troposphere#511