### PR TITLE
Improve check_zip_file to calculate a minimum length

### DIFF
--- a/tests/test_awslambda.py
+++ b/tests/test_awslambda.py
@@ -1,5 +1,5 @@
 import unittest
-from troposphere import GetAtt, Template, Join
+from troposphere import GetAtt, Template, Join, Ref
 from troposphere.awslambda import Code, Function
 
 
@@ -49,6 +49,7 @@ class TestAWSLambda(unittest.TestCase):
             'a'*4096,
             Join('', ['a'*4096]),
             Join('', ['a', 10]),
+            Join('', ['a'*4096, Ref('EmptyParameter')]),
             Join('ab', ['a'*2047, 'a'*2047]),
             GetAtt('foo', 'bar'),
         ]
@@ -57,6 +58,7 @@ class TestAWSLambda(unittest.TestCase):
         negative_tests = [
             'a'*4097,
             Join('', ['a'*4097]),
+            Join('', ['a'*4097, Ref('EmptyParameter')]),
             Join('abc', ['a'*2047, 'a'*2047]),
         ]
         for z in negative_tests:


### PR DESCRIPTION
This reworks the check_zip_file function (https://github.com/cloudtools/troposphere/pull/537 and https://github.com/cloudtools/troposphere/commit/1f69f01155105117eb2e543d2a96569e2bae3a3c) to always try to get a minimum length, even if not all parts are strings.

My original plan was to only replace `return` on line 56 with `continue`, but when I started writing it, I saw that I could also  use list comprehension instead of a loop (and make the variable name use snake_case).