### PR TITLE
add support to old mysql db engine

### DIFF
--- a/troposphere/rds.py
+++ b/troposphere/rds.py
@@ -12,7 +12,7 @@ from .validators import boolean, network_port, integer, positive_integer
 # http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html
 
 VALID_STORAGE_TYPES = ('standard', 'gp2', 'io1')
-VALID_DB_ENGINES = ('MySQL', 'oracle-se1', 'oracle-se', 'oracle-ee',
+VALID_DB_ENGINES = ('MySQL', 'mysql', 'oracle-se1', 'oracle-se', 'oracle-ee',
                     'sqlserver-ee', 'sqlserver-se', 'sqlserver-ex',
                     'sqlserver-web', 'postgres', 'aurora', 'mariadb')
 VALID_LICENSE_MODELS = ('license-included', 'bring-your-own-license',


### PR DESCRIPTION
This is a Backward compatibility change proposal.
I got old templates generated with troposphere that needs as db engine parameter 'mysql' in order to avoid the replacement of the RDS during a stack update.
