### PR TITLE
do not require Status as a property in iam.AccessKey

### DIFF
--- a/troposphere/iam.py
+++ b/troposphere/iam.py
@@ -23,8 +23,7 @@ class AccessKey(AWSObject):
 
     props = {
         'Serial': (integer, False),
-        # XXX - Is Status required? Docs say yes, examples say no
-        'Status': (status, True),
+        'Status': (status, False),
         'UserName': (basestring, True),
     }
 


### PR DESCRIPTION
Greetings,

Thank you for this excellent software. Per the following documentation:

http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-accesskey.html

'Status' is not a required property of IAM::AccessKey. I do not know what examples the OP was referring to, but IAM::AccessKey does actually default to 'Active'

Thanks!
Niko