### PR TITLE
Initial take on SAM support in troposphere

### DIFF
--- a/examples/Serverless_Api_Backend.py
+++ b/examples/Serverless_Api_Backend.py
@@ -1,0 +1,87 @@
+# Converted from api_backend located at:
+# https://github.com/awslabs/serverless-application-model/blob/dbc54b5d0cd31bf5cebd16d765b74aee9eb34641/examples/2016-10-31/api_backend/template.yaml
+
+from troposphere import Template, Ref
+from troposphere.awslambda import Environment
+from troposphere.serverless import Function, ApiEvent, SimpleTable
+
+t = Template()
+
+t.add_description(
+    "Simple CRUD webservice. State is stored in a SimpleTable (DynamoDB) "
+    "resource.")
+
+t.add_transform('AWS::Serverless-2016-10-31')
+
+simple_table = t.add_resource(
+    SimpleTable("Table")
+)
+
+t.add_resource(
+    Function(
+        "GetFunction",
+        Handler='index.get',
+        Runtime='nodejs4.3',
+        CodeUri='s3://<bucket>/api_backend.zip',
+        Policies='AmazonDynamoDBReadOnlyAccess',
+        Environment=Environment(
+            Variables={
+                'TABLE_NAME': Ref(simple_table)
+            }
+        ),
+        Events={
+            'GetResource': ApiEvent(
+                'GetResource',
+                Path='/resource/{resourceId}',
+                Method='get'
+            )
+        }
+    )
+)
+
+t.add_resource(
+    Function(
+        "PutFunction",
+        Handler='index.put',
+        Runtime='nodejs4.3',
+        CodeUri='s3://<bucket>/api_backend.zip',
+        Policies='AmazonDynamoDBReadOnlyAccess',
+        Environment=Environment(
+            Variables={
+                'TABLE_NAME': Ref(simple_table)
+            }
+        ),
+        Events={
+            'PutResource': ApiEvent(
+                'PutResource',
+                Path='/resource/{resourceId}',
+                Method='put'
+            )
+        }
+    )
+)
+
+t.add_resource(
+    Function(
+        "DeleteFunction",
+        Handler='index.delete',
+        Runtime='nodejs4.3',
+        CodeUri='s3://<bucket>/api_backend.zip',
+        Policies='AmazonDynamoDBReadOnlyAccess',
+        Environment=Environment(
+            Variables={
+                'TABLE_NAME': Ref(simple_table)
+            }
+        ),
+        Events={
+            'DeleteResource': ApiEvent(
+                'DeleteResource',
+                Path='/resource/{resourceId}',
+                Method='delete'
+            )
+        }
+    )
+)
+
+
+print(t.to_json())

--- a/examples/Serverless_S3_Processor.py
+++ b/examples/Serverless_S3_Processor.py
@@ -1,0 +1,38 @@
+# Converted from s3_processor located at:
+# https://github.com/awslabs/serverless-application-model/blob/dbc54b5d0cd31bf5cebd16d765b74aee9eb34641/examples/2016-10-31/s3_processor/template.yaml
+
+from troposphere import Template, Ref
+from troposphere.s3 import Bucket
+from troposphere.serverless import Function, EventSource
+
+t = Template()
+
+t.add_description(
+    "A function is triggered off an upload to a bucket. It logs the content "
+    "type of the uploaded object.")
+
+t.add_transform('AWS::Serverless-2016-10-31')
+
+
+s3_bucket = t.add_resource(
+    Bucket("Bucket")
+)
+
+t.add_resource(
+    Function(
+        "ProcessorFunction",
+        Handler='index.handler',
+        Runtime='nodejs4.3',
+        CodeUri='s3://<bucket>/s3_processor.zip',
+        Policies='AmazonS3ReadOnlyAccess',
+        Events={
+            'PhotoUpload': EventSource(
+                Type='S3',
+                Bucket=Ref(s3_bucket),
+                Events=['s3:ObjectCreated:*']
+            )
+        }
+    )
+)
+
+print(t.to_json())

--- a/examples/Serverless_S3_Processor.py
+++ b/examples/Serverless_S3_Processor.py
@@ -3,7 +3,7 @@
 
 from troposphere import Template, Ref
 from troposphere.s3 import Bucket
-from troposphere.serverless import Function, EventSource
+from troposphere.serverless import Function, S3Event
 
 t = Template()
 
@@ -26,8 +26,8 @@ t.add_resource(
         CodeUri='s3://<bucket>/s3_processor.zip',
         Policies='AmazonS3ReadOnlyAccess',
         Events={
-            'PhotoUpload': EventSource(
-                Type='S3',
+            'PhotoUpload': S3Event(
+                'PhotoUpload',
                 Bucket=Ref(s3_bucket),
                 Events=['s3:ObjectCreated:*']
             )

--- a/tests/examples_output/Serverless_Api_Backend.template
+++ b/tests/examples_output/Serverless_Api_Backend.template
@@ -1,0 +1,84 @@
+{
+    "Description": "Simple CRUD webservice. State is stored in a SimpleTable (DynamoDB) resource.",
+    "Resources": {
+        "DeleteFunction": {
+            "Properties": {
+                "CodeUri": "s3://<bucket>/api_backend.zip",
+                "Environment": {
+                    "Variables": {
+                        "TABLE_NAME": {
+                            "Ref": "Table"
+                        }
+                    }
+                },
+                "Events": {
+                    "DeleteResource": {
+                        "Properties": {
+                            "Method": "delete",
+                            "Path": "/resource/{resourceId}"
+                        },
+                        "Type": "Api"
+                    }
+                },
+                "Handler": "index.delete",
+                "Policies": "AmazonDynamoDBReadOnlyAccess",
+                "Runtime": "nodejs4.3"
+            },
+            "Type": "AWS::Serverless::Function"
+        },
+        "GetFunction": {
+            "Properties": {
+                "CodeUri": "s3://<bucket>/api_backend.zip",
+                "Environment": {
+                    "Variables": {
+                        "TABLE_NAME": {
+                            "Ref": "Table"
+                        }
+                    }
+                },
+                "Events": {
+                    "GetResource": {
+                        "Properties": {
+                            "Method": "get",
+                            "Path": "/resource/{resourceId}"
+                        },
+                        "Type": "Api"
+                    }
+                },
+                "Handler": "index.get",
+                "Policies": "AmazonDynamoDBReadOnlyAccess",
+                "Runtime": "nodejs4.3"
+            },
+            "Type": "AWS::Serverless::Function"
+        },
+        "PutFunction": {
+            "Properties": {
+                "CodeUri": "s3://<bucket>/api_backend.zip",
+                "Environment": {
+                    "Variables": {
+                        "TABLE_NAME": {
+                            "Ref": "Table"
+                        }
+                    }
+                },
+                "Events": {
+                    "PutResource": {
+                        "Properties": {
+                            "Method": "put",
+                            "Path": "/resource/{resourceId}"
+                        },
+                        "Type": "Api"
+                    }
+                },
+                "Handler": "index.put",
+                "Policies": "AmazonDynamoDBReadOnlyAccess",
+                "Runtime": "nodejs4.3"
+            },
+            "Type": "AWS::Serverless::Function"
+        },
+        "Table": {
+            "Type": "AWS::Serverless::SimpleTable"
+        }
+    },
+    "Transform": "AWS::Serverless-2016-10-31"
+}

--- a/tests/examples_output/Serverless_S3_Processor.template
+++ b/tests/examples_output/Serverless_S3_Processor.template
@@ -9,12 +9,14 @@
                 "CodeUri": "s3://<bucket>/s3_processor.zip",
                 "Events": {
                     "PhotoUpload": {
-                        "Bucket": {
-                            "Ref": "Bucket"
+                        "Properties": {
+                            "Bucket": {
+                                "Ref": "Bucket"
+                            },
+                            "Events": [
+                                "s3:ObjectCreated:*"
+                            ]
                         },
-                        "Events": [
-                            "s3:ObjectCreated:*"
-                        ],
                         "Type": "S3"
                     }
                 },

--- a/tests/examples_output/Serverless_S3_Processor.template
+++ b/tests/examples_output/Serverless_S3_Processor.template
@@ -1,0 +1,29 @@
+{
+    "Description": "A function is triggered off an upload to a bucket. It logs the content type of the uploaded object.",
+    "Resources": {
+        "Bucket": {
+            "Type": "AWS::S3::Bucket"
+        },
+        "ProcessorFunction": {
+            "Properties": {
+                "CodeUri": "s3://<bucket>/s3_processor.zip",
+                "Events": {
+                    "PhotoUpload": {
+                        "Bucket": {
+                            "Ref": "Bucket"
+                        },
+                        "Events": [
+                            "s3:ObjectCreated:*"
+                        ],
+                        "Type": "S3"
+                    }
+                },
+                "Handler": "index.handler",
+                "Policies": "AmazonS3ReadOnlyAccess",
+                "Runtime": "nodejs4.3"
+            },
+            "Type": "AWS::Serverless::Function"
+        }
+    },
+    "Transform": "AWS::Serverless-2016-10-31"
+}

--- a/tests/test_serverless.py
+++ b/tests/test_serverless.py
@@ -2,6 +2,7 @@ import unittest
 from troposphere import Template
 from troposphere.serverless import Function, Api, SimpleTable
 
+
 class TestServerless(unittest.TestCase):
     def test_required_function(self):
         serverless_func = Function(
@@ -31,6 +32,7 @@ class TestServerless(unittest.TestCase):
         t = Template()
         t.add_resource(serverless_table)
         t.to_json()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_serverless.py
+++ b/tests/test_serverless.py
@@ -1,0 +1,36 @@
+import unittest
+from troposphere import Template
+from troposphere.serverless import Function, Api, SimpleTable
+
+class TestServerless(unittest.TestCase):
+    def test_required_function(self):
+        serverless_func = Function(
+            "SomeHandler",
+            Handler="index.handler",
+            Runtime="nodejs",
+            CodeUri="s3://bucket/handler.zip"
+        )
+        t = Template()
+        t.add_resource(serverless_func)
+        t.to_json()
+
+    def test_required_api(self):
+        serverless_api = Api(
+            "SomeApi",
+            StageName='test',
+            DefinitionUri='s3://bucket/swagger.yml',
+        )
+        t = Template()
+        t.add_resource(serverless_api)
+        t.to_json()
+
+    def test_simple_table(self):
+        serverless_table = SimpleTable(
+            "SomeTable"
+        )
+        t = Template()
+        t.add_resource(serverless_table)
+        t.to_json()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -23,6 +23,12 @@ class TestInitArguments(unittest.TestCase):
         template = Template(Metadata=value)
         self.assertEqual(template.metadata, value)
 
+    def test_transform(self):
+        transform = 'AWS::Serverless-2016-10-31'
+        template = Template()
+        template.add_transform(transform)
+        self.assertEqual(template.transform, transform)
+
 
 class TestValidate(unittest.TestCase):
     def test_max_parameters(self):

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -458,6 +458,7 @@ class Tags(AWSHelperFn):
 class Template(object):
     props = {
         'AWSTemplateFormatVersion': (basestring, False),
+        'Transform': (basestring, False),
         'Description': (basestring, False),
         'Parameters': (dict, False),
         'Mappings': (dict, False),
@@ -474,6 +475,7 @@ class Template(object):
         self.parameters = {}
         self.resources = {}
         self.version = None
+        self.transform = None
 
     def add_description(self, description):
         self.description = description
@@ -522,6 +524,9 @@ class Template(object):
         else:
             self.version = "2010-09-09"
 
+    def add_transform(self, transform):
+        self.transform = transform
+
     def to_dict(self):
         t = {}
         if self.description:
@@ -538,6 +543,8 @@ class Template(object):
             t['Parameters'] = self.parameters
         if self.version:
             t['AWSTemplateFormatVersion'] = self.version
+        if self.transform:
+            t['Transform'] = self.transform
         t['Resources'] = self.resources
 
         return encode_to_dict(t)

--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2017, Fernando Freire <fernando.freire@nike.com>
+# All rights reserved.
+#
+# See LICENSE file for full license.
+
+from . import AWSObject, AWSProperty
+from .awslambda import Environment, VPCConfig, validate_memory_size
+from .dynamodb import ProvisionedThroughput
+from .iam import policytypes
+from .validators import positive_integer
+
+
+def primary_key_type_validator(x):
+    valid_types = ["String", "Number", "Binary"]
+    if x not in valid_types:
+        raise ValueError("KeyType must be one of: %s" % ", ".join(valid_types))
+    return x
+
+
+class Function(AWSObject):
+    resource_type = "AWS::Serverless::Function"
+
+    props = {
+        'Handler': (basestring, True),
+        'Runtime': (basestring, True),
+        'CodeUri': (basestring, True),
+        'Description': (basestring, False),
+        'MemorySize': (validate_memory_size, False),
+        'Timeout': (positive_integer, False),
+        'Role': (basestring, False),
+        'Policies': (policytypes, False),  # TODO not sure this is the righht approach
+        'Environment': (Environment, False),
+        'VpcConfig': (VPCConfig, False),
+        'Events': (dict, False)  # TODO this is certainly not the right approach
+    }
+
+
+class Api(AWSObject):
+    resource_type = "AWS::Serverless::Api"
+
+    props = {
+        'StageName': (basestring, True),
+        'DefinitionUri': (basestring, True),
+        'CacheClusterEnabled': (bool, False),
+        'CacheClusterSize': (basestring, False),
+        'Variables': (dict, False)
+    }
+
+
+class PrimaryKey(AWSProperty):
+    props = {
+        'Name': (basestring, False),
+        'Type': (primary_key_type_validator, False)
+    }
+
+
+class SimpleTable(AWSObject):
+    resource_type = "AWS::Serverless::SimpleTable"
+
+    props = {
+        'PrimaryKey': (PrimaryKey, False),
+        'ProvisionedThroughput': (ProvisionedThroughput, False)
+    }
+
+class S3EventSource(AWSObject):
+    resource_type = 'S3'
+
+    props = {
+        'Bucket': (basestring, True),
+        'Events': (basestring, True),
+        'Filter': (basestring, False)
+    }

--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -17,6 +17,7 @@ def primary_key_type_validator(x):
         raise ValueError("KeyType must be one of: %s" % ", ".join(valid_types))
     return x
 
+
 def policy_validator(x):
     if isinstance(x, types.StringTypes):
         return x
@@ -73,12 +74,90 @@ class SimpleTable(AWSObject):
         'ProvisionedThroughput': (ProvisionedThroughput, False)
     }
 
-class EventSource(AWSProperty):
+
+class S3Event(AWSObject):
     resource_type = 'S3'
 
     props = {
-        'Type': (basestring, True),
         'Bucket': (basestring, True),
         'Events': (list, True),
         'Filter': (basestring, False)
     }
+
+
+class SNSEvent(AWSObject):
+    resource_type = 'SNS'
+
+    props = {
+        'Topic': (basestring, True)
+    }
+
+
+def starting_position_validator(x):
+    valid_types = ['TRIM_HORIZON', 'LATEST']
+    if x not in valid_types:
+        raise ValueError("StartingPosition must be one of: %s" % ", ".join(valid_types))
+    return x
+
+
+class KinesisEvent(AWSObject):
+    resource_type = 'Kinesis'
+
+    props = {
+        'Stream': (basestring, True),
+        'StartingPosition': (starting_position_validator, True),
+        'BatchSize': (positive_integer, False)
+    }
+
+
+class DynamoDBEvent(AWSObject):
+    resource_type = 'DynamoDB'
+
+    props = {
+        'Stream': (basestring, True),
+        'StartingPosition': (starting_position_validator, True),
+        'BatchSize': (positive_integer, False)
+    }
+
+
+class ApiEvent(AWSObject):
+    resource_type = 'Api'
+
+    props = {
+        'Path': (basestring, True),
+        'Method': (basestring, True),
+        'RestApiId': (basestring, False)
+    }
+
+
+class ScheduleEvent(AWSObject):
+    resource_type = 'Schedule'
+
+    props = {
+        'Schedule': (basestring, True),
+        'Input': (basestring, False)
+    }
+
+
+class CloudWatchEvent(AWSObject):
+    resource_type = 'CloudWatchEvent'
+
+    props = {
+        'Pattern': (dict, True),
+        'Input': (basestring, False),
+        'InputPath': (basestring, False)
+    }
+
+
+class IoTRuleEvent(AWSObject):
+    resource_type = 'IoTRule'
+
+    props = {
+        'Sql': (basestring, True),
+        'AwsIotSqlVersion': (basestring, False)
+    }
+
+
+class AlexaSkillEvent(AWSObject):
+    resource_type = 'AlexaSkill'
+    props = {}

--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -96,7 +96,10 @@ class SNSEvent(AWSObject):
 def starting_position_validator(x):
     valid_types = ['TRIM_HORIZON', 'LATEST']
     if x not in valid_types:
-        raise ValueError("StartingPosition must be one of: %s" % ", ".join(valid_types))
+        raise ValueError(
+            "StartingPosition must be one of: %s"
+            % ", ".join(valid_types)
+        )
     return x
 
 

--- a/troposphere/template_generator.py
+++ b/troposphere/template_generator.py
@@ -30,7 +30,7 @@ from troposphere.policies import UpdatePolicy, CreationPolicy
 
 
 class TemplateGenerator(Template):
-    DEPRECATED_MODULES = ['troposphere.dynamodb']
+    DEPRECATED_MODULES = ['troposphere.dynamodb', 'troposphere.serverless']
 
     _inspect_members = set()
     _inspect_resources = {}

--- a/troposphere/template_generator.py
+++ b/troposphere/template_generator.py
@@ -45,6 +45,8 @@ class TemplateGenerator(Template):
         self._reference_map = {}
         if 'AWSTemplateFormatVersion' in cf_template:
             self.add_version(cf_template['AWSTemplateFormatVersion'])
+        if 'Transform' in cf_template:
+            self.add_transform(cf_template['Transform'])
         if 'Description' in cf_template:
             self.add_description(cf_template['Description'])
         if 'Metadata' in cf_template:


### PR DESCRIPTION
Howdy,

We've taken a stab at implementing [SAM support](https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md) for Troposphere. Everything is wired up and works okay except for two related issues:

  - The events block in `Function` is a map of string key to object value. The current implementation technically generates this structure but the block titles are duplicated and it doesn't look very nice.
  - Because events are instantiated as full AWSObjects it's breaking tests in CodeBuild and CodePipeline

Any suggestions on how to move forward?