### PR TITLE
Add support for LogGroupName in Logs::LogGroup

### DIFF
--- a/troposphere/logs.py
+++ b/troposphere/logs.py
@@ -17,6 +17,7 @@ class LogGroup(AWSObject):
     resource_type = "AWS::Logs::LogGroup"
 
     props = {
+        'LogGroupName': (basestring, False),
         'RetentionInDays': (positive_integer, False),
     }
 


### PR DESCRIPTION
Docs [here](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-loggroup.html)