### PR TITLE
Add a validator for ELB names

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -76,7 +76,8 @@ class TestValidators(unittest.TestCase):
     def test_elb_name(self):
         for b in ['a', 'a'*32, 'wick3d-elb-name', 'Wick3d-ELB-Name']:
             elb_name(b)
-        for b in ['a'*63, 'invalid_elb', '-invalid-elb', 'invalid-elb-', '-elb-']:
+        for b in ['a'*63, 'invalid_elb', '-invalid-elb',
+                  'invalid-elb-', '-elb-']:
             with self.assertRaises(ValueError):
                 elb_name(b)
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -4,7 +4,7 @@ from troposphere.validators import boolean, integer, integer_range
 from troposphere.validators import positive_integer, network_port
 from troposphere.validators import s3_bucket_name, encoding, status
 from troposphere.validators import iam_path, iam_names, iam_role_name
-from troposphere.validators import iam_group_name, iam_user_name
+from troposphere.validators import iam_group_name, iam_user_name, elb_name
 
 
 class TestValidators(unittest.TestCase):
@@ -72,6 +72,13 @@ class TestValidators(unittest.TestCase):
         for b in ['1.2.3.4', '11.22.33.44', '111.222.333.444']:
             with self.assertRaises(ValueError):
                 s3_bucket_name(b)
+
+    def test_elb_name(self):
+        for b in ['a', 'a'*32, 'wick3d-elb-name', 'Wick3d-ELB-Name']:
+            elb_name(b)
+        for b in ['a'*63, 'invalid_elb', '-invalid-elb', 'invalid-elb-', '-elb-']:
+            with self.assertRaises(ValueError):
+                elb_name(b)
 
     def test_encoding(self):
         for e in ['plain', 'base64']:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -74,10 +74,11 @@ class TestValidators(unittest.TestCase):
                 s3_bucket_name(b)
 
     def test_elb_name(self):
-        for b in ['a', 'a'*32, 'wick3d-elb-name', 'Wick3d-ELB-Name']:
+        for b in ['a', 'a-a', 'aaa', 'a'*32,
+                  'wick3d-elb-name', 'Wick3d-ELB-Name']:
             elb_name(b)
-        for b in ['a'*63, 'invalid_elb', '-invalid-elb',
-                  'invalid-elb-', '-elb-']:
+        for b in ['a'*33, 'invalid_elb', '-invalid-elb',
+                  'invalid-elb-', '-elb-', '-a', 'a-']:
             with self.assertRaises(ValueError):
                 elb_name(b)
 

--- a/troposphere/elasticloadbalancing.py
+++ b/troposphere/elasticloadbalancing.py
@@ -5,7 +5,7 @@
 
 from . import AWSObject, AWSProperty
 from .validators import (
-    boolean, integer_range, positive_integer, network_port, integer)
+    boolean, elb_name, integer_range, positive_integer, network_port, integer)
 
 
 class AppCookieStickinessPolicy(AWSProperty):
@@ -88,7 +88,7 @@ class LoadBalancer(AWSObject):
         'HealthCheck': (HealthCheck, False),
         'Instances': (list, False),
         'LBCookieStickinessPolicy': (list, False),
-        'LoadBalancerName': (basestring, False),
+        'LoadBalancerName': (elb_name, False),
         'Listeners': (list, True),
         'Policies': (list, False),
         'Scheme': (basestring, False),

--- a/troposphere/elasticloadbalancingv2.py
+++ b/troposphere/elasticloadbalancingv2.py
@@ -5,7 +5,7 @@
 
 from . import AWSObject, AWSProperty
 from .validators import (
-    network_port, integer)
+    elb_name, network_port, integer)
 
 
 class LoadBalancerAttributes(AWSProperty):
@@ -106,7 +106,7 @@ class LoadBalancer(AWSObject):
 
     props = {
         'LoadBalancerAttributes': ([LoadBalancerAttributes], False),
-        'Name': (basestring, False),
+        'Name': (elb_name, False),
         'Scheme': (basestring, False),
         'SecurityGroups': (list, False),
         'Subnets': (list, True),

--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -73,6 +73,14 @@ def s3_bucket_name(b):
         raise ValueError("%s is not a valid s3 bucket name" % b)
 
 
+def elb_name(b):
+    elb_name_re = compile(r'^[a-zA-Z0-9][a-zA-Z0-9\-]{0,30}[a-zA-Z0-9]{1}$')
+    if elb_name_re.match(b):
+        return b
+    else:
+        raise ValueError("%s is not a valid elb name" % b)
+
+
 def encoding(encoding):
     valid_encodings = ['plain', 'base64']
     if encoding not in valid_encodings:

--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -74,7 +74,7 @@ def s3_bucket_name(b):
 
 
 def elb_name(b):
-    elb_name_re = compile(r'^[a-zA-Z0-9][a-zA-Z0-9\-]{0,30}[a-zA-Z0-9]{1}$')
+    elb_name_re = compile(r'^[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,30}[a-zA-Z0-9]{1})?$')  # noqa
     if elb_name_re.match(b):
         return b
     else:


### PR DESCRIPTION
The LoadBalancerName has some constraints that we can validate for ahead of time:

> This name must be unique within your set of load balancers for the region, must have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, and cannot begin or end with a hyphen.

From: http://docs.aws.amazon.com/elasticloadbalancing/2012-06-01/APIReference/API_CreateLoadBalancer.html

My current implementation of the regex doesn't quite work.  A one character name ought to work but I have created a regex that will fail on names of one character.  I could use some help on it.