### PR TITLE
Add support for IAM Roles in ECS Task Definitions

### DIFF
--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -1,6 +1,7 @@
 import unittest
-from troposphere import Template
+from troposphere import Template, Ref
 from troposphere import ecs
+from troposphere import iam
 
 
 class TestDict(unittest.TestCase):
@@ -39,6 +40,7 @@ class TestDict(unittest.TestCase):
                 "taskdef",
                 ContainerDefinitions=[cd],
                 Volumes=[ecs.Volume(Name="myvol")],
+                TaskRoleArn=Ref(iam.Role("myecsrole"))
         )
         t.add_resource(td)
         t.to_json()

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -1,6 +1,7 @@
 import unittest
 from troposphere import Ref
 import troposphere.ecs as ecs
+from troposphere import iam
 
 
 class TestECS(unittest.TestCase):
@@ -51,3 +52,47 @@ class TestECS(unittest.TestCase):
         )
 
         ecs_service.JSONrepr()
+
+    def test_task_role_arn_is_optional(self):
+        task_definition = ecs.TaskDefinition(
+            "mytaskdef",
+            ContainerDefinitions=[
+                ecs.ContainerDefinition(
+                    Image="myimage",
+                    Memory="300",
+                    Name="mycontainer",
+                )
+            ],
+        )
+
+        task_definition.JSONrepr()
+
+    def test_allow_string_task_role_arn(self):
+        task_definition = ecs.TaskDefinition(
+            "mytaskdef",
+            ContainerDefinitions=[
+                ecs.ContainerDefinition(
+                    Image="myimage",
+                    Memory="300",
+                    Name="mycontainer",
+                )
+            ],
+            TaskRoleArn="myiamrole"
+        )
+
+        task_definition.JSONrepr()
+
+    def test_allow_ref_task_role_arn(self):
+        task_definition = ecs.TaskDefinition(
+            "mytaskdef",
+            ContainerDefinitions=[
+                ecs.ContainerDefinition(
+                    Image="myimage",
+                    Memory="300",
+                    Name="mycontainer",
+                )
+            ],
+            TaskRoleArn=Ref(iam.Role("myRole"))
+        )
+
+        task_definition.JSONrepr()

--- a/troposphere/ecs.py
+++ b/troposphere/ecs.py
@@ -137,4 +137,5 @@ class TaskDefinition(AWSObject):
     props = {
         'ContainerDefinitions': ([ContainerDefinition], True),
         'Volumes': ([Volume], False),
+        'TaskRoleArn': (basestring, False),
     }


### PR DESCRIPTION
Even though the Cloudformation Documentation has not been updated to mention the TaskRoleArn property for TaskDefinitions, it is supported and successfully provisions task definitions with IAM Roles, as described in the API documentation:
http://docs.aws.amazon.com/cli/latest/reference/ecs/register-task-definition.html