### PR TITLE
Add EFS example

### DIFF
--- a/examples/EFS.py
+++ b/examples/EFS.py
@@ -1,0 +1,131 @@
+from troposphere import FindInMap, Ref, Template, Parameter, Tags
+from troposphere.iam import InstanceProfile, Role
+from troposphere.efs import FileSystem, MountTarget
+from troposphere.ec2 import SecurityGroup, SecurityGroupRule, Instance
+from awacs.aws import Allow, Statement, Policy, Action
+
+
+template = Template()
+template.add_version('2010-09-09')
+
+template.add_mapping('RegionMap', {
+    "us-east-1": {"AMI": "ami-7f418316"},
+    "us-west-1": {"AMI": "ami-951945d0"},
+    "us-west-2": {"AMI": "ami-16fd7026"},
+    "eu-west-1": {"AMI": "ami-24506250"},
+    "sa-east-1": {"AMI": "ami-3e3be423"},
+    "ap-southeast-1": {"AMI": "ami-74dda626"},
+    "ap-northeast-1": {"AMI": "ami-dcfa4edd"}
+})
+
+keyname_param = template.add_parameter(Parameter(
+    "KeyName",
+    Description="Name of an existing EC2 KeyPair to enable SSH "
+                "access to the instance",
+    Type="String",
+))
+
+vpcid_param = template.add_parameter(Parameter(
+    "VpcId",
+    Description="VPC ID where the MountTarget and instance should be created",
+    Type="String",
+))
+
+subnetid_param = template.add_parameter(Parameter(
+    "SubnetId",
+    Description="Subnet ID where the MountTarget and instance "
+                "should be created",
+    Type="String",
+))
+
+# security group for the host
+efs_host_security_group = SecurityGroup(
+    "EFSHostSecurityGroup",
+    GroupDescription="EC2 Instance Security Group"
+)
+template.add_resource(efs_host_security_group)
+
+# create security group for NFS over TCP for EC2 instances. Only allow the
+# instance(s) from the efs_host_security_group to access the mount target
+# given by this security group.
+efs_security_group_rule = SecurityGroupRule(
+    IpProtocol='tcp',
+    FromPort='2049',
+    ToPort='2049',
+    SourceSecurityGroupId=Ref(efs_host_security_group)
+)
+
+# Security group that's applied to the Mount Targets.
+efs_security_group = SecurityGroup(
+    "SecurityGroup",
+    SecurityGroupIngress=[Ref(efs_security_group_rule)],
+    VpcId=Ref(vpcid_param),
+    GroupDescription="Allow NFS over TCP"
+)
+template.add_resource(efs_security_group)
+
+# Create FileSystem. This is the actual filesystem, which has one or more
+# mount targets. Give it some tags so we can identify it later.
+tags = Tags(Name='MyEFSFileSystem')
+efs_file_system = FileSystem(
+    title='MyEFSFileSystem',
+    FileSystemTags=tags
+)
+template.add_resource(efs_file_system)
+
+# create MountTarget. You really want a mount target in each subnet where
+# it's required, but for the purpose of this example we'll
+# put it in just one.
+efs_mount_target = MountTarget(
+    title='MyEFSMountTarget',
+    FileSystemId=Ref(efs_file_system),
+    SecurityGroups=[Ref(efs_security_group)],
+    SubnetId=Ref(subnetid_param)
+)
+template.add_resource(efs_mount_target)
+
+# Create the policy that allows the instance to describe file systems and tags,
+# so it can lookup the file system using AWS tags. An alternative would be to
+# pass in the FileSystem name as UserData.
+efs_host_role = Role(
+    "EFSHostRole",
+    AssumeRolePolicyDocument=Policy(
+        Statement=[
+            Statement(
+                Effect=Allow,
+                Action=[
+                    Action('elasticfilesystem', 'DescribeFileSystems'),
+                    Action('elasticfilesystem', 'DescribeTags')
+                ],
+                Resource=["*"]
+            )
+        ]
+    )
+)
+template.add_resource(efs_host_role)
+
+efs_host_instance_profile = InstanceProfile(
+    "EFSInstanceProfile",
+    Roles=[Ref(efs_host_role)]
+)
+template.add_resource(efs_host_instance_profile)
+
+# And finally the EC2 instance.
+ec2_instance = Instance(
+    "Ec2Instance",
+    ImageId=FindInMap("RegionMap", Ref("AWS::Region"), "AMI"),
+    InstanceType="t1.micro",
+    KeyName=Ref(keyname_param),
+    SecurityGroups=[Ref(efs_host_security_group)],
+    IamInstanceProfile=Ref(efs_host_instance_profile),
+    DependsOn=Ref(efs_mount_target)
+)
+template.add_resource(ec2_instance)
+
+# the instance can then mount the filesystem with something like
+# (depending on your operating system):
+#   mount <az>.<filesystem-name>.efs.<region>.amazonaws.com: /path
+# for example:
+#   mount us-west-1a.fs-abcd1234.efs.us-west-1.amazonaws.com: /path
+
+print(template.to_json())

--- a/tests/examples_output/EFS.template
+++ b/tests/examples_output/EFS.template
@@ -1,0 +1,149 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Mappings": {
+        "RegionMap": {
+            "ap-northeast-1": {
+                "AMI": "ami-dcfa4edd"
+            },
+            "ap-southeast-1": {
+                "AMI": "ami-74dda626"
+            },
+            "eu-west-1": {
+                "AMI": "ami-24506250"
+            },
+            "sa-east-1": {
+                "AMI": "ami-3e3be423"
+            },
+            "us-east-1": {
+                "AMI": "ami-7f418316"
+            },
+            "us-west-1": {
+                "AMI": "ami-951945d0"
+            },
+            "us-west-2": {
+                "AMI": "ami-16fd7026"
+            }
+        }
+    },
+    "Parameters": {
+        "KeyName": {
+            "Description": "Name of an existing EC2 KeyPair to enable SSH access to the instance",
+            "Type": "String"
+        },
+        "SubnetId": {
+            "Description": "Subnet ID where the MountTarget and instance should be created",
+            "Type": "String"
+        },
+        "VpcId": {
+            "Description": "VPC ID where the MountTarget and instance should be created",
+            "Type": "String"
+        }
+    },
+    "Resources": {
+        "EFSHostRole": {
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [
+                        {
+                            "Action": [
+                                "elasticfilesystem:DescribeFileSystems",
+                                "elasticfilesystem:DescribeTags"
+                            ],
+                            "Effect": "Allow",
+                            "Resource": [
+                                "*"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "Type": "AWS::IAM::Role"
+        },
+        "EFSHostSecurityGroup": {
+            "Properties": {
+                "GroupDescription": "EC2 Instance Security Group"
+            },
+            "Type": "AWS::EC2::SecurityGroup"
+        },
+        "EFSInstanceProfile": {
+            "Properties": {
+                "Roles": [
+                    {
+                        "Ref": "EFSHostRole"
+                    }
+                ]
+            },
+            "Type": "AWS::IAM::InstanceProfile"
+        },
+        "Ec2Instance": {
+            "DependsOn": {
+                "Ref": "MyEFSMountTarget"
+            },
+            "Properties": {
+                "IamInstanceProfile": {
+                    "Ref": "EFSInstanceProfile"
+                },
+                "ImageId": {
+                    "Fn::FindInMap": [
+                        "RegionMap",
+                        {
+                            "Ref": "AWS::Region"
+                        },
+                        "AMI"
+                    ]
+                },
+                "InstanceType": "t1.micro",
+                "KeyName": {
+                    "Ref": "KeyName"
+                },
+                "SecurityGroups": [
+                    {
+                        "Ref": "EFSHostSecurityGroup"
+                    }
+                ]
+            },
+            "Type": "AWS::EC2::Instance"
+        },
+        "MyEFSFileSystem": {
+            "Properties": {
+                "FileSystemTags": [
+                    {
+                        "Key": "Name",
+                        "Value": "MyEFSFileSystem"
+                    }
+                ]
+            },
+            "Type": "AWS::EFS::FileSystem"
+        },
+        "MyEFSMountTarget": {
+            "Properties": {
+                "FileSystemId": {
+                    "Ref": "MyEFSFileSystem"
+                },
+                "SecurityGroups": [
+                    {
+                        "Ref": "SecurityGroup"
+                    }
+                ],
+                "SubnetId": {
+                    "Ref": "SubnetId"
+                }
+            },
+            "Type": "AWS::EFS::MountTarget"
+        },
+        "SecurityGroup": {
+            "Properties": {
+                "GroupDescription": "Allow NFS over TCP",
+                "SecurityGroupIngress": [
+                    {
+                        "Ref": null
+                    }
+                ],
+                "VpcId": {
+                    "Ref": "VpcId"
+                }
+            },
+            "Type": "AWS::EC2::SecurityGroup"
+        }
+    }
+}


### PR DESCRIPTION
After deploying EFS myself and seeing https://github.com/cloudtools/troposphere/issues/580 decided to give back and add an EFS example.

I purposely made it a a reasonably interesting example with security groups, IAM artifacts etc since that's probably a more realistic real-world example. The examples have helped me tremendously in the past but you often have to pull info from several different ones to get a full picture.
