### PR TITLE
Add new subproperties to route53 and redshift

### DIFF
--- a/troposphere/redshift.py
+++ b/troposphere/redshift.py
@@ -24,6 +24,7 @@ class Cluster(AWSObject):
         'Encrypted': (boolean, False),
         'HsmClientCertificateIdentifier': (basestring, False),
         'HsmConfigurationIdentifier': (basestring, False),
+        'IamRoles': ([basestring], False),
         'KmsKeyId': (basestring, False),
         'MasterUsername': (basestring, True),
         'MasterUserPassword': (basestring, True),

--- a/troposphere/route53.py
+++ b/troposphere/route53.py
@@ -77,11 +77,25 @@ class RecordSetGroup(AWSObject):
     }
 
 
+class AlarmIdentifier(AWSProperty):
+    props = {
+        'Name': (basestring, True),
+        'Region': (basestring, True),
+    }
+
+
 class HealthCheckConfiguration(AWSProperty):
     props = {
+        'AlarmIdentifier': (AlarmIdentifier, False),
+        'ChildHealthChecks': (basestring, False),
+        'EnableSNI': (boolean, False),
         'FailureThreshold': (positive_integer, False),
         'FullyQualifiedDomainName': (basestring, False),
+        'HealthThreshold': (positive_integer, False),
+        'InsufficientDataHealthStatus': (basestring, False),
+        'Inverted': (boolean, False),
         'IPAddress': (basestring, False),
+        'MeasureLatency': (boolean, False),
         'Port': (network_port, False),
         'RequestInterval': (positive_integer, False),
         'ResourcePath': (basestring, False),


### PR DESCRIPTION
**AWS::Route53::HealthCheck**
There are seven new resource subproperty types for the Amazon Route 53 HealthCheckConfig HealthCheckConfig property: AlarmIdentifier, ChildHealthChecks, EnableSNI, HealthThreshold, InsufficientDataHealthStatus, Inverted, and MeasureLatency.

```
{
  "AlarmIdentifier" : AlarmIdentifier,
  "ChildHealthChecks" : String,
  "EnableSNI" : Boolean,
  "FailureThreshold" : Integer,
  "FullyQualifiedDomainName" : String,
  "HealthThreshold" : Integer,
  "InsufficientDataHealthStatus" : String,
  "Inverted" : Boolean,
  "IPAddress" : String,
  "MeasureLatency" : Boolean,
  "Port" : Integer,
  "RequestInterval" : Integer,
  "ResourcePath" : String,
  "SearchString" : String,
  "Type" : String
}
```
http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig.html

**AlarmIdentifier**
```
{
  "Name" : String,
  "Region" : String
}
```
http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-healthcheck-healthcheckconfig-alarmidentifier.html

**AWS::Redshift::Cluster**
Use the IamRoles property to provide a list of one or more AWS Identity and Access Management roles that the Amazon Redshift cluster can use to access other AWS services.
```
{
  "Type" : "AWS::Redshift::Cluster",
  "Properties" : {
    "AllowVersionUpgrade" : Boolean,
    "AutomatedSnapshotRetentionPeriod" : Integer,
    "AvailabilityZone" : String,
    "ClusterParameterGroupName" : String,
    "ClusterSecurityGroups" : [ String, ... ],
    "ClusterSubnetGroupName" : String,
    "ClusterType" : String,
    "ClusterVersion" : String,
    "DBName" : String,
    "ElasticIp" : String,
    "Encrypted" : Boolean,
    "HsmClientCertificateIdentifier" : String,
    "HsmConfigurationIdentifier" : String,
    "IamRoles" : [ String, ... ],
    "KmsKeyId" : String,
    "MasterUsername" : String,
    "MasterUserPassword" : String,
    "NodeType" : String,
    "NumberOfNodes" : Integer,
    "OwnerAccount" : String,
    "Port" : Integer,
    "PreferredMaintenanceWindow" : String,
    "PubliclyAccessible" : Boolean,
    "SnapshotClusterIdentifier" : String,
    "SnapshotIdentifier" : String,
    "VpcSecurityGroupIds" : [ String, ... ]
  }
}
```
http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-redshift-cluster.html