### PR TITLE
SSM Target fix Values instead of Value

### DIFF
--- a/troposphere/ssm.py
+++ b/troposphere/ssm.py
@@ -9,7 +9,7 @@ from . import AWSObject, AWSProperty
 class Targets(AWSProperty):
     props = {
         'Key': (basestring, True),
-        'Value': ([basestring], True),
+        'Values': ([basestring], True),
     }
 
 


### PR DESCRIPTION
The SSM Target Property only support "Values" not "Value"

Source:
http://docs.aws.amazon.com/ssm/latest/APIReference/API_Target.html