### PR TITLE
VPCPeeringConnection: add PeerOwnerId & PeerRoleArn

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -559,6 +559,8 @@ class VPCPeeringConnection(AWSObject):
         'PeerVpcId': (basestring, True),
         'VpcId': (basestring, True),
         'Tags': (list, False),
+        'PeerOwnerId': (basestring, False),
+        'PeerRoleArn': (basestring, False),
     }
 
 


### PR DESCRIPTION
Adding PeerOwnerId & PeerRoleArn
```
{
   "Type" : "AWS::EC2::VPCPeeringConnection",
   "Properties" : {
      "PeerVpcId" : String,
      "Tags" : [ Resource Tag, ... ],
      "VpcId" : String,
      "PeerOwnerId" : String,
      "PeerRoleArn" :  String
   }
}
```
http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpcpeeringconnection.html

