### PR TITLE
Change EFS Tags to allow add tags as a python list

### DIFF
--- a/troposphere/efs.py
+++ b/troposphere/efs.py
@@ -5,7 +5,7 @@ class FileSystem(AWSObject):
     resource_type = "AWS::EFS::FileSystem"
 
     props = {
-        'FileSystemTags': (Tags, False),
+        'FileSystemTags': (list, False),
         'PerformanceMode': (basestring, False),
     }
 

--- a/troposphere/efs.py
+++ b/troposphere/efs.py
@@ -1,4 +1,4 @@
-from . import AWSObject, Tags
+from . import AWSObject
 
 
 class FileSystem(AWSObject):


### PR DESCRIPTION
Sometimes in the EFS Tags we use some advance tags like _"user:application"="XYZ"_. Unfortunately the FileSystemTags does not allow to use more advance tag' name when it uses the Tags type.