### PR TITLE
Add Fn::Split function

### DIFF
--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -286,7 +286,8 @@ class AWSAttribute(BaseAWSObject):
 
 def validate_delimiter(delimiter):
     if not isinstance(delimiter, basestring):
-        raise ValueError("Delimiter must be a String, %s provided." % type(delimiter))
+        raise ValueError("Delimiter must be a String, %s provided " 
+            "% type(delimiter)")
 
 
 def validate_pausetime(pausetime):

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -394,6 +394,7 @@ class Not(AWSHelperFn):
 
 class Join(AWSHelperFn):
     def __init__(self, delimiter, values):
+        validate_delimiter(delimiter)
         self.data = {'Fn::Join': [delimiter, values]}
 
     def JSONrepr(self):

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -284,6 +284,11 @@ class AWSAttribute(BaseAWSObject):
         super(AWSAttribute, self).__init__(title, **kwargs)
 
 
+def validate_delimiter(delimiter):
+    if not isinstance(delimiter, basestring):
+        raise ValueError("Delimiter must be a String, %s provided." % type(delimiter))
+
+
 def validate_pausetime(pausetime):
     if not pausetime.startswith('PT'):
         raise ValueError('PauseTime should look like PT#H#M#S')
@@ -397,11 +402,11 @@ class Join(AWSHelperFn):
 
 class Split(AWSHelperFn):
     def __init__(self, delimiter, values):
+        validate_delimiter(delimiter)
         self.data = {'Fn::Split': [delimiter, values]}
 
     def JSONrepr(self):
         return self.data
-
 
 class Sub(AWSHelperFn):
     def __init__(self, input_str, **values):

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -409,6 +409,7 @@ class Split(AWSHelperFn):
     def JSONrepr(self):
         return self.data
 
+
 class Sub(AWSHelperFn):
     def __init__(self, input_str, **values):
         self.data = {'Fn::Sub': [input_str, values] if values else input_str}

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -395,6 +395,14 @@ class Join(AWSHelperFn):
         return self.data
 
 
+class Split(AWSHelperFn):
+    def __init__(self, delimiter, values):
+        self.data = {'Fn::Split': [delimiter, values]}
+
+    def JSONrepr(self):
+        return self.data
+
+
 class Sub(AWSHelperFn):
     def __init__(self, input_str, **values):
         self.data = {'Fn::Sub': [input_str, values] if values else input_str}

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -286,8 +286,9 @@ class AWSAttribute(BaseAWSObject):
 
 def validate_delimiter(delimiter):
     if not isinstance(delimiter, basestring):
-        raise ValueError("Delimiter must be a String, %s provided " 
-            "% type(delimiter)")
+        raise ValueError(
+            "Delimiter must be a String, %s provided" % type(delimiter)
+        )
 
 
 def validate_pausetime(pausetime):


### PR DESCRIPTION
This implements the Fn::Split function announced here:

https://aws.amazon.com/about-aws/whats-new/2017/01/aws-cloudformation-introduces-support-for-listing-imports-split-function-and-resource-coverage-updates/

I guess there should be a test case, but there isn't one for its partner Fn::Join, so perhaps I should create one for both?