### PR TITLE
Allow HelperFn in UpdatePolicy for ASG

### DIFF
--- a/tests/test_asg.py
+++ b/tests/test_asg.py
@@ -1,7 +1,7 @@
 import unittest
 from troposphere.autoscaling import AutoScalingGroup
 from troposphere.policies import AutoScalingRollingUpdate, UpdatePolicy
-from troposphere import If
+from troposphere import If, Ref
 
 
 class TestAutoScalingGroup(unittest.TestCase):
@@ -60,6 +60,26 @@ class TestAutoScalingGroup(unittest.TestCase):
                     WaitOnResourceSignals=True
                 )
             )
+        )
+        self.assertTrue(group.validate())
+
+    def test_helperfn_as_updatepolicy(self):
+        update_policy = UpdatePolicy(
+            AutoScalingRollingUpdate=AutoScalingRollingUpdate(
+                PauseTime='PT5M',
+                MinInstancesInService="1",
+                MaxBatchSize='1',
+                WaitOnResourceSignals=True
+            )
+        )
+        group = AutoScalingGroup(
+            'mygroup',
+            AvailabilityZones=['eu-west-1a', 'eu-west-1b'],
+            LaunchConfigurationName="I'm a test",
+            MaxSize=If("isstage", "1", "5"),
+            MinSize="1",
+            UpdatePolicy=If("UseUpdatePolicy",
+                            update_policy, Ref("AWS::NoValue"))
         )
         self.assertTrue(group.validate())
 

--- a/troposphere/autoscaling.py
+++ b/troposphere/autoscaling.py
@@ -135,7 +135,8 @@ class AutoScalingGroup(AWSObject):
         if 'UpdatePolicy' in self.resource:
             update_policy = self.resource['UpdatePolicy']
 
-            if 'AutoScalingRollingUpdate' in update_policy.properties:
+            if (not isinstance(update_policy, AWSHelperFn) and
+                    'AutoScalingRollingUpdate' in update_policy.properties):
                 rolling_update = update_policy.AutoScalingRollingUpdate
 
                 isMinNoCheck = isinstance(


### PR DESCRIPTION
If you tried to use an AWSHelperFn object in an UpdatePolicy for an ASG,
you would run into issues because of the extra validation.  This
disables the extra validation whenever the UpdatePolicy is an
AWSHelperFn, which is in line with the way troposphere usually handles
these things.