### PR TITLE
Remove `title` validation. Fixes #428 (attempt 2)

### DIFF
--- a/troposphere/iam.py
+++ b/troposphere/iam.py
@@ -50,9 +50,6 @@ PolicyProperty = Policy
 
 
 class Group(AWSObject):
-    def validate_title(self):
-        iam_group_name(self.title)
-
     resource_type = "AWS::IAM::Group"
 
     props = {
@@ -73,9 +70,6 @@ class InstanceProfile(AWSObject):
 
 
 class Role(AWSObject):
-    def validate_title(self):
-        iam_role_name(self.title)
-
     resource_type = "AWS::IAM::Role"
 
     props = {


### PR DESCRIPTION
The title specified in troposphere is not the actual physical resource name and should be validated as such.

The original pull request was https://github.com/cloudtools/troposphere/pull/429, cc @phobologic.