### PR TITLE
Fixed missing add_resource in example Cloudwatch rule

### DIFF
--- a/examples/CloudWatchEventsSample.py
+++ b/examples/CloudWatchEventsSample.py
@@ -35,7 +35,7 @@ foobar_target = Target(
 )
 
 # Create the Event Rule
-rule = Rule(
+rule = t.add_resource(Rule(
     "FoobarRule",
     EventPattern={
         "source": [
@@ -53,6 +53,6 @@ rule = Rule(
     Description="Foobar CloudWatch Event",
     State="ENABLED",
     Targets=[foobar_target]
-)
+))
 
 print(t.to_json())

--- a/tests/examples_output/CloudWatchEventsSample.template
+++ b/tests/examples_output/CloudWatchEventsSample.template
@@ -26,6 +26,37 @@
                 "Runtime": "nodejs"
             },
             "Type": "AWS::Lambda::Function"
+        },
+        "FoobarRule": {
+            "Properties": {
+                "Description": "Foobar CloudWatch Event",
+                "EventPattern": {
+                    "detail": {
+                        "state": [
+                            "stopping"
+                        ]
+                    },
+                    "detail-type": [
+                        "EC2 Instance State-change Notification"
+                    ],
+                    "source": [
+                        "aws.ec2"
+                    ]
+                },
+                "State": "ENABLED",
+                "Targets": [
+                    {
+                        "Arn": {
+                            "Fn::GetAtt": [
+                                "FoobarFunction",
+                                "Arn"
+                            ]
+                        },
+                        "Id": "FooBarFunction1"
+                    }
+                ]
+            },
+            "Type": "AWS::Events::Rule"
         }
     }
 }


### PR DESCRIPTION
In the example it was missing t.add_resource and therefore wasn't outputting the rule in the json.