### PR TITLE
IAM: Add InstanceProfileName to InstanceProfile

### DIFF
--- a/troposphere/iam.py
+++ b/troposphere/iam.py
@@ -67,6 +67,7 @@ class InstanceProfile(AWSObject):
     props = {
         'Path': (iam_path, False),
         'Roles': (list, True),
+        'InstanceProfileName': (basestring, False),
     }
 
 


### PR DESCRIPTION
Add InstanceProfileName to InstanceProfile
```
{
   "Type": "AWS::IAM::InstanceProfile",
   "Properties": {
      "Path": String,
      "Roles": [ IAM Roles ],
      "InstanceProfileName": String
   }
}
```
http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html