### PR TITLE
A fully automated IPv6 example for VPC setup.

### DIFF
--- a/examples/Ipv6_With_Custom_Resource_For_Subnet_Calculation.py
+++ b/examples/Ipv6_With_Custom_Resource_For_Subnet_Calculation.py
@@ -1,24 +1,25 @@
 #!/usr/bin/env python
 
-from troposphere import GetAtt, Select, Join, Ref, Template, Tags, GetAZs
-from troposphere.awslambda import Function, Code, MEMORY_VALUES, Permission
+from troposphere import GetAtt, Select, Join, Ref, Template, GetAZs
+from troposphere.awslambda import Function, Code
 from troposphere.iam import PolicyType as IAMPolicy
 from troposphere import ec2
 from awacs.aws import Allow, Statement, Action as Action, Principal, Policy
 from troposphere.iam import Role
 from awacs.sts import AssumeRole
 from troposphere.cloudformation import AWSCustomObject
-import awacs.logs
+
 
 class Ipv6SubnetCalculator(AWSCustomObject):
 
-     resource_type = "Custom::Ipv6SubnetCalculator"
+    resource_type = "Custom::Ipv6SubnetCalculator"
 
-     props = {
-      'ServiceToken': (str, True),
-      'AllocatedSubnet': (str, True),
-      'SubnetIndexStart': (str, True),
-     }
+    props = {
+        'ServiceToken': (str, True),
+        'AllocatedSubnet': (str, True),
+        'SubnetIndexStart': (str, True),
+    }
+
 
 template = Template()
 
@@ -89,8 +90,8 @@ Ipv6SubnetCalculatorFunction = template.add_resource(Function(
 ))
 
 template.add_resource(Role(
-"Ipv6SubnetCalculatorExecutionLambdaRole",
-     AssumeRolePolicyDocument=Policy(
+    "Ipv6SubnetCalculatorExecutionLambdaRole",
+    AssumeRolePolicyDocument=Policy(
         Statement=[
             Statement(
                 Effect=Allow, Action=[AssumeRole],
@@ -99,8 +100,8 @@ template.add_resource(Role(
                 ),
             )
         ]
-   ),
-Path="/"
+    ),
+    Path="/"
 ))
 
 template.add_resource(IAMPolicy(
@@ -110,8 +111,8 @@ template.add_resource(IAMPolicy(
     PolicyDocument=Policy(
         Statement=[
             Statement(
-                    Effect=Allow,
-                    Action=[Action("logs", "*")],
+                Effect=Allow,
+                Action=[Action("logs", "*")],
                 Resource=["arn:aws:logs:*:*:*"],
             )
         ],
@@ -129,7 +130,7 @@ ipv6cidrblock = template.add_resource(ec2.VPCCidrBlock(
     "ExampleIPV6Block",
     AmazonProvidedIpv6CidrBlock=True,
     VpcId=Ref(vpcid),
-    ))
+))
 
 ipv6calculation = template.add_resource(Ipv6SubnetCalculator(
     "ipv6calculation",
@@ -150,6 +151,6 @@ exampleipv6subnet = template.add_resource(ec2.SubnetCidrBlock(
     "ExampleIPV6Subnet",
     Ipv6CidrBlock=Ref(ipv6calculation),
     SubnetId=Ref(examplesubnet1)
-    ))
+))
 
 print(template.to_json())

--- a/examples/Ipv6_With_Custom_Resource_For_Subnet_Calculation.py
+++ b/examples/Ipv6_With_Custom_Resource_For_Subnet_Calculation.py
@@ -23,7 +23,7 @@ class Ipv6SubnetCalculator(AWSCustomObject):
 template = Template()
 
 template.add_description("""\
-Create ipv6 test for the systime stack
+Create VPC ipv6 example stack
 """)
 
 Ipv6SubnetCalculatorCode = [
@@ -119,14 +119,14 @@ template.add_resource(IAMPolicy(
 ))
 
 vpcid = template.add_resource(ec2.VPC(
-    "Test",
+    "Example",
     CidrBlock="10.254.0.0/16",
     EnableDnsHostnames=True,
     EnableDnsSupport=True,
 ))
 
 ipv6cidrblock = template.add_resource(ec2.VPCCidrBlock(
-    "TestIPV6Block",
+    "ExampleIPV6Block",
     AmazonProvidedIpv6CidrBlock=True,
     VpcId=Ref(vpcid),
     ))
@@ -136,20 +136,20 @@ ipv6calculation = template.add_resource(Ipv6SubnetCalculator(
     ServiceToken=GetAtt(Ipv6SubnetCalculatorFunction, "Arn"),
     AllocatedSubnet=Select(0, GetAtt(vpcid, "Ipv6CidrBlocks")),
     SubnetIndexStart='0',
-    DependsOn="TestIPV6Block"
+    DependsOn="ExampleIPV6Block"
 ))
 
-publicsubnet1 = template.add_resource(ec2.Subnet(
-    "Public1",
+examplesubnet1 = template.add_resource(ec2.Subnet(
+    "ExampleSubnet1",
     VpcId=Ref(vpcid),
     CidrBlock="10.254.1.0/24",
     AvailabilityZone=Select(0, GetAZs(Ref("AWS::Region"))),
 ))
 
-ipv6subnet = template.add_resource(ec2.SubnetCidrBlock(
-    "TestIPV6Subnet",
+exampleipv6subnet = template.add_resource(ec2.SubnetCidrBlock(
+    "ExampleIPV6Subnet",
     Ipv6CidrBlock=Ref(ipv6calculation),
-    SubnetId=Ref(publicsubnet1)
+    SubnetId=Ref(examplesubnet1)
     ))
 
 print(template.to_json())

--- a/examples/Ipv6_With_Custom_Resource_For_Subnet_Calculation.py
+++ b/examples/Ipv6_With_Custom_Resource_For_Subnet_Calculation.py
@@ -15,9 +15,9 @@ class Ipv6SubnetCalculator(AWSCustomObject):
     resource_type = "Custom::Ipv6SubnetCalculator"
 
     props = {
-        'ServiceToken': (str, True),
-        'AllocatedSubnet': (str, True),
-        'SubnetIndexStart': (str, True),
+        'ServiceToken': (basestring, True),
+        'AllocatedSubnet': (basestring, True),
+        'SubnetIndexStart': (basestring, True),
     }
 
 

--- a/examples/Ipv6_With_Custom_Resource_For_Subnet_Calculation.py
+++ b/examples/Ipv6_With_Custom_Resource_For_Subnet_Calculation.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python
+
+from troposphere import GetAtt, Select, Join, Ref, Template, Tags, GetAZs
+from troposphere.awslambda import Function, Code, MEMORY_VALUES, Permission
+from troposphere.iam import PolicyType as IAMPolicy
+from troposphere import ec2
+from awacs.aws import Allow, Statement, Action as Action, Principal, Policy
+from troposphere.iam import Role
+from awacs.sts import AssumeRole
+from troposphere.cloudformation import AWSCustomObject
+import awacs.logs
+
+class Ipv6SubnetCalculator(AWSCustomObject):
+
+     resource_type = "Custom::Ipv6SubnetCalculator"
+
+     props = {
+      'ServiceToken': (str, True),
+      'AllocatedSubnet': (str, True),
+      'SubnetIndexStart': (str, True),
+     }
+
+template = Template()
+
+template.add_description("""\
+Create ipv6 test for the systime stack
+""")
+
+Ipv6SubnetCalculatorCode = [
+    "import socket",
+    "from binascii import hexlify",
+    "import cfnresponse",
+    "responseData={}",
+    "def IPV6_to_int(ipv6_addr):",
+    " return int(hexlify(socket.inet_pton(socket.AF_INET6,ipv6_addr)),16)",
+    "def long2ip(l):",
+    " hex_str='%032x'%l",
+    " hextets=['%x'%int(hex_str[x:x+4],16)for x in range(0,32,4)]",
+    " dc_start,dc_len=(-1,0)",
+    " run_start,run_len=(-1,0)",
+    " for idx,hextet in enumerate(hextets):",
+    "  if '0'==hextet:",
+    "   run_len+=1",
+    "   if-1==run_start:",
+    "    run_start=idx",
+    "   if run_len>dc_len:",
+    "    dc_len,dc_start=(run_len,run_start)",
+    "  else:",
+    "   run_len,run_start=(0,-1)",
+    " if dc_len>1:",
+    "  dc_end=dc_start+dc_len",
+    "  if dc_end==len(hextets):",
+    "   hextets+=['']",
+    "  hextets[dc_start:dc_end]=['']",
+    "  if dc_start==0:",
+    "   hextets=['']+hextets",
+    " return ':'.join(hextets)",
+    "def lambda_handler(event,context):",
+    " if event['RequestType'] is not 'delete':",
+    "  create(event,context)",
+    " if event['RequestType'] is 'delete':",
+    "  delete(event,context)",
+    "def delete(event,context):",
+    " cfnresponse.send(event,context,cfnresponse.SUCCESS,responseData,"")",
+    "def create(event,context):",
+    " v6sm=event['ResourceProperties']['AllocatedSubnet']",
+    " print(v6sm)",
+    " v6snm=v6sm.split('/')[0]",
+    " sis=int(event['ResourceProperties']['SubnetIndexStart'])",
+    " dec=long(IPV6_to_int(v6snm))",
+    " S64S=(2**64)",
+    " o64d= dec+((sis)*long(S64S))",
+    " o64s=(str(long2ip(o64d))+'/64')",
+    " responseData['SubnetIndexStart']=sis",
+    " cfnresponse.send(event,context,cfnresponse.SUCCESS,responseData,o64s)",
+]
+
+Ipv6SubnetCalculatorFunction = template.add_resource(Function(
+    "Ipv6SubnetCalculatorFunction",
+    Description="Calculates Ipv6 Subnets for Cloudformation",
+    Code=Code(
+        ZipFile=Join("\n", Ipv6SubnetCalculatorCode)
+    ),
+    Handler="index.lambda_handler",
+    Role=GetAtt("Ipv6SubnetCalculatorExecutionLambdaRole", "Arn"),
+    Runtime="python2.7",
+    MemorySize=128,
+    Timeout=30
+))
+
+template.add_resource(Role(
+"Ipv6SubnetCalculatorExecutionLambdaRole",
+     AssumeRolePolicyDocument=Policy(
+        Statement=[
+            Statement(
+                Effect=Allow, Action=[AssumeRole],
+                Principal=Principal(
+                    "Service", ["lambda.amazonaws.com"]
+                ),
+            )
+        ]
+   ),
+Path="/"
+))
+
+template.add_resource(IAMPolicy(
+    "Ipv6SubnetCalculatorExecutionLambdaPolicy",
+    PolicyName="Ipv6SubnetCalculatorExecutionLambdaPolicy",
+    Roles=[Ref("Ipv6SubnetCalculatorExecutionLambdaRole")],
+    PolicyDocument=Policy(
+        Statement=[
+            Statement(
+                    Effect=Allow,
+                    Action=[Action("logs", "*")],
+                Resource=["arn:aws:logs:*:*:*"],
+            )
+        ],
+    ),
+))
+
+vpcid = template.add_resource(ec2.VPC(
+    "Test",
+    CidrBlock="10.254.0.0/16",
+    EnableDnsHostnames=True,
+    EnableDnsSupport=True,
+))
+
+ipv6cidrblock = template.add_resource(ec2.VPCCidrBlock(
+    "TestIPV6Block",
+    AmazonProvidedIpv6CidrBlock=True,
+    VpcId=Ref(vpcid),
+    ))
+
+ipv6calculation = template.add_resource(Ipv6SubnetCalculator(
+    "ipv6calculation",
+    ServiceToken=GetAtt(Ipv6SubnetCalculatorFunction, "Arn"),
+    AllocatedSubnet=Select(0, GetAtt(vpcid, "Ipv6CidrBlocks")),
+    SubnetIndexStart='0',
+    DependsOn="TestIPV6Block"
+))
+
+publicsubnet1 = template.add_resource(ec2.Subnet(
+    "Public1",
+    VpcId=Ref(vpcid),
+    CidrBlock="10.254.1.0/24",
+    AvailabilityZone=Select(0, GetAZs(Ref("AWS::Region"))),
+))
+
+ipv6subnet = template.add_resource(ec2.SubnetCidrBlock(
+    "TestIPV6Subnet",
+    Ipv6CidrBlock=Ref(ipv6calculation),
+    SubnetId=Ref(publicsubnet1)
+    ))
+
+print(template.to_json())

--- a/tests/examples_output/Ipv6_With_Custom_Resource_For_Subnet_Calculation.template
+++ b/tests/examples_output/Ipv6_With_Custom_Resource_For_Subnet_Calculation.template
@@ -1,0 +1,192 @@
+{
+    "Description": "Create VPC ipv6 example stack\n",
+    "Resources": {
+        "Example": {
+            "Properties": {
+                "CidrBlock": "10.254.0.0/16",
+                "EnableDnsHostnames": "true",
+                "EnableDnsSupport": "true"
+            },
+            "Type": "AWS::EC2::VPC"
+        },
+        "ExampleIPV6Block": {
+            "Properties": {
+                "AmazonProvidedIpv6CidrBlock": "true",
+                "VpcId": {
+                    "Ref": "Example"
+                }
+            },
+            "Type": "AWS::EC2::VPCCidrBlock"
+        },
+        "ExampleIPV6Subnet": {
+            "Properties": {
+                "Ipv6CidrBlock": {
+                    "Ref": "ipv6calculation"
+                },
+                "SubnetId": {
+                    "Ref": "ExampleSubnet1"
+                }
+            },
+            "Type": "AWS::EC2::SubnetCidrBlock"
+        },
+        "ExampleSubnet1": {
+            "Properties": {
+                "AvailabilityZone": {
+                    "Fn::Select": [
+                        0,
+                        {
+                            "Fn::GetAZs": {
+                                "Ref": "AWS::Region"
+                            }
+                        }
+                    ]
+                },
+                "CidrBlock": "10.254.1.0/24",
+                "VpcId": {
+                    "Ref": "Example"
+                }
+            },
+            "Type": "AWS::EC2::Subnet"
+        },
+        "Ipv6SubnetCalculatorExecutionLambdaPolicy": {
+            "Properties": {
+                "PolicyDocument": {
+                    "Statement": [
+                        {
+                            "Action": [
+                                "logs:*"
+                            ],
+                            "Effect": "Allow",
+                            "Resource": [
+                                "arn:aws:logs:*:*:*"
+                            ]
+                        }
+                    ]
+                },
+                "PolicyName": "Ipv6SubnetCalculatorExecutionLambdaPolicy",
+                "Roles": [
+                    {
+                        "Ref": "Ipv6SubnetCalculatorExecutionLambdaRole"
+                    }
+                ]
+            },
+            "Type": "AWS::IAM::Policy"
+        },
+        "Ipv6SubnetCalculatorExecutionLambdaRole": {
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [
+                        {
+                            "Action": [
+                                "sts:AssumeRole"
+                            ],
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "lambda.amazonaws.com"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "Path": "/"
+            },
+            "Type": "AWS::IAM::Role"
+        },
+        "Ipv6SubnetCalculatorFunction": {
+            "Properties": {
+                "Code": {
+                    "ZipFile": {
+                        "Fn::Join": [
+                            "\n",
+                            [
+                                "import socket",
+                                "from binascii import hexlify",
+                                "import cfnresponse",
+                                "responseData={}",
+                                "def IPV6_to_int(ipv6_addr):",
+                                " return int(hexlify(socket.inet_pton(socket.AF_INET6,ipv6_addr)),16)",
+                                "def long2ip(l):",
+                                " hex_str='%032x'%l",
+                                " hextets=['%x'%int(hex_str[x:x+4],16)for x in range(0,32,4)]",
+                                " dc_start,dc_len=(-1,0)",
+                                " run_start,run_len=(-1,0)",
+                                " for idx,hextet in enumerate(hextets):",
+                                "  if '0'==hextet:",
+                                "   run_len+=1",
+                                "   if-1==run_start:",
+                                "    run_start=idx",
+                                "   if run_len>dc_len:",
+                                "    dc_len,dc_start=(run_len,run_start)",
+                                "  else:",
+                                "   run_len,run_start=(0,-1)",
+                                " if dc_len>1:",
+                                "  dc_end=dc_start+dc_len",
+                                "  if dc_end==len(hextets):",
+                                "   hextets+=['']",
+                                "  hextets[dc_start:dc_end]=['']",
+                                "  if dc_start==0:",
+                                "   hextets=['']+hextets",
+                                " return ':'.join(hextets)",
+                                "def lambda_handler(event,context):",
+                                " if event['RequestType'] is not 'delete':",
+                                "  create(event,context)",
+                                " if event['RequestType'] is 'delete':",
+                                "  delete(event,context)",
+                                "def delete(event,context):",
+                                " cfnresponse.send(event,context,cfnresponse.SUCCESS,responseData,)",
+                                "def create(event,context):",
+                                " v6sm=event['ResourceProperties']['AllocatedSubnet']",
+                                " print(v6sm)",
+                                " v6snm=v6sm.split('/')[0]",
+                                " sis=int(event['ResourceProperties']['SubnetIndexStart'])",
+                                " dec=long(IPV6_to_int(v6snm))",
+                                " S64S=(2**64)",
+                                " o64d= dec+((sis)*long(S64S))",
+                                " o64s=(str(long2ip(o64d))+'/64')",
+                                " responseData['SubnetIndexStart']=sis",
+                                " cfnresponse.send(event,context,cfnresponse.SUCCESS,responseData,o64s)"
+                            ]
+                        ]
+                    }
+                },
+                "Description": "Calculates Ipv6 Subnets for Cloudformation",
+                "Handler": "index.lambda_handler",
+                "MemorySize": 128,
+                "Role": {
+                    "Fn::GetAtt": [
+                        "Ipv6SubnetCalculatorExecutionLambdaRole",
+                        "Arn"
+                    ]
+                },
+                "Runtime": "python2.7",
+                "Timeout": 30
+            },
+            "Type": "AWS::Lambda::Function"
+        },
+        "ipv6calculation": {
+            "DependsOn": "ExampleIPV6Block",
+            "Properties": {
+                "AllocatedSubnet": {
+                    "Fn::Select": [
+                        0,
+                        {
+                            "Fn::GetAtt": [
+                                "Example",
+                                "Ipv6CidrBlocks"
+                            ]
+                        }
+                    ]
+                },
+                "ServiceToken": {
+                    "Fn::GetAtt": [
+                        "Ipv6SubnetCalculatorFunction",
+                        "Arn"
+                    ]
+                },
+                "SubnetIndexStart": "0"
+            },
+            "Type": "Custom::Ipv6SubnetCalculator"
+        }
+    }
+}


### PR DESCRIPTION
Thought this little example might be useful for someone. I've had a bit of a fight with the IPv6 support in AWS and currently it doesn't seem Amazon provides any proper mechanism for chopping the provided /56 into /64 pieces for automatic provisioning, so did this little custom resource for it, until Amazon hopefully get around to creating an intrinsic function for it, or however they'll solve it.

Maybe someone else is interested. Also, it's a decent basic example of IPv6 provisioning.