### PR TITLE
Update autoscaling example to remove rebinding

### DIFF
--- a/examples/Autoscaling.py
+++ b/examples/Autoscaling.py
@@ -126,7 +126,7 @@ ApiSubnet1 = t.add_parameter(Parameter(
     Description="First private VPC subnet ID for the api app.",
 ))
 
-LaunchConfiguration = t.add_resource(LaunchConfiguration(
+LaunchConfig = t.add_resource(LaunchConfiguration(
     "LaunchConfiguration",
     Metadata=autoscaling.Metadata(
         cloudformation.Init({
@@ -221,7 +221,7 @@ AutoscalingGroup = t.add_resource(AutoScalingGroup(
     Tags=[
         Tag("Environment", Ref(EnvType), True)
     ],
-    LaunchConfigurationName=Ref(LaunchConfiguration),
+    LaunchConfigurationName=Ref(LaunchConfig),
     MinSize=Ref(ScaleCapacity),
     MaxSize=Ref(ScaleCapacity),
     VPCZoneIdentifier=[Ref(ApiSubnet1), Ref(ApiSubnet2)],


### PR DESCRIPTION
The example imports the `LaunchConfiguration` class object, but then rebinds the `LaunchConfiguration` name to an instance of the class, preventing any further use of the `LaunchConfiguration` class object. This patch binds the instance object to a new variable name, keeping `LaunchConfiguration` bound to the original class object.