### PR TITLE
Updated Validation Regex for Validators to allow - and _

### DIFF
--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -32,7 +32,7 @@ MAX_PARAMETERS = 60
 MAX_RESOURCES = 200
 PARAMETER_TITLE_MAX = 255
 
-valid_names = re.compile(r'^[a-zA-Z0-9]+$')
+valid_names = re.compile(r'^[a-zA-Z0-9-_]+$')
 
 
 def is_aws_object_subclass(cls):


### PR DESCRIPTION
I have modified the troposphere use case to allow for the following:

```
GIVEN an AWS resource described by Troposphere script (specifically, SNS)
WHEN Troposphere is run
AND AWS resource includes alphanumerics and hyphens and underscores in display names
THEN Troposphere successfully generates CloudFormation which can run in AWS
```

I had a need to create SNS topics using Troposphere, and although AWS allows for alphanumerics + hyphens and underscores, the Troposphere validation was blocking successful creation of SNS topic names, such as "THIS_SNS_TOPIC-1"

Please let me know if there is a less global way to inject this regex change so that it only affects SNS topic creation, and I will gladly contribute.