### PR TITLE
Fix TemplateGenerator import logic.

### DIFF
--- a/troposphere/template_generator.py
+++ b/troposphere/template_generator.py
@@ -16,6 +16,7 @@ Usage:
 import inspect
 import pkgutil
 import importlib
+import os
 
 from collections import Sequence, Mapping
 
@@ -307,10 +308,11 @@ class TemplateGenerator(Template):
 
     def _import_all_troposphere_modules(self):
         """ Imports all troposphere modules and returns them """
+        dirname = os.path.join(os.path.dirname(__file__), "..")
         module_names = [
             pkg_name
             for importer, pkg_name, is_pkg in
-            pkgutil.walk_packages(__file__)
+            pkgutil.walk_packages([dirname])
             if not is_pkg and pkg_name.startswith("troposphere") and
             pkg_name not in self.DEPRECATED_MODULES]
         module_names.append('troposphere')

--- a/troposphere/template_generator.py
+++ b/troposphere/template_generator.py
@@ -313,8 +313,7 @@ class TemplateGenerator(Template):
             pkg_name
             for importer, pkg_name, is_pkg in
             pkgutil.walk_packages([dirname], prefix="troposphere.")
-            if not is_pkg and pkg_name.startswith("troposphere") and
-            pkg_name not in self.DEPRECATED_MODULES]
+            if not is_pkg and pkg_name not in self.DEPRECATED_MODULES]
         module_names.append('troposphere')
 
         modules = []

--- a/troposphere/template_generator.py
+++ b/troposphere/template_generator.py
@@ -308,11 +308,11 @@ class TemplateGenerator(Template):
 
     def _import_all_troposphere_modules(self):
         """ Imports all troposphere modules and returns them """
-        dirname = os.path.join(os.path.dirname(__file__), "..")
+        dirname = os.path.join(os.path.dirname(__file__))
         module_names = [
             pkg_name
             for importer, pkg_name, is_pkg in
-            pkgutil.walk_packages([dirname])
+            pkgutil.walk_packages([dirname], prefix="troposphere.")
             if not is_pkg and pkg_name.startswith("troposphere") and
             pkg_name not in self.DEPRECATED_MODULES]
         module_names.append('troposphere')


### PR DESCRIPTION
template_generator.py was incorrectly invoking pkgutil.walk_packages,
passing in the filepath directly rather than as a list of paths. By
coincidence, this resulted in the current directory being processed
instead, which allowed the tests to accidentally pass.

Fixes #532