### PR TITLE
Allow environment variable feature 

### DIFF
--- a/troposphere/awslambda.py
+++ b/troposphere/awslambda.py
@@ -116,6 +116,7 @@ class Function(AWSObject):
     props = {
         'Code': (Code, True),
         'Description': (basestring, False),
+        'Environment': (dict, False),
         'FunctionName': (basestring, False),
         'Handler': (basestring, True),
         'MemorySize': (validate_memory_size, False),


### PR DESCRIPTION
AWS Just added Lambda environment variables
https://aws.amazon.com/about-aws/whats-new/2016/11/aws-cloudformation-supports-aws-serverless-application-model-aws-lambda-environment-variables-and-new-cli-commands/

Here is how it can be used in troposphere
```
Function(
            "FunctionWithEnvironment",
            Description="Lambda Environment feature is awesome",
            Code=Code(
                S3Bucket="s3_bucket_name",
                S3Key="key/file.zip",
            ),
            Environment={
                "Variables": {"ENV_NAME": "env_value"}
            },
            Handler="handler.index",
            Role=GetAtt(lambda_role, "Arn"),
            Runtime="python2.7",
            Timeout=10
        )
```

in lambda python code:
```
import os
print("ENV_NAME={}".format(os.environ.get('ENV_NAME')))
```