### PR TITLE
Automatically check if zip_file exceeds 4096 chars

### DIFF
--- a/troposphere/awslambda.py
+++ b/troposphere/awslambda.py
@@ -38,6 +38,10 @@ class Code(AWSProperty):
             raise ValueError(
                 "You can't specify both 'S3ObjectVersion' and 'ZipFile'"
             )
+        if zip_file and len(zip_file) > 4096:
+            raise ValueError(
+                "ZipFile length cannot exceed 4096 characters. For larger source use S3Bucket/S3Key properties instead. Current length: %d" % len(zip_file)
+            )            
         if not zip_file and not (s3_bucket and s3_key):
             raise ValueError(
                 "You must specify a bucket location (both the 'S3Bucket' and "


### PR DESCRIPTION
CloudFormation doesn't allow to specify more than 4096 characters in ZipFile. Lets
do check locally instead of failing when template is deployed in Amazon.

http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-code.html

>ZipFile
>
> ...
>
>You can specify up to 4096 characters. You must precede certain special characters in your source code,  such as quotation marks ("), newlines (\n), and tabs (\t), with a backslash (\). For a list of special characters,   see http://json.org/.
