### PR TITLE
feat(Cloudwatch): add support for latest Cloudwatch alarms properties

### DIFF
--- a/troposphere/cloudwatch.py
+++ b/troposphere/cloudwatch.py
@@ -26,7 +26,7 @@ class Alarm(AWSObject):
         'Dimensions': ([MetricDimension], False),
         'EvaluateLowSampleCountPercentile': (basestring, False),
         'EvaluationPeriods': (positive_integer, True),
-        'ExtendedStatistic': (basestring, False)
+        'ExtendedStatistic': (basestring, False),
         'InsufficientDataActions': ([basestring], False),
         'MetricName': (basestring, True),
         'Namespace': (basestring, True),
@@ -35,7 +35,7 @@ class Alarm(AWSObject):
         'Statistic': (basestring, False),
         'Threshold': (basestring, True),
         'TreatMissingData': (basestring, False),
-        'Unit': (basestring, False),
+        'Unit': (basestring, False)
     }
 
     def validate(self):

--- a/troposphere/cloudwatch.py
+++ b/troposphere/cloudwatch.py
@@ -33,4 +33,6 @@ class Alarm(AWSObject):
         'Statistic': (basestring, True),
         'Threshold': (basestring, True),
         'Unit': (basestring, False),
+        'TreatMissingData': (basestring, False),
+        'EvaluateLowSampleCountPercentile': (basestring, False)
     }

--- a/troposphere/cloudwatch.py
+++ b/troposphere/cloudwatch.py
@@ -4,7 +4,7 @@
 # See LICENSE file for full license.
 
 from . import AWSObject, AWSProperty
-from .validators import positive_integer, boolean
+from .validators import positive_integer, boolean, exactly_one
 
 
 class MetricDimension(AWSProperty):
@@ -24,7 +24,9 @@ class Alarm(AWSObject):
         'AlarmName': (basestring, False),
         'ComparisonOperator': (basestring, True),
         'Dimensions': ([MetricDimension], False),
+        'EvaluateLowSampleCountPercentile': (basestring, False),
         'EvaluationPeriods': (positive_integer, True),
+        'ExtendedStatistic': (basestring, False)
         'InsufficientDataActions': ([basestring], False),
         'MetricName': (basestring, True),
         'Namespace': (basestring, True),
@@ -32,8 +34,13 @@ class Alarm(AWSObject):
         'Period': (positive_integer, True),
         'Statistic': (basestring, False),
         'Threshold': (basestring, True),
-        'Unit': (basestring, False),
         'TreatMissingData': (basestring, False),
-        'EvaluateLowSampleCountPercentile': (basestring, False),
-        'ExtendedStatistic': (basestring, False)
+        'Unit': (basestring, False),
     }
+
+    def validate(self):
+        conds = [
+            'ExtendedStatistic',
+            'Statistic',
+        ]
+        exactly_one(self.__class__.__name__, self.properties, conds)

--- a/troposphere/cloudwatch.py
+++ b/troposphere/cloudwatch.py
@@ -30,9 +30,10 @@ class Alarm(AWSObject):
         'Namespace': (basestring, True),
         'OKActions': ([basestring], False),
         'Period': (positive_integer, True),
-        'Statistic': (basestring, True),
+        'Statistic': (basestring, False),
         'Threshold': (basestring, True),
         'Unit': (basestring, False),
         'TreatMissingData': (basestring, False),
-        'EvaluateLowSampleCountPercentile': (basestring, False)
+        'EvaluateLowSampleCountPercentile': (basestring, False),
+        'ExtendedStatistic': (basestring, False)
     }


### PR DESCRIPTION
These new Cloudwatch alarms properties are documented here : http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarms-and-missing-data

CloudFormation API doc is not up to date right now though.