### PR TITLE
Change param type for resource: RestAPI

### DIFF
--- a/troposphere/apigateway.py
+++ b/troposphere/apigateway.py
@@ -210,7 +210,7 @@ class RestApi(AWSObject):
     resource_type = "AWS::ApiGateway::RestApi"
 
     props = {
-        "Body": (basestring, False),
+        "Body": (dict, False),
         "BodyS3Location": (S3Location, False),
         "CloneFrom": (basestring, False),
         "Description": (basestring, False),


### PR DESCRIPTION
"Body" is a dict now: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html