### PR TITLE
Rename LoadBalancerAttributes to be singular

### DIFF
--- a/troposphere/elasticloadbalancingv2.py
+++ b/troposphere/elasticloadbalancingv2.py
@@ -8,7 +8,7 @@ from .validators import (
     network_port, integer)
 
 
-class LoadBalancerAttributes(AWSProperty):
+class LoadBalancerAttribute(AWSProperty):
     props = {
         'Key': (basestring, False),
         'Value': (basestring, False)
@@ -105,7 +105,7 @@ class LoadBalancer(AWSObject):
     resource_type = "AWS::ElasticLoadBalancingV2::LoadBalancer"
 
     props = {
-        'LoadBalancerAttributes': ([LoadBalancerAttributes], False),
+        'LoadBalancerAttributes': ([LoadBalancerAttribute], False),
         'Name': (basestring, False),
         'Scheme': (basestring, False),
         'SecurityGroups': (list, False),


### PR DESCRIPTION
The LoadBalancerAttributes object contains only one LoadBalancerAttribute and shouldn't end in an 's'. i.e. singular not plural.

This is already the case for TargetGroupAttribute which is named correctly.