### PR TITLE
Added support for protocol in container definition's PortMapping property.

### DIFF
--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -96,3 +96,31 @@ class TestECS(unittest.TestCase):
         )
 
         task_definition.JSONrepr()
+
+    def test_allow_port_mapping_protocol(self):
+        container_definition = ecs.ContainerDefinition(
+            Image="myimage",
+            Memory="300",
+            Name="mycontainer",
+            PortMappings=[
+                ecs.PortMapping(
+                    ContainerPort=8125, HostPort=8125, Protocol="udp"
+                )
+            ]
+        )
+
+        container_definition.JSONrepr()
+
+    def test_port_mapping_does_not_require_protocol(self):
+        container_definition = ecs.ContainerDefinition(
+            Image="myimage",
+            Memory="300",
+            Name="mycontainer",
+            PortMappings=[
+                ecs.PortMapping(
+                    ContainerPort=8125, HostPort=8125,
+                )
+            ]
+        )
+
+        container_definition.JSONrepr()

--- a/troposphere/ecs.py
+++ b/troposphere/ecs.py
@@ -56,6 +56,7 @@ class PortMapping(AWSProperty):
     props = {
         'ContainerPort': (network_port, True),
         'HostPort': (network_port, False),
+        'Protocol': (basestring, False),
     }
 
 


### PR DESCRIPTION
This is now supported in CloudFormation. From http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions-portmappings.html
