### PR TITLE
add support for Tags to Certificate Manager Certificates

### DIFF
--- a/examples/CertificateManagerSample.py
+++ b/examples/CertificateManagerSample.py
@@ -1,7 +1,6 @@
 from troposphere import Template
 from troposphere.certificatemanager import Certificate, DomainValidationOption
 
-
 t = Template()
 
 t.add_resource(
@@ -13,6 +12,12 @@ t.add_resource(
                 DomainName='example.com',
                 ValidationDomain='example.com',
             ),
+        ],
+        Tags=[
+            {
+                'Key': 'tag-key',
+                'Value': 'tag-value'
+            },
         ],
     )
 )

--- a/tests/examples_output/CertificateManagerSample.template
+++ b/tests/examples_output/CertificateManagerSample.template
@@ -8,6 +8,12 @@
                         "DomainName": "example.com",
                         "ValidationDomain": "example.com"
                     }
+                ],
+                "Tags": [
+                    {
+                        "Key": "tag-key",
+                        "Value": "tag-value"
+                    }
                 ]
             },
             "Type": "AWS::CertificateManager::Certificate"

--- a/troposphere/certificatemanager.py
+++ b/troposphere/certificatemanager.py
@@ -15,4 +15,5 @@ class Certificate(AWSObject):
         'DomainName': (basestring, True),
         'DomainValidationOptions': ([DomainValidationOption], False),
         'SubjectAlternativeNames': ([basestring], False),
+        'Tags': (list, False)
     }


### PR DESCRIPTION
Certificate Manager certificates support tagging: see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html