### PR TITLE
Allow a dict to be passed in to initalize Tags

### DIFF
--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -42,6 +42,15 @@ class TestTags(unittest.TestCase):
         tags = Tags({'test-tag': '123456'})
         self.assertEqual(tags.to_dict(), result)
 
+        with self.assertRaises(TypeError):
+            Tags(1)
+        with self.assertRaises(TypeError):
+            Tags("tag")
+        with self.assertRaises(TypeError):
+            Tags("key", "value")
+        with self.assertRaises(TypeError):
+            Tags({}, "key", "value")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -26,6 +26,22 @@ class TestTags(unittest.TestCase):
         ]
         self.assertEqual(tags.to_dict(), result)
 
+    def test_Formats(self):
+        result = [
+            {'Value': 'bar', 'Key': 'bar'},
+            {'Value': 'baz', 'Key': 'baz'},
+            {'Value': 'foo', 'Key': 'foo'},
+        ]
+        tags = Tags(bar='bar', baz='baz', foo='foo')
+        self.assertEqual(tags.to_dict(), result)
+        tags = Tags({'bar': 'bar', 'baz': 'baz', 'foo': 'foo'})
+        self.assertEqual(tags.to_dict(), result)
+        tags = Tags(**{'bar': 'bar', 'baz': 'baz', 'foo': 'foo'})
+        self.assertEqual(tags.to_dict(), result)
+        result = [{'Key': 'test-tag', 'Value': '123456'}]
+        tags = Tags({'test-tag': '123456'})
+        self.assertEqual(tags.to_dict(), result)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -439,9 +439,18 @@ class ImportValue(AWSHelperFn):
 
 
 class Tags(AWSHelperFn):
-    def __init__(self, **kwargs):
+    def __init__(self, *args, **kwargs):
+        if not args:
+            # Assume kwargs variant
+            tag_dict = kwargs
+        else:
+            # Validate single argument passed in is a dict
+            if not isinstance(args[0], dict):
+                raise(TypeError, "Tags needs to be either kwargs or dict")
+            tag_dict = args[0]
+
         self.tags = []
-        for k, v in sorted(kwargs.iteritems()):
+        for k, v in sorted(tag_dict.iteritems()):
             self.tags.append({
                 'Key': k,
                 'Value': v,

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -444,6 +444,9 @@ class Tags(AWSHelperFn):
             # Assume kwargs variant
             tag_dict = kwargs
         else:
+            if len(args) != 1:
+                raise(TypeError, "Multiple non-kwargs passed to Tags")
+
             # Validate single argument passed in is a dict
             if not isinstance(args[0], dict):
                 raise(TypeError, "Tags needs to be either kwargs or dict")

--- a/troposphere/template_generator.py
+++ b/troposphere/template_generator.py
@@ -25,7 +25,7 @@ from troposphere import (
     Output, Parameter,  # AWSDeclarations
     AWSObject,  # covers resources
     AWSHelperFn, GenericHelperFn,  # covers ref, fn::, etc
-    autoscaling, cloudformation)
+    Tags, autoscaling, cloudformation)
 from troposphere.policies import UpdatePolicy, CreationPolicy
 
 
@@ -178,6 +178,12 @@ class TemplateGenerator(Template):
             # special handling for functions, we want to handle it before
             # entering the other conditions.
             try:
+                if issubclass(cls, Tags):
+                    arg_dict = {}
+                    for d in args:
+                        arg_dict[d['Key']] = d['Value']
+                    return cls(arg_dict)
+
                 if (isinstance(args, Sequence) and
                         not isinstance(args, basestring)):
                     return cls(*self._convert_definition(args))


### PR DESCRIPTION
The implementation of Tags has limitations due to the use of
kwargs for initialization. This change adds the ability to
initialize Tags using a dict.

@kaarolch @brandonshough @tomdeblende @tamas7 does this match the use cases for the issues filed on this behavior?