### PR TITLE
Allow dash in titles

### DIFF
--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -32,7 +32,7 @@ MAX_PARAMETERS = 60
 MAX_RESOURCES = 200
 PARAMETER_TITLE_MAX = 255
 
-valid_names = re.compile(r'^[a-zA-Z0-9]+$')
+valid_names = re.compile(r'^[a-zA-Z0-9\-]+$')
 
 
 def is_aws_object_subclass(cls):


### PR DESCRIPTION
As far as I can tell, AWS doesn't restrict using dashes in names. This updated regex will permit dashes, which makes the titles easier to read in my environment.