### PR TITLE
Get support for new DomainVersion attribute

### DIFF
--- a/examples/ElasticsearchDomain.py
+++ b/examples/ElasticsearchDomain.py
@@ -14,6 +14,7 @@ templ.add_description('Elasticsearch Domain example')
 es_domain = templ.add_resource(Domain(
     'ElasticsearchDomain',
     DomainName="ExampleElasticsearchDomain",
+    DomainVersion="2.3",
     ElasticsearchClusterConfig=ElasticsearchClusterConfig(
         DedicatedMasterEnabled=True,
         InstanceCount=2,

--- a/tests/examples_output/ElasticsearchDomain.template
+++ b/tests/examples_output/ElasticsearchDomain.template
@@ -20,6 +20,7 @@
                     "rest.action.multi.allow_explicit_index": "true"
                 },
                 "DomainName": "ExampleElasticsearchDomain",
+                "DomainVersion": "2.3",
                 "EBSOptions": {
                     "EBSEnabled": "true",
                     "Iops": 0,

--- a/troposphere/elasticsearch.py
+++ b/troposphere/elasticsearch.py
@@ -62,6 +62,7 @@ class Domain(AWSObject):
         'AccessPolicies': (policytypes, False),
         'AdvancedOptions': (dict, False),
         'DomainName': (basestring, False),
+        'DomainVersion': (basestring, False),
         'EBSOptions': (EBSOptions, False),
         'ElasticsearchClusterConfig': (ElasticsearchClusterConfig, False),
         'SnapshotOptions': (SnapshotOptions, False),


### PR DESCRIPTION
As was announced right now AWS supports ElasticSearch 2.3, the default version if it is not specified is 1.5. This PR enables to the user choose a different version rather than the default one. 