### PR TITLE
Spot fleet's IamInstanceProfile has a name property

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -594,6 +594,7 @@ class SecurityGroups(AWSProperty):
 class IamInstanceProfile(AWSProperty):
     props = {
         'Arn': (basestring, False),
+        'Name': (basestring, False),
     }
 
 


### PR DESCRIPTION
See http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IamInstanceProfileSpecification.html. It would make life easier for me to have this property available in troposphere.