### PR TITLE
alb example that showcases autoscaling groups and route53 a aliases

### DIFF
--- a/examples/ALB_Autoscaling_Route53_A_Alias_Sample.py
+++ b/examples/ALB_Autoscaling_Route53_A_Alias_Sample.py
@@ -1,21 +1,33 @@
-from troposphere import Base64, Join, Parameter, Ref, Template, Output, FindInMap, GetAtt, Select, Export, Sub
+from troposphere import Base64, \
+    Join, \
+    Parameter, \
+    Ref, \
+    Template, \
+    Output, \
+    FindInMap, \
+    GetAtt, \
+    Select, \
+    Export, \
+    Sub
 import troposphere.autoscaling as autoscaling
 import troposphere.elasticloadbalancingv2 as elb
 import troposphere.route53 as route53
 
 t = Template()
 
+
 # Windows server 2016 Base
 def AddAMI(template):
-     t.add_mapping("windowsAMI", {
-         "us-east-1": {"AMI": "ami-b06249a7"},
-         "us-east-2": {"AMI": "ami-20683245"},
-         "us-west-1": {"AMI": "ami-d3a8fdb3"},
-         "us-west-2": {"AMI": "ami-b9b71ad9"},
-         "eu-west-1": {"AMI": "ami-32792a41"},
-         "eu-west-2": {"AMI": "ami-29353f4d"},
-         "eu-central-1": {"AMI": "ami-c0f237af"}
-     })
+    t.add_mapping("windowsAMI", {
+        "us-east-1": {"AMI": "ami-b06249a7"},
+        "us-east-2": {"AMI": "ami-20683245"},
+        "us-west-1": {"AMI": "ami-d3a8fdb3"},
+        "us-west-2": {"AMI": "ami-b9b71ad9"},
+        "eu-west-1": {"AMI": "ami-32792a41"},
+        "eu-west-2": {"AMI": "ami-29353f4d"},
+        "eu-central-1": {"AMI": "ami-c0f237af"}
+    })
+
 
 def main():
     # Meta
@@ -43,7 +55,7 @@ def main():
                     {
                         "Label": {"default": "Global parameters"},
                         "Parameters": ["environment"]
-                     },
+                    },
                     {
                         "Label": {"default": "Application Loadbalancer"},
                         "Parameters": ["albSubnets", "loadbalancerPrefix", "loadBalancerArn", "albPaths", "albPort", ]
@@ -66,9 +78,9 @@ def main():
                     }
 
                 ]
-             }
-         }
-     )
+            }
+        }
+    )
 
     AddAMI(t)
 
@@ -299,8 +311,8 @@ def main():
         )
     )
 
-
     print(t.to_json())
+
 
 if __name__ == '__main__':
     main()

--- a/examples/ALB_Autoscaling_Route53_A_Alias_Sample.py
+++ b/examples/ALB_Autoscaling_Route53_A_Alias_Sample.py
@@ -1,4 +1,4 @@
-from troposphere import Base64, Join, Parameter, Ref, Template
+from troposphere import Join, Parameter, Ref, Template
 from troposphere import Output, FindInMap, GetAtt
 from troposphere import Select, Export, Sub
 import troposphere.autoscaling as autoscaling
@@ -245,7 +245,7 @@ def main():
     ))
 
     # Auto scaling group
-    auto_scaling_group = t.add_resource(autoscaling.AutoScalingGroup(
+    t.add_resource(autoscaling.AutoScalingGroup(
         "autoScalingGroup",
         DesiredCapacity=Ref(asg_capacity),
         Tags=autoscaling.Tags(
@@ -279,7 +279,7 @@ def main():
             TargetGroupArn=Ref(alb_target_group)
         )]
     ))
-    alb_listener_rule = t.add_resource(elb.ListenerRule(
+    t.add_resource(elb.ListenerRule(
         "albListenerRule",
         ListenerArn=Ref(alb_listener),
         Conditions=[elb.Condition(
@@ -294,7 +294,7 @@ def main():
     ))
 
     # Route53
-    route53_roundrobin = t.add_resource(route53.RecordSetGroup(
+    t.add_resource(route53.RecordSetGroup(
         "route53RoundRobin",
         HostedZoneId=Ref(route53_hosted_zone_id),
         RecordSets=[

--- a/examples/ALB_Autoscaling_Route53_A_Alias_Sample.py
+++ b/examples/ALB_Autoscaling_Route53_A_Alias_Sample.py
@@ -217,7 +217,7 @@ def main():
     ))
 
     # Launchconfiguration
-    EC2LaunchConfiguration = t.add_resource(autoscaling.LaunchConfiguration(
+    ec2_launchconfiguration = t.add_resource(autoscaling.LaunchConfiguration(
         "EC2LaunchConfiguration",
         ImageId=FindInMap("windowsAMI", Ref("AWS::Region"), "AMI"),
         KeyName=Ref(ec2_key),
@@ -256,7 +256,7 @@ def main():
         MinSize=Ref(asg_min_size),
         MaxSize=Ref(asg_max_size),
         Cooldown=Ref(asg_cooldown),
-        LaunchConfigurationName=Ref(EC2LaunchConfiguration),
+        LaunchConfigurationName=Ref(ec2_launchconfiguration),
         HealthCheckGracePeriod=Ref(asg_health_grace),
         HealthCheckType="EC2",
     ))

--- a/examples/ALB_Autoscaling_Route53_A_Alias_Sample.py
+++ b/examples/ALB_Autoscaling_Route53_A_Alias_Sample.py
@@ -1,14 +1,6 @@
-from troposphere import Base64, \
-    Join, \
-    Parameter, \
-    Ref, \
-    Template, \
-    Output, \
-    FindInMap, \
-    GetAtt, \
-    Select, \
-    Export, \
-    Sub
+from troposphere import Base64, Join, Parameter, Ref, Template
+from troposphere import Output, FindInMap, GetAtt
+from troposphere import Select, Export, Sub
 import troposphere.autoscaling as autoscaling
 import troposphere.elasticloadbalancingv2 as elb
 import troposphere.route53 as route53

--- a/examples/ALB_Autoscaling_Route53_A_Alias_Sample.py
+++ b/examples/ALB_Autoscaling_Route53_A_Alias_Sample.py
@@ -32,13 +32,15 @@ def AddAMI(template):
 def main():
     # Meta
     t.add_version("2010-09-09")
-    t.add_description("Template for auto-scaling in an Application load balancer target group. "
+    t.add_description("Template for auto-scaling in an Application"
+                      "load balancer target group. "
                       "The ALB will be used as an A Alias target "
                       "for a specified Route53 hosted zone. "
-                      "This template also showcases Metadata Parameter Grouping, "
+                      "This template also showcases "
+                      "Metadata Parameter Grouping, "
                       "Special AWS Parameter Types, "
-                      "and Cloudformation Outputs with Exports which can be imported into "
-                      "other templates."
+                      "and Cloudformation Outputs with Exports"
+                      "which can be imported into other templates."
 
                       )
     t.add_metadata({
@@ -58,23 +60,41 @@ def main():
                     },
                     {
                         "Label": {"default": "Application Loadbalancer"},
-                        "Parameters": ["albSubnets", "loadbalancerPrefix", "loadBalancerArn", "albPaths", "albPort", ]
+                        "Parameters": ["albSubnets",
+                                       "loadbalancerPrefix",
+                                       "loadBalancerArn",
+                                       "albPaths",
+                                       "albPort"
+                                       ]
                     },
                     {
                         "Label": {"default": "VPC"},
-                        "Parameters": ["ec2Subnets", "VPC", "securityGroup"]
+                        "Parameters": ["ec2Subnets",
+                                       "VPC",
+                                       "securityGroup"
+                                       ]
                     },
                     {
                         "Label": {"default": "EC2"},
-                        "Parameters": ["ec2Name", "ec2Type", "ec2Key"]
+                        "Parameters": ["ec2Name",
+                                       "ec2Type",
+                                       "ec2Key"
+                                       ]
                     },
                     {
                         "Label": {"default": "Auto-scaling"},
-                        "Parameters": ["asgCapacity", "asgMinSize", "asgMaxSize", "asgCooldown", "asgHealthGrace"]
+                        "Parameters": ["asgCapacity",
+                                       "asgMinSize",
+                                       "asgMaxSize",
+                                       "asgCooldown",
+                                       "asgHealthGrace"
+                                       ]
                     },
                     {
                         "Label": {"default": "Route53"},
-                        "Parameters": ["route53HostedZoneId", "route53HostedZoneName"]
+                        "Parameters": ["route53HostedZoneId",
+                                       "route53HostedZoneName"
+                                       ]
                     }
 
                 ]
@@ -118,7 +138,8 @@ def main():
         "albPaths",
         Default="/",
         Type="CommaDelimitedList",
-        Description="Path-patterns you want the loadbalancer to point to in your application"
+        Description="Path-patterns you want the loadbalancer to point to in "
+                    "your application"
     ))
     albPort = t.add_parameter(Parameter(
         "albPort",
@@ -287,12 +308,17 @@ def main():
         RecordSets=[
             route53.RecordSet(
                 Weight=1,
-                SetIdentifier=Join(".", [Ref(environment), Ref(route53_hosted_zone_name), "ELB"]),
-                Name=Join(".", [Ref(environment), Ref(route53_hosted_zone_name)]),
+                SetIdentifier=Join(".", [Ref(environment),
+                                         Ref(route53_hosted_zone_name),
+                                         "ELB"]),
+                Name=Join(".", [Ref(environment),
+                                Ref(route53_hosted_zone_name)]),
                 Type="A",
                 AliasTarget=route53.AliasTarget(
-                    GetAtt(application_load_balancer, "CanonicalHostedZoneID"),
-                    GetAtt(application_load_balancer, "DNSName")
+                    GetAtt(application_load_balancer,
+                           "CanonicalHostedZoneID"),
+                    GetAtt(application_load_balancer,
+                           "DNSName")
                 )
             )
         ]

--- a/examples/ALB_Autoscaling_Route53_A_Alias_Sample.py
+++ b/examples/ALB_Autoscaling_Route53_A_Alias_Sample.py
@@ -1,0 +1,306 @@
+from troposphere import Base64, Join, Parameter, Ref, Template, Output, FindInMap, GetAtt, Select, Export, Sub
+import troposphere.autoscaling as autoscaling
+import troposphere.elasticloadbalancingv2 as elb
+import troposphere.route53 as route53
+
+t = Template()
+
+# Windows server 2016 Base
+def AddAMI(template):
+     t.add_mapping("windowsAMI", {
+         "us-east-1": {"AMI": "ami-b06249a7"},
+         "us-east-2": {"AMI": "ami-20683245"},
+         "us-west-1": {"AMI": "ami-d3a8fdb3"},
+         "us-west-2": {"AMI": "ami-b9b71ad9"},
+         "eu-west-1": {"AMI": "ami-32792a41"},
+         "eu-west-2": {"AMI": "ami-29353f4d"},
+         "eu-central-1": {"AMI": "ami-c0f237af"}
+     })
+
+def main():
+    # Meta
+    t.add_version("2010-09-09")
+    t.add_description("Template for auto-scaling in an Application load balancer target group. "
+                      "The ALB will be used as an A Alias target "
+                      "for a specified Route53 hosted zone. "
+                      "This template also showcases Metadata Parameter Grouping, "
+                      "Special AWS Parameter Types, "
+                      "and Cloudformation Outputs with Exports which can be imported into "
+                      "other templates."
+
+                      )
+    t.add_metadata({
+        "Author": "https://github.com/hmain/",
+        "LastUpdated": "2017 01 31",
+        "Version": "1",
+    })
+
+    # Parameter grouping
+    t.add_metadata(
+        {
+            "AWS::CloudFormation::Interface": {
+                "ParameterGroups": [
+                    {
+                        "Label": {"default": "Global parameters"},
+                        "Parameters": ["environment"]
+                     },
+                    {
+                        "Label": {"default": "Application Loadbalancer"},
+                        "Parameters": ["albSubnets", "loadbalancerPrefix", "loadBalancerArn", "albPaths", "albPort", ]
+                    },
+                    {
+                        "Label": {"default": "VPC"},
+                        "Parameters": ["ec2Subnets", "VPC", "securityGroup"]
+                    },
+                    {
+                        "Label": {"default": "EC2"},
+                        "Parameters": ["ec2Name", "ec2Type", "ec2Key"]
+                    },
+                    {
+                        "Label": {"default": "Auto-scaling"},
+                        "Parameters": ["asgCapacity", "asgMinSize", "asgMaxSize", "asgCooldown", "asgHealthGrace"]
+                    },
+                    {
+                        "Label": {"default": "Route53"},
+                        "Parameters": ["route53HostedZoneId", "route53HostedZoneName"]
+                    }
+
+                ]
+             }
+         }
+     )
+
+    AddAMI(t)
+
+    environment = t.add_parameter(Parameter(
+        "environment",
+        Default="dev",
+        Type="String",
+        Description="Development or Production environment",
+        AllowedValues=[
+            "dev",
+            "prod"
+        ],
+        ConstraintDescription="dev or prod",
+    ))
+    route53_hosted_zone_id = t.add_parameter(Parameter(
+        "route53HostedZoneId",
+        Default="",
+        Type="AWS::Route53::HostedZone::Id",
+        Description="Route53 DNS zone ID"
+    ))
+
+    route53_hosted_zone_name = t.add_parameter(Parameter(
+        "route53HostedZoneName",
+        Default="my.aws.dns.com",
+        Type="String",
+        Description="Route53 hosted zone name"
+    ))
+    security_group = t.add_parameter(Parameter(
+        "securityGroup",
+        Default="",
+        Type="List<AWS::EC2::SecurityGroup::Id>",
+        Description="Which security groups to use"
+    ))
+    alb_paths = t.add_parameter(Parameter(
+        "albPaths",
+        Default="/",
+        Type="CommaDelimitedList",
+        Description="Path-patterns you want the loadbalancer to point to in your application"
+    ))
+    albPort = t.add_parameter(Parameter(
+        "albPort",
+        Default="80",
+        Type="Number",
+        Description="Which loadbalancer port to use"
+    ))
+    ec2_subnets = t.add_parameter(Parameter(
+        "ec2Subnets",
+        Default="",
+        Type="List<AWS::EC2::Subnet::Id>",
+        Description="Private subnets for the instances."
+    ))
+    alb_subnets = t.add_parameter(Parameter(
+        "albSubnets",
+        Default="",
+        Type="List<AWS::EC2::Subnet::Id>",
+        Description="Public subnets for the load balancer."
+    ))
+    loadbalancer_prefix = t.add_parameter(Parameter(
+        "loadbalancerPrefix",
+        Default="",
+        Type="String",
+        Description="Specify a prefix for your loadbalancer",
+    ))
+    vpc = t.add_parameter(Parameter(
+        "VPC",
+        Default="",
+        Type="AWS::EC2::VPC::Id",
+        Description="Environment VPC"
+    ))
+
+    # Auto scaling group parameters
+    asg_capacity = t.add_parameter(Parameter(
+        "asgCapacity",
+        Default="0",
+        Type="Number",
+        Description="Number of instances"
+    ))
+    asg_min_size = t.add_parameter(Parameter(
+        "asgMinSize",
+        Default="0",
+        Type="Number",
+        Description="Minimum size of AutoScalingGroup"
+    ))
+    asg_max_size = t.add_parameter(Parameter(
+        "asgMaxSize",
+        Default="1",
+        Type="Number",
+        Description="Maximum size of AutoScalingGroup"
+    ))
+    asg_cooldown = t.add_parameter(Parameter(
+        "asgCooldown",
+        Default="300",
+        Type="Number",
+        Description="Cooldown before starting/stopping another instance"
+    ))
+    asg_health_grace = t.add_parameter(Parameter(
+        "asgHealthGrace",
+        Default="300",
+        Type="Number",
+        Description="Wait before starting/stopping another instance"
+    ))
+
+    # EC2 parameters
+    ec2_name = t.add_parameter(Parameter(
+        "ec2Name",
+        Default="myApplication",
+        Type="String",
+        Description="Name of the instances"
+    ))
+    ec2_type = t.add_parameter(Parameter(
+        "ec2Type",
+        Default="t2.large",
+        Type="String",
+        Description="Instance type."
+    ))
+    ec2_key = t.add_parameter(Parameter(
+        "ec2Key",
+        Default="",
+        Type="AWS::EC2::KeyPair::KeyName",
+        Description="EC2 Key Pair"
+    ))
+
+    # Launchconfiguration
+    EC2LaunchConfiguration = t.add_resource(autoscaling.LaunchConfiguration(
+        "EC2LaunchConfiguration",
+        ImageId=FindInMap("windowsAMI", Ref("AWS::Region"), "AMI"),
+        KeyName=Ref(ec2_key),
+        SecurityGroups=Ref(security_group),
+        InstanceType=Ref(ec2_type),
+        AssociatePublicIpAddress=False,
+    ))
+
+    # Application ELB
+    alb_target_group = t.add_resource(elb.TargetGroup(
+        "albTargetGroup",
+        HealthCheckPath=Select("0", Ref(alb_paths)),
+        HealthCheckIntervalSeconds="30",
+        HealthCheckProtocol="HTTP",
+        HealthCheckTimeoutSeconds="10",
+        HealthyThresholdCount="4",
+        Matcher=elb.Matcher(
+            HttpCode="200"),
+        Name=Ref(ec2_name),
+        Port=80,
+        Protocol="HTTP",
+        UnhealthyThresholdCount="3",
+        VpcId=Ref(vpc)
+
+    ))
+
+    # Auto scaling group
+    auto_scaling_group = t.add_resource(autoscaling.AutoScalingGroup(
+        "autoScalingGroup",
+        DesiredCapacity=Ref(asg_capacity),
+        Tags=autoscaling.Tags(
+            Environment=Ref(environment)
+        ),
+        VPCZoneIdentifier=Ref(ec2_subnets),
+        TargetGroupARNs=[Ref(alb_target_group)],
+        MinSize=Ref(asg_min_size),
+        MaxSize=Ref(asg_max_size),
+        Cooldown=Ref(asg_cooldown),
+        LaunchConfigurationName=Ref(EC2LaunchConfiguration),
+        HealthCheckGracePeriod=Ref(asg_health_grace),
+        HealthCheckType="EC2",
+    ))
+
+    # Application Load Balancer
+    application_load_balancer = t.add_resource(elb.LoadBalancer(
+        "applicationLoadBalancer",
+        Name=Ref(loadbalancer_prefix),
+        Scheme="internet-facing",
+        Subnets=Ref(alb_subnets),
+        SecurityGroups=Ref(security_group)
+    ))
+    alb_listener = t.add_resource(elb.Listener(
+        "albListener",
+        Port=Ref(albPort),
+        Protocol="HTTP",
+        LoadBalancerArn=Ref(application_load_balancer),
+        DefaultActions=[elb.Action(
+            Type="forward",
+            TargetGroupArn=Ref(alb_target_group)
+        )]
+    ))
+    alb_listener_rule = t.add_resource(elb.ListenerRule(
+        "albListenerRule",
+        ListenerArn=Ref(alb_listener),
+        Conditions=[elb.Condition(
+            Field="path-pattern",
+            Values=Ref(alb_paths)
+        )],
+        Actions=[elb.Action(
+            Type="forward",
+            TargetGroupArn=Ref(alb_target_group)
+        )],
+        Priority="1"
+    ))
+
+    # Route53
+    route53_roundrobin = t.add_resource(route53.RecordSetGroup(
+        "route53RoundRobin",
+        HostedZoneId=Ref(route53_hosted_zone_id),
+        RecordSets=[
+            route53.RecordSet(
+                Weight=1,
+                SetIdentifier=Join(".", [Ref(environment), Ref(route53_hosted_zone_name), "ELB"]),
+                Name=Join(".", [Ref(environment), Ref(route53_hosted_zone_name)]),
+                Type="A",
+                AliasTarget=route53.AliasTarget(
+                    GetAtt(application_load_balancer, "CanonicalHostedZoneID"),
+                    GetAtt(application_load_balancer, "DNSName")
+                )
+            )
+        ]
+    ))
+
+    t.add_output(
+        Output(
+            "URL",
+            Description="URL of the website",
+            Value=Join("", [
+                "http://",
+                GetAtt(application_load_balancer, "DNSName"),
+                Select("0", Ref(alb_paths))
+            ]),
+            Export=Export(Sub("${AWS::StackName}-URL")),
+        )
+    )
+
+
+    print(t.to_json())
+
+if __name__ == '__main__':
+    main()

--- a/tests/examples_output/ALB_Autoscaling_Route53_A_Alias_Sample.template
+++ b/tests/examples_output/ALB_Autoscaling_Route53_A_Alias_Sample.template
@@ -1,0 +1,436 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Template for auto-scaling in an Applicationload balancer target group. The ALB will be used as an A Alias target for a specified Route53 hosted zone. This template also showcases Metadata Parameter Grouping, Special AWS Parameter Types, and Cloudformation Outputs with Exportswhich can be imported into other templates.",
+    "Mappings": {
+        "windowsAMI": {
+            "eu-central-1": {
+                "AMI": "ami-c0f237af"
+            },
+            "eu-west-1": {
+                "AMI": "ami-32792a41"
+            },
+            "eu-west-2": {
+                "AMI": "ami-29353f4d"
+            },
+            "us-east-1": {
+                "AMI": "ami-b06249a7"
+            },
+            "us-east-2": {
+                "AMI": "ami-20683245"
+            },
+            "us-west-1": {
+                "AMI": "ami-d3a8fdb3"
+            },
+            "us-west-2": {
+                "AMI": "ami-b9b71ad9"
+            }
+        }
+    },
+    "Metadata": {
+        "AWS::CloudFormation::Interface": {
+            "ParameterGroups": [
+                {
+                    "Label": {
+                        "default": "Global parameters"
+                    },
+                    "Parameters": [
+                        "environment"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "Application Loadbalancer"
+                    },
+                    "Parameters": [
+                        "albSubnets",
+                        "loadbalancerPrefix",
+                        "loadBalancerArn",
+                        "albPaths",
+                        "albPort"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "VPC"
+                    },
+                    "Parameters": [
+                        "ec2Subnets",
+                        "VPC",
+                        "securityGroup"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "EC2"
+                    },
+                    "Parameters": [
+                        "ec2Name",
+                        "ec2Type",
+                        "ec2Key"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "Auto-scaling"
+                    },
+                    "Parameters": [
+                        "asgCapacity",
+                        "asgMinSize",
+                        "asgMaxSize",
+                        "asgCooldown",
+                        "asgHealthGrace"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "Route53"
+                    },
+                    "Parameters": [
+                        "route53HostedZoneId",
+                        "route53HostedZoneName"
+                    ]
+                }
+            ]
+        }
+    },
+    "Outputs": {
+        "URL": {
+            "Description": "URL of the website",
+            "Export": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName}-URL"
+                }
+            },
+            "Value": {
+                "Fn::Join": [
+                    "",
+                    [
+                        "http://",
+                        {
+                            "Fn::GetAtt": [
+                                "applicationLoadBalancer",
+                                "DNSName"
+                            ]
+                        },
+                        {
+                            "Fn::Select": [
+                                "0",
+                                {
+                                    "Ref": "albPaths"
+                                }
+                            ]
+                        }
+                    ]
+                ]
+            }
+        }
+    },
+    "Parameters": {
+        "VPC": {
+            "Default": "",
+            "Description": "Environment VPC",
+            "Type": "AWS::EC2::VPC::Id"
+        },
+        "albPaths": {
+            "Default": "/",
+            "Description": "Path-patterns you want the loadbalancer to point to in your application",
+            "Type": "CommaDelimitedList"
+        },
+        "albPort": {
+            "Default": "80",
+            "Description": "Which loadbalancer port to use",
+            "Type": "Number"
+        },
+        "albSubnets": {
+            "Default": "",
+            "Description": "Public subnets for the load balancer.",
+            "Type": "List<AWS::EC2::Subnet::Id>"
+        },
+        "asgCapacity": {
+            "Default": "0",
+            "Description": "Number of instances",
+            "Type": "Number"
+        },
+        "asgCooldown": {
+            "Default": "300",
+            "Description": "Cooldown before starting/stopping another instance",
+            "Type": "Number"
+        },
+        "asgHealthGrace": {
+            "Default": "300",
+            "Description": "Wait before starting/stopping another instance",
+            "Type": "Number"
+        },
+        "asgMaxSize": {
+            "Default": "1",
+            "Description": "Maximum size of AutoScalingGroup",
+            "Type": "Number"
+        },
+        "asgMinSize": {
+            "Default": "0",
+            "Description": "Minimum size of AutoScalingGroup",
+            "Type": "Number"
+        },
+        "ec2Key": {
+            "Default": "",
+            "Description": "EC2 Key Pair",
+            "Type": "AWS::EC2::KeyPair::KeyName"
+        },
+        "ec2Name": {
+            "Default": "myApplication",
+            "Description": "Name of the instances",
+            "Type": "String"
+        },
+        "ec2Subnets": {
+            "Default": "",
+            "Description": "Private subnets for the instances.",
+            "Type": "List<AWS::EC2::Subnet::Id>"
+        },
+        "ec2Type": {
+            "Default": "t2.large",
+            "Description": "Instance type.",
+            "Type": "String"
+        },
+        "environment": {
+            "AllowedValues": [
+                "dev",
+                "prod"
+            ],
+            "ConstraintDescription": "dev or prod",
+            "Default": "dev",
+            "Description": "Development or Production environment",
+            "Type": "String"
+        },
+        "loadbalancerPrefix": {
+            "Default": "",
+            "Description": "Specify a prefix for your loadbalancer",
+            "Type": "String"
+        },
+        "route53HostedZoneId": {
+            "Default": "",
+            "Description": "Route53 DNS zone ID",
+            "Type": "AWS::Route53::HostedZone::Id"
+        },
+        "route53HostedZoneName": {
+            "Default": "my.aws.dns.com",
+            "Description": "Route53 hosted zone name",
+            "Type": "String"
+        },
+        "securityGroup": {
+            "Default": "",
+            "Description": "Which security groups to use",
+            "Type": "List<AWS::EC2::SecurityGroup::Id>"
+        }
+    },
+    "Resources": {
+        "EC2LaunchConfiguration": {
+            "Properties": {
+                "AssociatePublicIpAddress": "false",
+                "ImageId": {
+                    "Fn::FindInMap": [
+                        "windowsAMI",
+                        {
+                            "Ref": "AWS::Region"
+                        },
+                        "AMI"
+                    ]
+                },
+                "InstanceType": {
+                    "Ref": "ec2Type"
+                },
+                "KeyName": {
+                    "Ref": "ec2Key"
+                },
+                "SecurityGroups": {
+                    "Ref": "securityGroup"
+                }
+            },
+            "Type": "AWS::AutoScaling::LaunchConfiguration"
+        },
+        "albListener": {
+            "Properties": {
+                "DefaultActions": [
+                    {
+                        "TargetGroupArn": {
+                            "Ref": "albTargetGroup"
+                        },
+                        "Type": "forward"
+                    }
+                ],
+                "LoadBalancerArn": {
+                    "Ref": "applicationLoadBalancer"
+                },
+                "Port": {
+                    "Ref": "albPort"
+                },
+                "Protocol": "HTTP"
+            },
+            "Type": "AWS::ElasticLoadBalancingV2::Listener"
+        },
+        "albListenerRule": {
+            "Properties": {
+                "Actions": [
+                    {
+                        "TargetGroupArn": {
+                            "Ref": "albTargetGroup"
+                        },
+                        "Type": "forward"
+                    }
+                ],
+                "Conditions": [
+                    {
+                        "Field": "path-pattern",
+                        "Values": {
+                            "Ref": "albPaths"
+                        }
+                    }
+                ],
+                "ListenerArn": {
+                    "Ref": "albListener"
+                },
+                "Priority": "1"
+            },
+            "Type": "AWS::ElasticLoadBalancingV2::ListenerRule"
+        },
+        "albTargetGroup": {
+            "Properties": {
+                "HealthCheckIntervalSeconds": "30",
+                "HealthCheckPath": {
+                    "Fn::Select": [
+                        "0",
+                        {
+                            "Ref": "albPaths"
+                        }
+                    ]
+                },
+                "HealthCheckProtocol": "HTTP",
+                "HealthCheckTimeoutSeconds": "10",
+                "HealthyThresholdCount": "4",
+                "Matcher": {
+                    "HttpCode": "200"
+                },
+                "Name": {
+                    "Ref": "ec2Name"
+                },
+                "Port": 80,
+                "Protocol": "HTTP",
+                "UnhealthyThresholdCount": "3",
+                "VpcId": {
+                    "Ref": "VPC"
+                }
+            },
+            "Type": "AWS::ElasticLoadBalancingV2::TargetGroup"
+        },
+        "applicationLoadBalancer": {
+            "Properties": {
+                "Name": {
+                    "Ref": "loadbalancerPrefix"
+                },
+                "Scheme": "internet-facing",
+                "SecurityGroups": {
+                    "Ref": "securityGroup"
+                },
+                "Subnets": {
+                    "Ref": "albSubnets"
+                }
+            },
+            "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer"
+        },
+        "autoScalingGroup": {
+            "Properties": {
+                "Cooldown": {
+                    "Ref": "asgCooldown"
+                },
+                "DesiredCapacity": {
+                    "Ref": "asgCapacity"
+                },
+                "HealthCheckGracePeriod": {
+                    "Ref": "asgHealthGrace"
+                },
+                "HealthCheckType": "EC2",
+                "LaunchConfigurationName": {
+                    "Ref": "EC2LaunchConfiguration"
+                },
+                "MaxSize": {
+                    "Ref": "asgMaxSize"
+                },
+                "MinSize": {
+                    "Ref": "asgMinSize"
+                },
+                "Tags": [
+                    {
+                        "Key": "Environment",
+                        "PropagateAtLaunch": "true",
+                        "Value": {
+                            "Ref": "environment"
+                        }
+                    }
+                ],
+                "TargetGroupARNs": [
+                    {
+                        "Ref": "albTargetGroup"
+                    }
+                ],
+                "VPCZoneIdentifier": {
+                    "Ref": "ec2Subnets"
+                }
+            },
+            "Type": "AWS::AutoScaling::AutoScalingGroup"
+        },
+        "route53RoundRobin": {
+            "Properties": {
+                "HostedZoneId": {
+                    "Ref": "route53HostedZoneId"
+                },
+                "RecordSets": [
+                    {
+                        "AliasTarget": {
+                            "DNSName": {
+                                "Fn::GetAtt": [
+                                    "applicationLoadBalancer",
+                                    "DNSName"
+                                ]
+                            },
+                            "HostedZoneId": {
+                                "Fn::GetAtt": [
+                                    "applicationLoadBalancer",
+                                    "CanonicalHostedZoneID"
+                                ]
+                            }
+                        },
+                        "Name": {
+                            "Fn::Join": [
+                                ".",
+                                [
+                                    {
+                                        "Ref": "environment"
+                                    },
+                                    {
+                                        "Ref": "route53HostedZoneName"
+                                    }
+                                ]
+                            ]
+                        },
+                        "SetIdentifier": {
+                            "Fn::Join": [
+                                ".",
+                                [
+                                    {
+                                        "Ref": "environment"
+                                    },
+                                    {
+                                        "Ref": "route53HostedZoneName"
+                                    },
+                                    "ELB"
+                                ]
+                            ]
+                        },
+                        "Type": "A",
+                        "Weight": 1
+                    }
+                ]
+            },
+            "Type": "AWS::Route53::RecordSetGroup"
+        }
+    }
+}


### PR DESCRIPTION
The examples are extremely useful so I thought I'd give back and create one of my own that showcases:

- Auto scaling + Application load balancer target groups
- Application load balancer as an A Alias target for a Route53 Round Robin
- Metadata Parameter Grouping
- AWS Parameter Types which grabs info automatically from your account
- Cloudformation outputs that can be used within other templates with FN::ImportValue

If it's too much in one template, or if it's not up to standards, or something else is wrong;  please feel free to tell me so as this is my first pull-request in this project.