### PR TITLE
Add ECS::Service ServiceName support

### DIFF
--- a/troposphere/ecs.py
+++ b/troposphere/ecs.py
@@ -35,6 +35,7 @@ class Service(AWSObject):
         'DesiredCount': (positive_integer, False),
         'LoadBalancers': ([LoadBalancer], False),
         'Role': (basestring, False),
+        'ServiceName': (basestring, False),
         'TaskDefinition': (basestring, True),
     }
 


### PR DESCRIPTION
The [April 28, 2017 release](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/ReleaseHistory.html) included support for the `ServiceName` property on `AWS::ECS::Service`.