### PR TITLE
Added missing QueryStringCacheKeys property to CloudFront ForwardedValues

### DIFF
--- a/troposphere/cloudfront.py
+++ b/troposphere/cloudfront.py
@@ -19,6 +19,7 @@ class ForwardedValues(AWSProperty):
         'Cookies': (Cookies, False),
         'Headers': ([basestring], False),
         'QueryString': (boolean, True),
+        'QueryStringCacheKeys': ([basestring], False),
     }
 
 


### PR DESCRIPTION
Fix for issue #611 