### PR TITLE
Adding RDS engine support for oracle-se2

### DIFF
--- a/troposphere/rds.py
+++ b/troposphere/rds.py
@@ -12,9 +12,10 @@ from .validators import boolean, network_port, integer, positive_integer
 # http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html
 
 VALID_STORAGE_TYPES = ('standard', 'gp2', 'io1')
-VALID_DB_ENGINES = ('MySQL', 'mysql', 'oracle-se1', 'oracle-se', 'oracle-ee',
-                    'sqlserver-ee', 'sqlserver-se', 'sqlserver-ex',
-                    'sqlserver-web', 'postgres', 'aurora', 'mariadb')
+VALID_DB_ENGINES = ('MySQL', 'mysql', 'oracle-se1', 'oracle-se2', 'oracle-se',
+                    'oracle-ee', 'sqlserver-ee', 'sqlserver-se',
+                    'sqlserver-ex', 'sqlserver-web', 'postgres', 'aurora',
+                    'mariadb')
 VALID_LICENSE_MODELS = ('license-included', 'bring-your-own-license',
                         'general-public-license', 'postgresql-license')
 


### PR DESCRIPTION
Currently troposphere doesn't support oracle-se2 as an engine choice. Added support & tested, working as expected.