### PR TITLE
Extend Template constructor.

### DIFF
--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,0 +1,27 @@
+import unittest
+
+from troposphere import Template
+
+
+class TestInitArguments(unittest.TestCase):
+    def test_description_default(self):
+        template = Template()
+        self.assertIsNone(template.description)
+
+    def test_description(self):
+        value = 'foo'
+        template = Template(Description=value)
+        self.assertEqual(template.description, value)
+
+    def test_metadata_default(self):
+        template = Template()
+        self.assertEqual(template.metadata, {})
+
+    def test_metadata(self):
+        value = 'foo'
+        template = Template(Metadata=value)
+        self.assertEqual(template.metadata, value)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -405,9 +405,9 @@ class Template(object):
         'Outputs': (dict, False),
     }
 
-    def __init__(self):
-        self.description = None
-        self.metadata = {}
+    def __init__(self, Description=None, Metadata=None):
+        self.description = Description
+        self.metadata = {} if Metadata is None else Metadata
         self.conditions = {}
         self.mappings = {}
         self.outputs = {}


### PR DESCRIPTION
Similar to the resource classes, this allows Description and Metadata to be set on construction.

Currently you have to do:
```python
template = Template()
template.add_description('Blah blah blah ...')
```

This PR makes it more consistent with other resources and allows:
```python
template = Template(Description='Blah blah blah ...')
```