### PR TITLE
Add DependsOn to Deployment and remove Enabled from StageKey

### DIFF
--- a/examples/ApiGateway.py
+++ b/examples/ApiGateway.py
@@ -112,6 +112,7 @@ method = t.add_resource(Method(
 stage_name = 'v1'
 deployment = t.add_resource(Deployment(
     "%sDeployment" % stage_name,
+    DependsOn="LambdaMethod",
     RestApiId=Ref(rest_api),
     StageName=stage_name
 ))
@@ -121,8 +122,7 @@ key = t.add_resource(ApiKey(
     StageKeys=[StageKey(
         RestApiId=Ref(rest_api),
         StageName=stage_name
-    )],
-    Enabled=True
+    )]
 ))
 
 # Add the deployment endpoint as an output

--- a/tests/examples_output/ApiGateway.template
+++ b/tests/examples_output/ApiGateway.template
@@ -26,7 +26,6 @@
     "Resources": {
         "ApiKey": {
             "Properties": {
-                "Enabled": true,
                 "StageKeys": [
                     {
                         "RestApiId": {
@@ -183,6 +182,7 @@
             "Type": "AWS::ApiGateway::Method"
         },
         "v1Deployment": {
+            "DependsOn": "LambdaMethod",
             "Properties": {
                 "RestApiId": {
                     "Ref": "ExampleApi"


### PR DESCRIPTION
DependsOn is required if the RestApi and Method are created in the same template as explained here: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-deployment.html#aws-resource-apigateway-deployment-examples