### PR TITLE
Allow Tags on AWS::CloudFormation::Stack (http://docs.aws.amazon.com/…

### DIFF
--- a/troposphere/cloudformation.py
+++ b/troposphere/cloudformation.py
@@ -13,6 +13,7 @@ class Stack(AWSObject):
     props = {
         'NotificationARNs': ([basestring], False),
         'Parameters': (dict, False),
+        'Tags': (list, False),
         'TemplateURL': (basestring, True),
         'TimeoutInMinutes': (integer, False),
     }


### PR DESCRIPTION
Allow Tags on the AWS::CloudFormation::Stack resource.
Reference: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stack.html
