### PR TITLE
Create new property Environment for aws lambda Function

### DIFF
--- a/troposphere/awslambda.py
+++ b/troposphere/awslambda.py
@@ -110,13 +110,20 @@ class EventSourceMapping(AWSObject):
     }
 
 
+class Environment(AWSProperty):
+
+    props = {
+        'Variables': (dict, True),
+    }
+
+
 class Function(AWSObject):
     resource_type = "AWS::Lambda::Function"
 
     props = {
         'Code': (Code, True),
         'Description': (basestring, False),
-        'Environment': (dict, False),
+        'Environment': (Environment, False),
         'FunctionName': (basestring, False),
         'Handler': (basestring, True),
         'KmsKeyArn': (basestring, False),


### PR DESCRIPTION
@markpeek - The `Environment` variable for a lambda `Function` is not just a dict, it has a specific format as defined here:

http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-environment.html

Discovered this after much head bashing.  I think this will improve usage of the code for others.