### PR TITLE
Added to_dict() method to troposphere.Template

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,6 +1,5 @@
-import json
 import unittest
-from troposphere import awsencode, AWSObject, AWSProperty, Output, Parameter
+from troposphere import AWSObject, AWSProperty, Output, Parameter
 from troposphere import Join, Ref, Split, Sub, Template
 from troposphere.ec2 import Instance, SecurityGroupRule
 from troposphere.elasticloadbalancing import HealthCheck
@@ -146,13 +145,13 @@ class TestOutput(unittest.TestCase):
 
     def test_noproperty(self):
         t = Output("MyOutput", Value="myvalue")
-        d = json.loads(json.dumps(t, cls=awsencode))
+        d = t.to_dict()
         with self.assertRaises(KeyError):
             d['Properties']
 
     def test_empty_awsproperty_outputs_empty_object(self):
         t = FakeAWSProperty()
-        d = json.loads(json.dumps(t, cls=awsencode))
+        d = t.to_dict()
         self.assertEquals(len(d), 0)
 
 
@@ -160,7 +159,7 @@ class TestParameter(unittest.TestCase):
 
     def test_noproperty(self):
         t = Parameter("MyParameter", Type="String")
-        d = json.loads(json.dumps(t, cls=awsencode))
+        d = t.to_dict()
         with self.assertRaises(KeyError):
             d['Properties']
 
@@ -196,7 +195,7 @@ class TestProperty(unittest.TestCase):
             ToPort="22",
             CidrIp="0.0.0.0/0",
         )
-        d = json.loads(json.dumps(t, cls=awsencode))
+        d = t.to_dict()
         with self.assertRaises(KeyError):
             d['Properties']
 
@@ -237,7 +236,7 @@ class TestRef(unittest.TestCase):
     def test_ref(self):
         param = Parameter("param", Description="description", Type="String")
         t = Ref(param)
-        ref = json.loads(json.dumps(t, cls=awsencode))
+        ref = t.to_dict()
         self.assertEqual(ref['Ref'], 'param')
 
 
@@ -255,7 +254,7 @@ class TestSub(unittest.TestCase):
     def test_sub_with_vars(self):
         s = 'foo ${AWS::Region}'
         raw = Sub(s)
-        actual = json.loads(json.dumps(raw, cls=awsencode))
+        actual = raw.to_dict()
         expected = {'Fn::Sub': 'foo ${AWS::Region}'}
         self.assertEqual(expected, actual)
 
@@ -263,7 +262,7 @@ class TestSub(unittest.TestCase):
         s = 'foo ${AWS::Region} ${sub1} ${sub2}'
         values = {'sub1': 'uno', 'sub2': 'dos'}
         raw = Sub(s, **values)
-        actual = json.loads(json.dumps(raw, cls=awsencode))
+        actual = raw.to_dict()
         expected = {'Fn::Sub': ['foo ${AWS::Region} ${sub1} ${sub2}', values]}
         self.assertEqual(expected, actual)
 
@@ -275,7 +274,7 @@ class TestSplit(unittest.TestCase):
         source_string = ('{ "Fn::ImportValue": { "Fn::Sub": '
                          '"${VpcStack}-PublicSubnets" }')
         raw = Split(delimiter, source_string)
-        actual = json.loads(json.dumps(raw, cls=awsencode))
+        actual = raw.to_dict()
         expected = (
                 {'Fn::Split': [',', '{ "Fn::ImportValue": { '
                  '"Fn::Sub": "${VpcStack}-PublicSubnets" }']}
@@ -296,7 +295,7 @@ class TestJoin(unittest.TestCase):
                 '":function:cfnRedisEndpointLookup" ] }'
         )
         raw = Join(delimiter, source_string)
-        actual = json.loads(json.dumps(raw, cls=awsencode))
+        actual = raw.to_dict()
         expected = (
             {'Fn::Join': [',', '{ [ "arn:aws:lambda:",{ "Ref": '
                           '"AWS::Region" },":",{ "Ref": "AWS::AccountId" },'

--- a/tests/test_codecommit.py
+++ b/tests/test_codecommit.py
@@ -10,7 +10,7 @@ class TestCodeCommit(unittest.TestCase):
                 'all',
             ]
         )
-        trigger.JSONrepr()
+        trigger.to_dict()
 
         trigger = cc.Trigger(
             Events=[
@@ -19,7 +19,7 @@ class TestCodeCommit(unittest.TestCase):
                 'deleteReference',
             ]
         )
-        trigger.JSONrepr()
+        trigger.to_dict()
 
         trigger = cc.Trigger(
             Events=[
@@ -28,7 +28,7 @@ class TestCodeCommit(unittest.TestCase):
             ]
         )
         with self.assertRaisesRegexp(ValueError, "Trigger events: all"):
-            trigger.JSONrepr()
+            trigger.to_dict()
 
         trigger = cc.Trigger(
             Events=[
@@ -37,4 +37,4 @@ class TestCodeCommit(unittest.TestCase):
             ]
         )
         with self.assertRaisesRegexp(ValueError, "invalid event foobar"):
-            trigger.JSONrepr()
+            trigger.to_dict()

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -13,7 +13,7 @@ class TestEC2(unittest.TestCase):
             GroupId="id",
             CidrIp="0.0.0.0/0",
         )
-        egress.JSONrepr()
+        egress.to_dict()
 
         egress = ec2.SecurityGroupEgress(
             'egress',
@@ -23,7 +23,7 @@ class TestEC2(unittest.TestCase):
             GroupId="id",
             DestinationPrefixListId='id',
         )
-        egress.JSONrepr()
+        egress.to_dict()
 
         egress = ec2.SecurityGroupEgress(
             'egress',
@@ -33,7 +33,7 @@ class TestEC2(unittest.TestCase):
             GroupId="id",
             DestinationSecurityGroupId='id',
         )
-        egress.JSONrepr()
+        egress.to_dict()
 
         egress = ec2.SecurityGroupEgress(
             'egress',
@@ -46,7 +46,7 @@ class TestEC2(unittest.TestCase):
         )
 
         with self.assertRaises(ValueError):
-            egress.JSONrepr()
+            egress.to_dict()
         egress = ec2.SecurityGroupEgress(
             'egress',
             ToPort='80',
@@ -59,4 +59,4 @@ class TestEC2(unittest.TestCase):
         )
 
         with self.assertRaises(ValueError):
-            egress.JSONrepr()
+            egress.to_dict()

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -27,7 +27,7 @@ class TestECS(unittest.TestCase):
             TaskDefinition=Ref(task_definition),
         )
 
-        ecs_service.JSONrepr()
+        ecs_service.to_dict()
 
     def test_allow_ref_cluster(self):
         task_definition = ecs.TaskDefinition(
@@ -51,7 +51,7 @@ class TestECS(unittest.TestCase):
             TaskDefinition=Ref(task_definition),
         )
 
-        ecs_service.JSONrepr()
+        ecs_service.to_dict()
 
     def test_task_role_arn_is_optional(self):
         task_definition = ecs.TaskDefinition(
@@ -65,7 +65,7 @@ class TestECS(unittest.TestCase):
             ],
         )
 
-        task_definition.JSONrepr()
+        task_definition.to_dict()
 
     def test_allow_string_task_role_arn(self):
         task_definition = ecs.TaskDefinition(
@@ -80,7 +80,7 @@ class TestECS(unittest.TestCase):
             TaskRoleArn="myiamrole"
         )
 
-        task_definition.JSONrepr()
+        task_definition.to_dict()
 
     def test_allow_ref_task_role_arn(self):
         task_definition = ecs.TaskDefinition(
@@ -95,7 +95,7 @@ class TestECS(unittest.TestCase):
             TaskRoleArn=Ref(iam.Role("myRole"))
         )
 
-        task_definition.JSONrepr()
+        task_definition.to_dict()
 
     def test_allow_port_mapping_protocol(self):
         container_definition = ecs.ContainerDefinition(
@@ -109,7 +109,7 @@ class TestECS(unittest.TestCase):
             ]
         )
 
-        container_definition.JSONrepr()
+        container_definition.to_dict()
 
     def test_port_mapping_does_not_require_protocol(self):
         container_definition = ecs.ContainerDefinition(
@@ -123,4 +123,4 @@ class TestECS(unittest.TestCase):
             ]
         )
 
-        container_definition.JSONrepr()
+        container_definition.to_dict()

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -9,7 +9,7 @@ class TestLogs(unittest.TestCase):
             "LogGroupWithDeletionPolicy",
             DeletionPolicy=Retain
         )
-        self.assertIn('DeletionPolicy', log_group.JSONrepr())
+        self.assertIn('DeletionPolicy', log_group.to_dict())
 
     def test_log_destination(self):
         log_destination = Destination(
@@ -19,7 +19,7 @@ class TestLogs(unittest.TestCase):
             TargetArn='target-arn',
             DestinationPolicy='destination-policy'
         )
-        log_destination_json = log_destination.JSONrepr()
+        log_destination_json = log_destination.to_dict()
         self.assertIn('Type', log_destination_json)
         self.assertIn('Properties', log_destination_json)
 

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -1,7 +1,6 @@
-import json
 import unittest
 
-from troposphere import awsencode, Parameter, Ref
+from troposphere import Parameter, Ref
 from troposphere.autoscaling import AutoScalingGroup
 from troposphere.policies import CreationPolicy, ResourceSignal, UpdatePolicy
 from troposphere.policies import AutoScalingCreationPolicy
@@ -32,7 +31,7 @@ class TestCreationPolicy(unittest.TestCase):
                 Timeout='PT10M'
             )
         )
-        p = json.loads(json.dumps(policy, cls=awsencode))
+        p = policy.to_dict()
         self.assertEqual(p['ResourceSignal']['Count'], 2)
         self.assertEqual(p['ResourceSignal']['Timeout'], 'PT10M')
 
@@ -61,7 +60,7 @@ class TestCreationPolicy(unittest.TestCase):
                 Timeout='PT10M'
             )
         )
-        p = json.loads(json.dumps(policy, cls=awsencode))
+        p = policy.to_dict()
         self.assertEqual(
             p['AutoScalingCreationPolicy']['MinSuccessfulInstancesPercent'],
             50
@@ -154,7 +153,7 @@ class TestUpdatePolicy(unittest.TestCase):
                 MinInstancesInService=1,
                 PauseTime='PT90S',
                 WaitOnResourceSignals=True))
-        p = json.loads(json.dumps(p, cls=awsencode))
+        p = p.to_dict()
         self.assertEqual(p['AutoScalingRollingUpdate']['MaxBatchSize'], 2)
         self.assertEqual(
             p['AutoScalingRollingUpdate']['MinInstancesInService'], 1

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -16,7 +16,7 @@ class TestRDS(unittest.TestCase):
             DBSnapshotIdentifier='SomeSnapshotIdentifier'
         )
 
-        rds_instance.JSONrepr()
+        rds_instance.to_dict()
 
     def test_it_allows_an_rds_instance_with_master_username_and_password(self):
         rds_instance = rds.DBInstance(
@@ -28,7 +28,7 @@ class TestRDS(unittest.TestCase):
             MasterUserPassword='SomePassword'
         )
 
-        rds_instance.JSONrepr()
+        rds_instance.to_dict()
 
     def test_it_rds_instances_require_either_a_snapshot_or_credentials(self):
         rds_instance = rds.DBInstance(
@@ -43,7 +43,7 @@ class TestRDS(unittest.TestCase):
                 'Either \(MasterUsername and MasterUserPassword\) or'
                 ' DBSnapshotIdentifier are required'
                 ):
-            rds_instance.JSONrepr()
+            rds_instance.to_dict()
 
     def test_it_allows_an_rds_replica(self):
         rds_instance = rds.DBInstance(
@@ -54,7 +54,7 @@ class TestRDS(unittest.TestCase):
             SourceDBInstanceIdentifier='SomeSourceDBInstanceIdentifier'
         )
 
-        rds_instance.JSONrepr()
+        rds_instance.to_dict()
 
     def test_replica_settings_are_inherited(self):
         rds_instance = rds.DBInstance(
@@ -81,7 +81,7 @@ class TestRDS(unittest.TestCase):
                 'SourceDBInstanceIdentifier is present '
                 'AWS::RDS::DBInstance.'
                 ):
-            rds_instance.JSONrepr()
+            rds_instance.to_dict()
 
     def test_it_rds_instances_require_encryption_if_kms_key_provided(self):
         rds_instance = rds.DBInstance(
@@ -99,7 +99,7 @@ class TestRDS(unittest.TestCase):
                 ValueError,
                 'If KmsKeyId is provided, StorageEncrypted is required'
                 ):
-            rds_instance.JSONrepr()
+            rds_instance.to_dict()
 
     def test_it_allows_an_rds_instance_with_iops(self):
         # ensure troposphere works with longs and ints
@@ -119,7 +119,7 @@ class TestRDS(unittest.TestCase):
             Iops=long_number,
         )
 
-        rds_instance.JSONrepr()
+        rds_instance.to_dict()
 
     def test_optiongroup(self):
         rds_optiongroup = rds.OptionGroup(
@@ -138,7 +138,7 @@ class TestRDS(unittest.TestCase):
                 ),
             ]
         )
-        rds_optiongroup.JSONrepr()
+        rds_optiongroup.to_dict()
 
     def test_fail_az_and_multiaz(self):
         i = rds.DBInstance(
@@ -151,15 +151,15 @@ class TestRDS(unittest.TestCase):
             AvailabilityZone="us-east-1",
             MultiAZ=True)
         with self.assertRaisesRegexp(ValueError, "if MultiAZ is set to "):
-            i.JSONrepr()
+            i.to_dict()
         i.MultiAZ = "false"
-        i.JSONrepr()
+        i.to_dict()
         i.MultiAZ = "true"
         with self.assertRaisesRegexp(ValueError, "if MultiAZ is set to "):
-            i.JSONrepr()
+            i.to_dict()
 
         i.MultiAZ = Ref(AWS_NO_VALUE)
-        i.JSONrepr()
+        i.to_dict()
 
     def test_az_and_multiaz_funcs(self):
         db_az = "us-east-1"
@@ -187,7 +187,7 @@ class TestRDS(unittest.TestCase):
             StorageType='io1')
         with self.assertRaisesRegexp(ValueError,
                                      "Must specify Iops if "):
-            i.JSONrepr()
+            i.to_dict()
 
     def test_storage_to_iops_ratio(self):
         i = rds.DBInstance(
@@ -201,15 +201,15 @@ class TestRDS(unittest.TestCase):
             AllocatedStorage=10)
         with self.assertRaisesRegexp(ValueError,
                                      " must be at least 100 "):
-            i.JSONrepr()
+            i.to_dict()
 
         i.AllocatedStorage = 100
         with self.assertRaisesRegexp(ValueError,
                                      " must be no less than 1/10th "):
-            i.JSONrepr()
+            i.to_dict()
 
         i.AllocatedStorage = 400
-        i.JSONrepr()
+        i.to_dict()
 
     def test_snapshot(self):
         i = rds.DBInstance(
@@ -220,7 +220,7 @@ class TestRDS(unittest.TestCase):
             DBSubnetGroupName='default',
             DBSnapshotIdentifier='id',
         )
-        i.JSONrepr()
+        i.to_dict()
 
     def test_snapshot_and_engine(self):
         i = rds.DBInstance(
@@ -232,7 +232,7 @@ class TestRDS(unittest.TestCase):
             DBSnapshotIdentifier='id',
             Engine="postgres",
         )
-        i.JSONrepr()
+        i.to_dict()
 
     def test_no_snapshot_or_engine(self):
         i = rds.DBInstance(
@@ -244,7 +244,7 @@ class TestRDS(unittest.TestCase):
         )
         with self.assertRaisesRegexp(ValueError,
                                      "Resource Engine is required"):
-            i.JSONrepr()
+            i.to_dict()
 
 
 class TestRDSValidators(unittest.TestCase):

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -13,7 +13,7 @@ class TestTags(unittest.TestCase):
             {'Value': 'bar', 'Key': 'bar'},
             {'Value': 'baz', 'Key': 'baz'},
         ]
-        self.assertEqual(tags.JSONrepr(), result)
+        self.assertEqual(tags.to_dict(), result)
 
     def test_ASTagAddition(self):
         tags = ASTags(foo=('fooval', True))
@@ -24,7 +24,7 @@ class TestTags(unittest.TestCase):
             {'Value': 'barval', 'Key': 'bar', 'PropagateAtLaunch': 'false'},
             {'Value': 'bazval', 'Key': 'baz', 'PropagateAtLaunch': 'true'},
         ]
-        self.assertEqual(tags.JSONrepr(), result)
+        self.assertEqual(tags.to_dict(), result)
 
 
 if __name__ == '__main__':

--- a/tests/test_userdata.py
+++ b/tests/test_userdata.py
@@ -2,9 +2,8 @@
 # -*- coding: utf-8 -*-
 
 import unittest
-import json
 import os
-from troposphere import Base64, Join, awsencode
+from troposphere import Base64, Join
 import troposphere.ec2 as ec2
 from troposphere.helpers import userdata
 
@@ -19,11 +18,10 @@ class TestUserdata(unittest.TestCase):
     def create_result(self, file, delimiter=""):
         file = os.path.join(self.filepath, file)
         self.instance.UserData = userdata.from_file(file, delimiter)
-        return json.dumps(self.instance.UserData, cls=awsencode)
+        return self.instance.UserData.to_dict()
 
     def create_answer(self, command_list, delimiter=""):
-        return json.dumps(Base64(Join(delimiter, command_list)),
-                          cls=awsencode)
+        return Base64(Join(delimiter, command_list)).to_dict()
 
     def test_simple(self):
         result = self.create_result('simple.sh')

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -45,6 +45,29 @@ def is_aws_object_subclass(cls):
     return is_aws_object
 
 
+def encode_to_dict(obj):
+    if hasattr(obj, 'to_dict'):
+        # Calling encode_to_dict to ensure object is
+        # nomalized to a base dictionary all the way down.
+        return encode_to_dict(obj.to_dict())
+    elif isinstance(obj, (list, tuple)):
+        new_lst = []
+        for o in list(obj):
+            new_lst.append(encode_to_dict(o))
+        return new_lst
+    elif isinstance(obj, dict):
+        props = {}
+        for name, prop in obj.items():
+            props[name] = encode_to_dict(prop)
+
+        return props
+    # This is useful when dealing with external libs using
+    # this format. Specifically awacs.
+    elif hasattr(obj, 'JSONrepr'):
+        return encode_to_dict(obj.JSONrepr())
+    return obj
+
+
 class BaseAWSObject(object):
     def __init__(self, title, template=None, **kwargs):
         self.title = title
@@ -177,6 +200,21 @@ class BaseAWSObject(object):
     def validate(self):
         pass
 
+    def to_dict(self):
+        self._validate_props()
+        self.validate()
+
+        if self.properties:
+            return encode_to_dict(self.resource)
+        elif hasattr(self, 'resource_type'):
+            d = {}
+            for k, v in self.resource.items():
+                if k != 'Properties':
+                    d[k] = v
+            return d
+        else:
+            return {}
+
     @classmethod
     def _from_dict(cls, title=None, **kwargs):
         props = {}
@@ -220,7 +258,7 @@ class BaseAWSObject(object):
     def from_dict(cls, title, d):
         return cls._from_dict(title, **d)
 
-    def JSONrepr(self):
+    def _validate_props(self):
         for k, (_, required) in self.props.items():
             if required and k not in self.properties:
                 rtype = getattr(self, 'resource_type', "<unknown type>")
@@ -229,19 +267,6 @@ class BaseAWSObject(object):
                 if title:
                     msg += " (title: %s)" % title
                 raise ValueError(msg)
-
-        self.validate()
-        # Mainly used to not have an empty "Properties".
-        if self.properties:
-            return self.resource
-        elif hasattr(self, 'resource_type'):
-            d = {}
-            for k, v in self.resource.items():
-                if k != 'Properties':
-                    d[k] = v
-            return d
-        else:
-            return {}
 
 
 class AWSObject(BaseAWSObject):
@@ -312,86 +337,62 @@ class AWSHelperFn(object):
         else:
             return data
 
+    def to_dict(self):
+        return encode_to_dict(self.data)
+
 
 class GenericHelperFn(AWSHelperFn):
     """ Used as a fallback for the template generator """
     def __init__(self, data):
         self.data = self.getdata(data)
 
-    def JSONrepr(self):
-        return self.data
+    def to_dict(self):
+        return encode_to_dict(self.data)
 
 
 class Base64(AWSHelperFn):
     def __init__(self, data):
         self.data = {'Fn::Base64': data}
 
-    def JSONrepr(self):
-        return self.data
-
 
 class FindInMap(AWSHelperFn):
     def __init__(self, mapname, key, value):
         self.data = {'Fn::FindInMap': [self.getdata(mapname), key, value]}
-
-    def JSONrepr(self):
-        return self.data
 
 
 class GetAtt(AWSHelperFn):
     def __init__(self, logicalName, attrName):
         self.data = {'Fn::GetAtt': [self.getdata(logicalName), attrName]}
 
-    def JSONrepr(self):
-        return self.data
-
 
 class GetAZs(AWSHelperFn):
     def __init__(self, region=""):
         self.data = {'Fn::GetAZs': region}
-
-    def JSONrepr(self):
-        return self.data
 
 
 class If(AWSHelperFn):
     def __init__(self, cond, true, false):
         self.data = {'Fn::If': [self.getdata(cond), true, false]}
 
-    def JSONrepr(self):
-        return self.data
-
 
 class Equals(AWSHelperFn):
     def __init__(self, value_one, value_two):
         self.data = {'Fn::Equals': [value_one, value_two]}
-
-    def JSONrepr(self):
-        return self.data
 
 
 class And(AWSHelperFn):
     def __init__(self, cond_one, cond_two, *conds):
         self.data = {'Fn::And': [cond_one, cond_two] + list(conds)}
 
-    def JSONrepr(self):
-        return self.data
-
 
 class Or(AWSHelperFn):
     def __init__(self, cond_one, cond_two, *conds):
         self.data = {'Fn::Or': [cond_one, cond_two] + list(conds)}
 
-    def JSONrepr(self):
-        return self.data
-
 
 class Not(AWSHelperFn):
     def __init__(self, cond):
         self.data = {'Fn::Not': [self.getdata(cond)]}
-
-    def JSONrepr(self):
-        return self.data
 
 
 class Join(AWSHelperFn):
@@ -399,72 +400,41 @@ class Join(AWSHelperFn):
         validate_delimiter(delimiter)
         self.data = {'Fn::Join': [delimiter, values]}
 
-    def JSONrepr(self):
-        return self.data
-
 
 class Split(AWSHelperFn):
     def __init__(self, delimiter, values):
         validate_delimiter(delimiter)
         self.data = {'Fn::Split': [delimiter, values]}
 
-    def JSONrepr(self):
-        return self.data
-
 
 class Sub(AWSHelperFn):
     def __init__(self, input_str, **values):
         self.data = {'Fn::Sub': [input_str, values] if values else input_str}
-
-    def JSONrepr(self):
-        return self.data
 
 
 class Name(AWSHelperFn):
     def __init__(self, data):
         self.data = self.getdata(data)
 
-    def JSONrepr(self):
-        return self.data
-
 
 class Select(AWSHelperFn):
     def __init__(self, indx, objects):
         self.data = {'Fn::Select': [indx, objects]}
-
-    def JSONrepr(self):
-        return self.data
 
 
 class Ref(AWSHelperFn):
     def __init__(self, data):
         self.data = {'Ref': self.getdata(data)}
 
-    def JSONrepr(self):
-        return self.data
-
 
 class Condition(AWSHelperFn):
     def __init__(self, data):
         self.data = {'Condition': self.getdata(data)}
 
-    def JSONrepr(self):
-        return self.data
-
 
 class ImportValue(AWSHelperFn):
     def __init__(self, data):
         self.data = {'Fn::ImportValue': data}
-
-    def JSONrepr(self):
-        return self.data
-
-
-class awsencode(json.JSONEncoder):
-    def default(self, obj):
-        if hasattr(obj, 'JSONrepr'):
-            return obj.JSONrepr()
-        return json.JSONEncoder.default(self, obj)
 
 
 class Tags(AWSHelperFn):
@@ -481,8 +451,8 @@ class Tags(AWSHelperFn):
         newtags.tags = self.tags + newtags.tags
         return newtags
 
-    def JSONrepr(self):
-        return self.tags
+    def to_dict(self):
+        return [encode_to_dict(tag) for tag in self.tags]
 
 
 class Template(object):
@@ -555,7 +525,7 @@ class Template(object):
         else:
             self.version = "2010-09-09"
 
-    def to_json(self, indent=4, sort_keys=True, separators=(',', ': ')):
+    def to_dict(self):
         t = {}
         if self.description:
             t['Description'] = self.description
@@ -573,11 +543,11 @@ class Template(object):
             t['AWSTemplateFormatVersion'] = self.version
         t['Resources'] = self.resources
 
-        return json.dumps(t, cls=awsencode, indent=indent,
-                          sort_keys=sort_keys, separators=separators)
+        return encode_to_dict(t)
 
-    def JSONrepr(self):
-        return [self.parameters, self.mappings, self.resources]
+    def to_json(self, indent=4, sort_keys=True, separators=(',', ': ')):
+        return json.dumps(self.to_dict(), indent=indent,
+                          sort_keys=sort_keys, separators=separators)
 
 
 class Export(AWSHelperFn):
@@ -585,9 +555,6 @@ class Export(AWSHelperFn):
         self.data = {
             'Name': name,
         }
-
-    def JSONrepr(self):
-        return self.data
 
 
 class Output(AWSDeclaration):

--- a/troposphere/autoscaling.py
+++ b/troposphere/autoscaling.py
@@ -30,9 +30,6 @@ class Tag(AWSHelperFn):
             'PropagateAtLaunch': propogate,
         }
 
-    def JSONrepr(self):
-        return self.data
-
 
 class Tags(AWSHelperFn):
     defaultPropagateAtLaunch = True
@@ -57,7 +54,7 @@ class Tags(AWSHelperFn):
         newtags.tags = self.tags + newtags.tags
         return newtags
 
-    def JSONrepr(self):
+    def to_dict(self):
         return self.tags
 
 
@@ -103,9 +100,6 @@ class Metadata(AWSHelperFn):
             raise ValueError(
                 'authentication must be of type cloudformation.Authentication'
             )
-
-    def JSONrepr(self):
-        return self.data
 
 
 class AutoScalingGroup(AWSObject):

--- a/troposphere/cloudformation.py
+++ b/troposphere/cloudformation.py
@@ -4,6 +4,7 @@
 # See LICENSE file for full license.
 
 from . import AWSHelperFn, AWSObject, AWSProperty, BaseAWSObject
+from . import encode_to_dict
 from .validators import integer, boolean, encoding
 
 
@@ -51,19 +52,16 @@ class Metadata(AWSHelperFn):
     def __init__(self, *args):
         self.data = args
 
-    def JSONrepr(self):
+    def to_dict(self):
         t = []
         for i in self.data:
-            t += i.JSONrepr().items()
+            t += encode_to_dict(i).items()
         return dict(t)
 
 
 class InitFileContext(AWSHelperFn):
     def __init__(self, data):
         self.data = data
-
-    def JSONrepr(self):
-        return self.data
 
 
 class InitFile(AWSProperty):
@@ -89,9 +87,6 @@ class InitFiles(AWSHelperFn):
             if not isinstance(data[k], InitFile):
                 raise ValueError("File '" + k + "' must be of type InitFile")
 
-    def JSONrepr(self):
-        return self.data
-
 
 class InitService(AWSProperty):
     props = {
@@ -116,9 +111,6 @@ class InitServices(AWSHelperFn):
                     "Service '" + k + "' must be of type InitService"
                 )
 
-    def JSONrepr(self):
-        return self.data
-
 
 class InitConfigSets(AWSHelperFn):
     def __init__(self, **kwargs):
@@ -129,9 +121,6 @@ class InitConfigSets(AWSHelperFn):
         for k, v in config_sets.iteritems():
             if not isinstance(v, list):
                 raise ValueError('configSets values must be of type list')
-
-    def JSONrepr(self):
-        return self.data
 
 
 class InitConfig(AWSProperty):
@@ -179,9 +168,6 @@ class Authentication(AWSHelperFn):
                     ' cloudformation.AuthenticationBlock'
                 )
 
-    def JSONrepr(self):
-        return self.data
-
 
 class Init(AWSHelperFn):
     def __init__(self, data, **kwargs):
@@ -210,6 +196,3 @@ class Init(AWSHelperFn):
                 raise ValueError(
                     'config property must be of type cloudformation.InitConfig'
                 )
-
-    def JSONrepr(self):
-        return self.data

--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -137,9 +137,6 @@ class Ipv6Addresses(AWSHelperFn):
             'Ipv6Addresses': address,
         }
 
-    def JSONrepr(self):
-        return self.data
-
 
 class PrivateIpAddressSpecification(AWSProperty):
     props = {


### PR DESCRIPTION
This removes the JSONrepr methods and replaces with to_dict() which
handle creating dicts for each of the individual objects. The to_json()
method then just calls to_dict() on self and marshals the resulting
dictionary. Adding to_dict() allows for output into other formats such
as YAML without needing to output JSON and then reload it back just to
output in another format.

This can be considered a breaking change if others are calling JSONrepr. If needed I can re-add the JSONrepr functionality back to make this backwards compatible.