### PR TITLE
Added .Ref & .GetAtt helper methods

### DIFF
--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -273,11 +273,15 @@ class BaseAWSObject(object):
 class AWSObject(BaseAWSObject):
     dictname = 'Properties'
 
-    def Ref(self):  # noqa: N802
+    def ref(self):
         return Ref(self)
 
-    def GetAtt(self, value):  # noqa: N802
+    Ref = ref
+
+    def get_att(self, value):
         return GetAtt(self, value)
+
+    GetAtt = get_att
 
 
 class AWSDeclaration(BaseAWSObject):

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -273,6 +273,12 @@ class BaseAWSObject(object):
 class AWSObject(BaseAWSObject):
     dictname = 'Properties'
 
+    def Ref(self):  # noqa: N802
+        return Ref(self)
+
+    def GetAtt(self, value):  # noqa: N802
+        return GetAtt(self, value)
+
 
 class AWSDeclaration(BaseAWSObject):
     """
@@ -362,7 +368,7 @@ class FindInMap(AWSHelperFn):
 
 
 class GetAtt(AWSHelperFn):
-    def __init__(self, logicalName, attrName):
+    def __init__(self, logicalName, attrName):  # noqa: N803
         self.data = {'Fn::GetAtt': [self.getdata(logicalName), attrName]}
 
 
@@ -478,7 +484,7 @@ class Template(object):
         'Outputs': (dict, False),
     }
 
-    def __init__(self, Description=None, Metadata=None):
+    def __init__(self, Description=None, Metadata=None):  # noqa: N803
         self.description = Description
         self.metadata = {} if Metadata is None else Metadata
         self.conditions = {}


### PR DESCRIPTION
This is so common I figured it might be worth just attaching the
behavior to the base AWSObject.  Would mean a couple less imports, and
it feels more pythonic.