### PR TITLE
Add back support for Python 2.6

### DIFF
--- a/troposphere/template_generator.py
+++ b/troposphere/template_generator.py
@@ -75,21 +75,27 @@ class TemplateGenerator(Template):
     def inspect_resources(self):
         """ Returns a map of `ResourceType: ResourceClass` """
         if not self._inspect_resources:
-            TemplateGenerator._inspect_resources = {
-                m.resource_type: m
-                for m in self.inspect_members
-                if issubclass(
-                    m, (AWSObject, cloudformation.AWSCustomObject)) and
-                hasattr(m, 'resource_type')}
+            d = {}
+            for m in self.inspect_members:
+                if issubclass(m, (AWSObject, cloudformation.AWSCustomObject)) \
+                        and hasattr(m, 'resource_type'):
+                    d[m.resource_type] = m
+
+            TemplateGenerator._inspect_resources = d
+
         return self._inspect_resources
 
     @property
     def inspect_functions(self):
         """ Returns a map of `FunctionName: FunctionClass` """
         if not self._inspect_functions:
-            TemplateGenerator._inspect_functions = {
-                m.__name__: m for m in self.inspect_members
-                if issubclass(m, AWSHelperFn)}
+            d = {}
+            for m in self.inspect_members:
+                if issubclass(m, AWSHelperFn):
+                    d[m.__name__] = m
+
+            TemplateGenerator._inspect_functions = d
+
         return self._inspect_functions
 
     def _convert_definition(self, definition, ref=None):
@@ -125,8 +131,10 @@ class TemplateGenerator(Template):
                         function_type, definition.values()[0])
 
             # nothing special here - return as dict
-            return {k: self._convert_definition(v)
-                    for k, v in definition.iteritems()}
+            d = {}
+            for k, v in definition.iteritems():
+                d[k] = self._convert_definition(v)
+            return d
 
         elif (isinstance(definition, Sequence) and
                 not isinstance(definition, basestring)):


### PR DESCRIPTION
The use of dictionary comprehension in #468 caused support for Python
2.6 to be dropped. This change converts these comprehensions to use
simple iteration.

See b8a6dae for a prior example of dictionary comprehensions breaking support. This fix was modeled after that commit. As per that commit the test suite does not run in Python 2.6, however I have tested that `pycodestyle .` and `pyflakes .` both pass when running using python2.6.6 and the unit tests pass when using 2.7.11.

Potentially Travis could be configured to run `pycodestyle` and `pyflakes` under python 2.6 to help with the "best effort" support so even if the unit tests can't run it'll help spot compilation errors but that's a discussion for another day.

(Oh I'm using python2.6 rather than upgrading because I'm still stuck on CentOS 6 for some things)