### PR TITLE
Fix AssociationParameters Value type to list of strings

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -136,7 +136,7 @@ class NetworkInterfaceProperty(AWSProperty):
 class AssociationParameters(AWSProperty):
     props = {
         'Key': (basestring, True),
-        'Value': (basestring, True),
+        'Value': ([basestring], True),
     }
 
 


### PR DESCRIPTION
According to
http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-ssmassociations-associationparameters.html,
the SsmAssociations AssociationParameters Value is a list of strings,
not a string. This was causing instance creation failure on templates
attempting to use SsmAssociations.