### PR TITLE
Allow valid value for TargetGroup HealthCheckPort

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2,6 +2,7 @@ import unittest
 from troposphere import Parameter, Ref
 from troposphere.validators import boolean, integer, integer_range
 from troposphere.validators import positive_integer, network_port
+from troposphere.validators import tg_healthcheck_port
 from troposphere.validators import s3_bucket_name, encoding, status
 from troposphere.validators import iam_path, iam_names, iam_role_name
 from troposphere.validators import iam_group_name, iam_user_name, elb_name
@@ -60,6 +61,19 @@ class TestValidators(unittest.TestCase):
     def test_network_port_ref(self):
         p = Parameter('myport')
         network_port(Ref(p))
+
+    def test_tg_healthcheck_port(self):
+        for x in ["traffic-port"]:
+            tg_healthcheck_port(x)
+        for x in [-1, 0, 1, 1024, 65535]:
+            tg_healthcheck_port(x)
+        for x in [-2, -10, 65536, 100000]:
+            with self.assertRaises(ValueError):
+                tg_healthcheck_port(x)
+
+    def test_tg_healthcheck_port_ref(self):
+        p = Parameter('myport')
+        tg_healthcheck_port(Ref(p))
 
     def test_s3_bucket_name(self):
         for b in ['a'*3, 'a'*63, 'wick3d-sweet.bucket']:

--- a/troposphere/elasticloadbalancingv2.py
+++ b/troposphere/elasticloadbalancingv2.py
@@ -5,7 +5,7 @@
 
 from . import AWSObject, AWSProperty
 from .validators import (
-    elb_name, network_port, integer)
+    elb_name, network_port, tg_healthcheck_port, integer)
 
 
 class LoadBalancerAttributes(AWSProperty):
@@ -85,7 +85,7 @@ class TargetGroup(AWSObject):
     props = {
         'HealthCheckIntervalSeconds': (integer, False),
         'HealthCheckPath': (basestring, False),
-        'HealthCheckPort': (network_port, False),
+        'HealthCheckPort': (tg_healthcheck_port, False),
         'HealthCheckProtocol': (basestring, False),
         'HealthCheckTimeoutSeconds': (integer, False),
         'HealthyThresholdCount': (integer, False),

--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -53,6 +53,12 @@ def network_port(x):
     return x
 
 
+def tg_healthcheck_port(x):
+    if isinstance(x, str) and x == "traffic-port":
+        return x
+    return network_port(x)
+
+
 def s3_bucket_name(b):
 
     # consecutive periods not allowed


### PR DESCRIPTION
For the TargetGroup in ElasticLoadBalancerV2 you can set the HealthCheckPort to the string `traffic-port`, which is the default if not set.  This is documented here:

http://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html

I've added a new validator and tests for this.