### PR TITLE
Add Name attributes for IAM groups and roles

### DIFF
--- a/troposphere/iam.py
+++ b/troposphere/iam.py
@@ -56,6 +56,7 @@ class Group(AWSObject):
     resource_type = "AWS::IAM::Group"
 
     props = {
+        'GroupName': (iam_group_name, False),
         'ManagedPolicyArns': ([basestring], False),
         'Path': (iam_path, False),
         'Policies': ([Policy], False),
@@ -82,6 +83,7 @@ class Role(AWSObject):
         'ManagedPolicyArns': ([basestring], False),
         'Path': (iam_path, False),
         'Policies': ([Policy], False),
+        'RoleName': (iam_role_name, False),
     }
 
 


### PR DESCRIPTION
http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-group.html#cfn-iam-group-groupname
http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#cfn-iam-role-rolename