### PR TITLE
Add HttpVersion prop to DistributionConfig (CloudFront HTTP/2 Support)

### DIFF
--- a/examples/CloudFront_S3.py
+++ b/examples/CloudFront_S3.py
@@ -37,7 +37,8 @@ myDistribution = t.add_resource(Distribution(
                 QueryString=False
             ),
             ViewerProtocolPolicy="allow-all"),
-        Enabled=True
+        Enabled=True,
+        HttpVersion='http2'
     )
 ))
 

--- a/tests/examples_output/CloudFront_S3.template
+++ b/tests/examples_output/CloudFront_S3.template
@@ -41,6 +41,7 @@
                         "ViewerProtocolPolicy": "allow-all"
                     },
                     "Enabled": "true",
+                    "HttpVersion": "http2",
                     "Origins": [
                         {
                             "DomainName": {

--- a/troposphere/cloudfront.py
+++ b/troposphere/cloudfront.py
@@ -142,7 +142,8 @@ class DistributionConfig(AWSProperty):
         'PriceClass': (basestring, False),
         'Restrictions': (Restrictions, False),
         'ViewerCertificate': (ViewerCertificate, False),
-        'WebACLId': (basestring, False)
+        'WebACLId': (basestring, False),
+        'HttpVersion', (basestring, False)
     }
 
 

--- a/troposphere/cloudfront.py
+++ b/troposphere/cloudfront.py
@@ -143,7 +143,7 @@ class DistributionConfig(AWSProperty):
         'Restrictions': (Restrictions, False),
         'ViewerCertificate': (ViewerCertificate, False),
         'WebACLId': (basestring, False),
-        'HttpVersion', (basestring, False)
+        'HttpVersion': (basestring, False)
     }
 
 


### PR DESCRIPTION
CloudFront now supports HTTP/2, this allow that property to be set in CloudFormation via Troposphere.

Support landed in CF to support this property on the 3rd November 2016, see: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/ReleaseHistory.html

https://aws.amazon.com/about-aws/whats-new/2016/09/amazon-cloudfront-now-supports-http2/

http://docs.aws.amazon.com/AmazonCloudFront/latest/APIReference/CreateDistribution.html