### PR TITLE
Add missing properties to various objects in ec2.py

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -409,6 +409,7 @@ class SecurityGroup(AWSObject):
     resource_type = "AWS::EC2::SecurityGroup"
 
     props = {
+        'GroupName': (basestring, False),
         'GroupDescription': (basestring, True),
         'SecurityGroupEgress': (list, False),
         'SecurityGroupIngress': (list, False),

--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -134,7 +134,7 @@ class Placement(AWSProperty):
 class Ipv6Addresses(AWSHelperFn):
     def __init__(self, address):
         self.data = {
-            'Ipv6Addresses': address,
+            'Ipv6Address': address,
         }
 
 

--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -281,6 +281,8 @@ class NetworkInterface(AWSObject):
     props = {
         'Description': (basestring, False),
         'GroupSet': (list, False),
+        'Ipv6AddressCount': (integer, False),
+        'Ipv6Addresses': ([Ipv6Addresses], False),
         'PrivateIpAddress': (basestring, False),
         'PrivateIpAddresses': ([PrivateIpAddressSpecification], False),
         'SecondaryPrivateIpAddressCount': (integer, False),


### PR DESCRIPTION
Add IPv6 address related properties to ec2.NetworkInterface
Reference: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-interface.html

Made Ipv6Addresses use the property 'Ipv6Address' instead of 'Ipv6Addresses'.
Reference: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinterface-ipv6addresses.html

Add GroupName property to ec2.SecurityGroup
Reference: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html