### PR TITLE
Removed validation for DBSubnetGroupName when creating a read replica

### DIFF
--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -68,13 +68,12 @@ class TestRDS(unittest.TestCase):
             PreferredBackupWindow="10:00-11:00",
             MultiAZ=True,
             DBSnapshotIdentifier="SomeDBSnapshotIdentifier",
-            DBSubnetGroupName="SomeDBSubnetGroupName",
         )
 
         with self.assertRaisesRegexp(
                 ValueError,
                 'BackupRetentionPeriod, DBName, DBSnapshotIdentifier, '
-                'DBSubnetGroupName, MasterUserPassword, MasterUsername, '
+                'MasterUserPassword, MasterUsername, '
                 'MultiAZ, PreferredBackupWindow '
                 'properties can\'t be provided when '
                 'SourceDBInstanceIdentifier is present '

--- a/troposphere/rds.py
+++ b/troposphere/rds.py
@@ -163,7 +163,7 @@ class DBInstance(AWSObject):
             invalid_replica_properties = (
                 'BackupRetentionPeriod', 'DBName', 'MasterUsername',
                 'MasterUserPassword', 'PreferredBackupWindow', 'MultiAZ',
-                'DBSnapshotIdentifier', 'DBSubnetGroupName',
+                'DBSnapshotIdentifier',
             )
 
             invalid_properties = [s for s in self.properties.keys() if


### PR DESCRIPTION
When creating a read replica using CloudFormation, the read replica will always be created in the default VPC unless the **DBSubnetGroupName** is stated. 

Prior to this PR, **DBSubnetGroupName** is not allowed to be stated when **SourceDBInstanceIdentifier** is stated. 

[AWS documentation](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html) also does not state the **DBSubnetGroupName** cannot be stated when **SourceDBInstanceIdentifier** is. 

A point to note when creating replica is when a read replica is already created in the region, the next read replica will always be created in the same VPC as the first read replica. This has been verified by AWS Support and also this [StackOverflow post](http://stackoverflow.com/questions/24746265/amazon-rds-read-replica-in-same-region-different-vpc).