### PR TITLE
Add support for ElasticsearchVersion in Elasticsearch Domain

### DIFF
--- a/troposphere/elasticsearch.py
+++ b/troposphere/elasticsearch.py
@@ -64,6 +64,7 @@ class Domain(AWSObject):
         'DomainName': (basestring, False),
         'EBSOptions': (EBSOptions, False),
         'ElasticsearchClusterConfig': (ElasticsearchClusterConfig, False),
+        'ElasticsearchVersion': (basestring, False),
         'SnapshotOptions': (SnapshotOptions, False),
         'Tags': (list, False)
     }


### PR DESCRIPTION
Similar to #556, there's now cloudformation support for specifying the desired ES version, but it's not added to their official docs. I stumbled upon [this StackOverflow thread](http://stackoverflow.com/questions/38796017/aws-elasticsearch-domain-cloudformation-template) when I was trying to find out whether it's supported. I've verified that the param is indeed supported.