### PR TITLE
Emr configurations values: also allow AWS helper functions

### DIFF
--- a/examples/EMR_Cluster.py
+++ b/examples/EMR_Cluster.py
@@ -1,5 +1,5 @@
-from troposphere import Parameter, Ref, Template, Tags
-from troposphere.constants import KEY_PAIR_NAME, SUBNET_ID, M4_LARGE
+from troposphere import Parameter, Ref, Template, Tags, If, Equals, Not
+from troposphere.constants import KEY_PAIR_NAME, SUBNET_ID, M4_LARGE, NUMBER
 import troposphere.emr as emr
 import troposphere.iam as iam
 
@@ -21,6 +21,16 @@ subnet = template.add_parameter(Parameter(
     Description="Subnet ID for creating the EMR cluster",
     Type=SUBNET_ID
 ))
+
+spot = template.add_parameter(Parameter(
+    "SpotPrice",
+    Description="Spot price (or use 0 for 'on demand' instance)",
+    Type=NUMBER,
+    Default="0.1"
+))
+
+withSpotPrice = "WithSpotPrice"
+template.add_condition(withSpotPrice, Not(Equals(Ref(spot), "0")))
 
 # IAM roles required by EMR
 
@@ -119,7 +129,8 @@ cluster = template.add_resource(emr.Cluster(
         ),
         CoreInstanceGroup=emr.InstanceGroupConfigProperty(
             Name="Core Instance",
-            BidPrice="0.1",
+            BidPrice=If(withSpotPrice, Ref(spot), Ref("AWS::NoValue")),
+            Market=If(withSpotPrice, "SPOT", "ON_DEMAND"),
             EbsConfiguration=emr.EbsConfiguration(
                 EbsBlockDeviceConfigs=[
                     emr.EbsBlockDeviceConfigs(
@@ -134,7 +145,6 @@ cluster = template.add_resource(emr.Cluster(
             ),
             InstanceCount="1",
             InstanceType=M4_LARGE,
-            Market="SPOT"
         )
     ),
     Applications=[

--- a/examples/EMR_Cluster.py
+++ b/examples/EMR_Cluster.py
@@ -1,5 +1,5 @@
 from troposphere import Parameter, Ref, Template, Tags, If, Equals, Not, Join
-from troposphere.constants import KEY_PAIR_NAME, SUBNET_ID, M4_LARGE, NUMBER, STRING
+from troposphere.constants import KEY_PAIR_NAME, SUBNET_ID, M4_LARGE, NUMBER
 import troposphere.emr as emr
 import troposphere.iam as iam
 
@@ -117,7 +117,8 @@ cluster = template.add_resource(emr.Cluster(
                     Classification="export",
                     ConfigurationProperties={
                         "HADOOP_DATANODE_HEAPSIZE": "2048",
-                        "HADOOP_NAMENODE_OPTS": Join("", ["-XX:GCTimeRatio=", Ref(gcTimeRatio)])
+                        "HADOOP_NAMENODE_OPTS": Join("",
+                            ["-XX:GCTimeRatio=", Ref(gcTimeRatio)])
                     }
                 )
             ]

--- a/examples/EMR_Cluster.py
+++ b/examples/EMR_Cluster.py
@@ -1,5 +1,5 @@
-from troposphere import Parameter, Ref, Template, Tags, If, Equals, Not
-from troposphere.constants import KEY_PAIR_NAME, SUBNET_ID, M4_LARGE, NUMBER
+from troposphere import Parameter, Ref, Template, Tags, If, Equals, Not, Join
+from troposphere.constants import KEY_PAIR_NAME, SUBNET_ID, M4_LARGE, NUMBER, STRING
 import troposphere.emr as emr
 import troposphere.iam as iam
 
@@ -31,6 +31,13 @@ spot = template.add_parameter(Parameter(
 
 withSpotPrice = "WithSpotPrice"
 template.add_condition(withSpotPrice, Not(Equals(Ref(spot), "0")))
+
+gcTimeRatio = template.add_parameter(Parameter(
+    "GcTimeRatioValue",
+    Description="Hadoop name node garbage collector time ratio",
+    Type=NUMBER,
+    Default="19"
+))
 
 # IAM roles required by EMR
 
@@ -110,7 +117,7 @@ cluster = template.add_resource(emr.Cluster(
                     Classification="export",
                     ConfigurationProperties={
                         "HADOOP_DATANODE_HEAPSIZE": "2048",
-                        "HADOOP_NAMENODE_OPTS": "-XX:GCTimeRatio=19"
+                        "HADOOP_NAMENODE_OPTS": Join("", ["-XX:GCTimeRatio=", Ref(gcTimeRatio)])
                     }
                 )
             ]

--- a/examples/EMR_Cluster.py
+++ b/examples/EMR_Cluster.py
@@ -117,8 +117,8 @@ cluster = template.add_resource(emr.Cluster(
                     Classification="export",
                     ConfigurationProperties={
                         "HADOOP_DATANODE_HEAPSIZE": "2048",
-                        "HADOOP_NAMENODE_OPTS": Join("",
-                            ["-XX:GCTimeRatio=", Ref(gcTimeRatio)])
+                        "HADOOP_NAMENODE_OPTS": Join("", ["-XX:GCTimeRatio=",
+                                                          Ref(gcTimeRatio)])
                     }
                 )
             ]

--- a/tests/examples_output/EMR_Cluster.template
+++ b/tests/examples_output/EMR_Cluster.template
@@ -1,9 +1,28 @@
 {
+    "Conditions": {
+        "WithSpotPrice": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "SpotPrice"
+                        },
+                        "0"
+                    ]
+                }
+            ]
+        }
+    },
     "Description": "Sample CloudFormation template for creating an EMR cluster",
     "Parameters": {
         "KeyName": {
             "Description": "Name of an existing EC2 KeyPair to enable SSH to the instances",
             "Type": "AWS::EC2::KeyPair::KeyName"
+        },
+        "SpotPrice": {
+            "Default": "0.1",
+            "Description": "Spot price (or use 0 for 'on demand' instance)",
+            "Type": "Number"
         },
         "Subnet": {
             "Description": "Subnet ID for creating the EMR cluster",
@@ -105,7 +124,17 @@
                 ],
                 "Instances": {
                     "CoreInstanceGroup": {
-                        "BidPrice": "0.1",
+                        "BidPrice": {
+                            "Fn::If": [
+                                "WithSpotPrice",
+                                {
+                                    "Ref": "SpotPrice"
+                                },
+                                {
+                                    "Ref": "AWS::NoValue"
+                                }
+                            ]
+                        },
                         "EbsConfiguration": {
                             "EbsBlockDeviceConfigs": [
                                 {
@@ -120,7 +149,13 @@
                         },
                         "InstanceCount": "1",
                         "InstanceType": "m4.large",
-                        "Market": "SPOT",
+                        "Market": {
+                            "Fn::If": [
+                                "WithSpotPrice",
+                                "SPOT",
+                                "ON_DEMAND"
+                            ]
+                        },
                         "Name": "Core Instance"
                     },
                     "Ec2KeyName": {

--- a/tests/examples_output/EMR_Cluster.template
+++ b/tests/examples_output/EMR_Cluster.template
@@ -15,6 +15,11 @@
     },
     "Description": "Sample CloudFormation template for creating an EMR cluster",
     "Parameters": {
+        "GcTimeRatioValue": {
+            "Default": "19",
+            "Description": "Hadoop name node garbage collector time ratio",
+            "Type": "Number"
+        },
         "KeyName": {
             "Description": "Name of an existing EC2 KeyPair to enable SSH to the instances",
             "Type": "AWS::EC2::KeyPair::KeyName"
@@ -116,7 +121,17 @@
                                 "Classification": "export",
                                 "ConfigurationProperties": {
                                     "HADOOP_DATANODE_HEAPSIZE": "2048",
-                                    "HADOOP_NAMENODE_OPTS": "-XX:GCTimeRatio=19"
+                                    "HADOOP_NAMENODE_OPTS": {
+                                        "Fn::Join": [
+                                            "",
+                                            [
+                                                "-XX:GCTimeRatio=",
+                                                {
+                                                    "Ref": "GcTimeRatioValue"
+                                                }
+                                            ]
+                                        ]
+                                    }
                                 }
                             }
                         ]

--- a/troposphere/emr.py
+++ b/troposphere/emr.py
@@ -3,7 +3,7 @@
 #
 # See LICENSE file for full license.
 
-from . import AWSObject, AWSProperty
+from . import AWSObject, AWSProperty, AWSHelperFn
 from .validators import (boolean, integer, positive_integer)
 
 
@@ -65,8 +65,8 @@ def properties_validator(xs):
     for k, v in xs.iteritems():
         if not isinstance(k, basestring):
             raise ValueError('ConfigurationProperties keys must be strings')
-        if not isinstance(v, basestring):
-            raise ValueError('ConfigurationProperties values must be strings')
+        if not isinstance(v, basestring) and not isinstance(v, AWSHelperFn):
+            raise ValueError('ConfigurationProperties values must be strings or helper functions')
 
     return xs
 

--- a/troposphere/emr.py
+++ b/troposphere/emr.py
@@ -66,7 +66,8 @@ def properties_validator(xs):
         if not isinstance(k, basestring):
             raise ValueError('ConfigurationProperties keys must be strings')
         if not isinstance(v, basestring) and not isinstance(v, AWSHelperFn):
-            raise ValueError('ConfigurationProperties values must be strings or helper functions')
+            raise ValueError('ConfigurationProperties values must be strings'
+                             ' or helper functions')
 
     return xs
 


### PR DESCRIPTION
The current master branch contains a too strict EMR configurations validator method: this validator forces configuration values to be strings.  CloudFormation also allows helper functions (which allow you to use for instance a parameter value as configuration value instead of a direct string value).

This branch contains an updated validator method and updated EMR cluster example using an indirect configuration value.

I also updated the EMR example with a parameter dependent choice between spot instances or on-demand instances (using a 'condition').

The EMR example is successfully created in my AWS region eu-west-1.