### PR TITLE
Do json validation on ApiGateway::Model Schema (Fix #679)

### DIFF
--- a/tests/test_apigateway.py
+++ b/tests/test_apigateway.py
@@ -1,0 +1,51 @@
+import unittest
+from troposphere.apigateway import Model
+
+
+class TestModel(unittest.TestCase):
+    def test_schema(self):
+        # Check with no schema
+        model = Model(
+            "schema",
+            RestApiId="apiid",
+        )
+        model.validate()
+
+        # Check valid json schema string
+        model = Model(
+            "schema",
+            RestApiId="apiid",
+            Schema='{"a": "b"}',
+        )
+        model.validate()
+
+        # Check invalid json schema string
+        model = Model(
+            "schema",
+            RestApiId="apiid",
+            Schema='{"a: "b"}',
+        )
+        with self.assertRaises(ValueError):
+            model.validate()
+
+        # Check accepting dict and converting to string in validate
+        d = {"c": "d"}
+        model = Model(
+            "schema",
+            RestApiId="apiid",
+            Schema=d
+        )
+        model.validate()
+        self.assertEqual(model.properties['Schema'], '{"c": "d"}')
+
+        # Check invalid Schema type
+        with self.assertRaises(TypeError):
+            model = Model(
+                "schema",
+                RestApiId="apiid",
+                Schema=1
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_apigateway.py
+++ b/tests/test_apigateway.py
@@ -1,4 +1,5 @@
 import unittest
+from troposphere import Join
 from troposphere.apigateway import Model
 
 
@@ -45,6 +46,14 @@ class TestModel(unittest.TestCase):
                 RestApiId="apiid",
                 Schema=1
             )
+
+        # Check Schema being an AWSHelperFn
+        model = Model(
+            "schema",
+            RestApiId="apiid",
+            Schema=Join(':', ['{"a', ': "b"}']),
+        )
+        model.validate()
 
 
 if __name__ == '__main__':

--- a/troposphere/apigateway.py
+++ b/troposphere/apigateway.py
@@ -1,5 +1,6 @@
 from . import AWSObject, AWSProperty
 from .validators import positive_integer
+import json
 
 
 def validate_authorizer_ttl(ttl_value):
@@ -183,8 +184,20 @@ class Model(AWSObject):
         "Description": (basestring, False),
         "Name": (basestring, False),
         "RestApiId": (basestring, True),
-        "Schema": (basestring, False)
+        "Schema": ((basestring, dict), False)
     }
+
+    def validate(self):
+        if 'Schema' in self.properties:
+            schema = self.properties.get('Schema')
+            if isinstance(schema, basestring):
+                # Verify it is a valid json string
+                json.loads(schema)
+            elif isinstance(schema, dict):
+                # Convert the dict to a basestring
+                self.properties['Schema'] = json.dumps(schema)
+            else:
+                raise ValueError("Schema must be a str or dict")
 
 
 class Resource(AWSObject):

--- a/troposphere/apigateway.py
+++ b/troposphere/apigateway.py
@@ -1,4 +1,4 @@
-from . import AWSObject, AWSProperty
+from . import AWSHelperFn, AWSObject, AWSProperty
 from .validators import positive_integer
 import json
 
@@ -196,6 +196,8 @@ class Model(AWSObject):
             elif isinstance(schema, dict):
                 # Convert the dict to a basestring
                 self.properties['Schema'] = json.dumps(schema)
+            elif isinstance(schema, AWSHelperFn):
+                pass
             else:
                 raise ValueError("Schema must be a str or dict")
 


### PR DESCRIPTION
Allow both a string and dict for the ApiGateway::Model Schema.
The string form is checked for a valid json string and the dict
form is converted into a json string.