### PR TITLE
Add missing CidrIpv6 property to ec2.SecurityGroupRule.

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -393,6 +393,7 @@ class SecurityGroupIngress(AWSObject):
 class SecurityGroupRule(AWSProperty):
     props = {
         'CidrIp': (basestring, False),
+        'CidrIpv6': (basestring, False),
         'FromPort': (network_port, False),
         'IpProtocol': (basestring, True),
         'SourceSecurityGroupId': (basestring, False),


### PR DESCRIPTION
Discovered a missing ipv6 parameter to the ec2.SecurityGroupRule object.

See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group-rule.html