### PR TITLE
Add new AWS::Lambda::Function Tags support

### DIFF
--- a/troposphere/awslambda.py
+++ b/troposphere/awslambda.py
@@ -1,4 +1,4 @@
-from . import AWSObject, AWSProperty, Join
+from . import AWSObject, AWSProperty, Join, Tags
 from .validators import positive_integer
 
 MEMORY_VALUES = [x for x in range(128, 1600, 64)]
@@ -138,6 +138,7 @@ class Function(AWSObject):
         'MemorySize': (validate_memory_size, False),
         'Role': (basestring, True),
         'Runtime': (basestring, True),
+        'Tags': (Tags, False),
         'Timeout': (positive_integer, False),
         'VpcConfig': (VPCConfig, False),
     }


### PR DESCRIPTION
The [April 28, 2017 release](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/ReleaseHistory.html) included support for `Tags` on the `AWS::Lambda::Function` resource.