### PR TITLE
Added SNS::Subscription object

### DIFF
--- a/troposphere/sns.py
+++ b/troposphere/sns.py
@@ -18,7 +18,7 @@ class Subscription(AWSProperty):
     }
 
 
-class SubscriptionObject(AWSObject):
+class SubscriptionResource(AWSObject):
     resource_type = "AWS::SNS::Subscription"
 
     props = {

--- a/troposphere/sns.py
+++ b/troposphere/sns.py
@@ -18,6 +18,16 @@ class Subscription(AWSProperty):
     }
 
 
+class SubscriptionObject(AWSObject):
+    resource_type = "AWS::SNS::Subscription"
+
+    props = {
+        'Endpoint': (basestring, True),
+        'Protocol': (basestring, True),
+        'TopicArn': (basestring, True),
+    }
+
+
 class TopicPolicy(AWSObject):
     resource_type = "AWS::SNS::TopicPolicy"
 


### PR DESCRIPTION
Added an SNS subscription object, to allow us to create SNS
subscriptions as seperate objects, rather than just as properties
of an SNS topic.