### PR TITLE
making ref() aware of lists

### DIFF
--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -425,7 +425,12 @@ class Select(AWSHelperFn):
 
 class Ref(AWSHelperFn):
     def __init__(self, data):
-        self.data = {'Ref': self.getdata(data)}
+        if type(data) == type([]):
+            self.data = []
+            for item in data:
+                self.data.append({'Ref': item})
+        else:
+            self.data = {'Ref': self.getdata(data)}
 
 
 class Condition(AWSHelperFn):

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -425,7 +425,7 @@ class Select(AWSHelperFn):
 
 class Ref(AWSHelperFn):
     def __init__(self, data):
-        if type(data) == type([]):
+        if isinstance(data, list):
             self.data = []
             for item in data:
                 self.data.append({'Ref': item})


### PR DESCRIPTION
Hi all,

I had the situation, that i wanted to create multiple ManagedPolicies, which shall be referenced by a created Role. To do so I had to reference more than one ManagedPolicy using Ref(), but this was not possible since Ref() always points to exact one destination.

I've implemented a check if the given object is an List and then extended the function as needed.

Cheers,
Matthias