### PR TITLE
logs.LogGroup#RetentionInDays is strictly defined list

### DIFF
--- a/troposphere/constants.py
+++ b/troposphere/constants.py
@@ -294,7 +294,8 @@ LIST_OF_HOSTED_ZONE_IDS = 'List<AWS::Route53::HostedZone::Id>'
 #
 # Logs
 #
-LOGS_ALLOWED_RETENTION_DAYS = [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
+LOGS_ALLOWED_RETENTION_DAYS = [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180,
+                               365, 400, 545, 731, 1827, 3653]
 
 #
 # Route53

--- a/troposphere/constants.py
+++ b/troposphere/constants.py
@@ -292,6 +292,11 @@ LIST_OF_VPC_IDS = 'List<AWS::EC2::VPC::Id>'
 LIST_OF_HOSTED_ZONE_IDS = 'List<AWS::Route53::HostedZone::Id>'
 
 #
+# Logs
+#
+LOGS_ALLOWED_RETENTION_DAYS = [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
+
+#
 # Route53
 #
 

--- a/troposphere/logs.py
+++ b/troposphere/logs.py
@@ -1,6 +1,6 @@
 from . import AWSObject, AWSProperty
 from .validators import integer_list_item
-from .constants import LOGS_ALLOWED_RETENTION_DAYS
+from .constants import LOGS_ALLOWED_RETENTION_DAYS as RETENTION_DAYS
 
 
 class Destination(AWSObject):
@@ -19,7 +19,7 @@ class LogGroup(AWSObject):
 
     props = {
         'LogGroupName': (basestring, False),
-        'RetentionInDays': (integer_list_item(LOGS_ALLOWED_RETENTION_DAYS), False),
+        'RetentionInDays': (integer_list_item(RETENTION_DAYS), False),
     }
 
 

--- a/troposphere/logs.py
+++ b/troposphere/logs.py
@@ -1,5 +1,6 @@
 from . import AWSObject, AWSProperty
-from .validators import positive_integer
+from .validators import integer_list_item
+from .constants import LOGS_ALLOWED_RETENTION_DAYS
 
 
 class Destination(AWSObject):
@@ -18,7 +19,7 @@ class LogGroup(AWSObject):
 
     props = {
         'LogGroupName': (basestring, False),
-        'RetentionInDays': (positive_integer, False),
+        'RetentionInDays': (integer_list_item(LOGS_ALLOWED_RETENTION_DAYS), False),
     }
 
 

--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -45,7 +45,8 @@ def integer_list_item(allowed_values):
         i = positive_integer(x)
         if i in allowed_values:
             return x
-        raise ValueError('Integer must be one of following: %s' % ', '.join(str(j) for j in allowed_values))
+        raise ValueError('Integer must be one of following: %s' %
+                         ', '.join(str(j) for j in allowed_values))
 
     return integer_list_item_checker
 

--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -40,6 +40,16 @@ def integer_range(minimum_val, maximum_val):
     return integer_range_checker
 
 
+def integer_list_item(allowed_values):
+    def integer_list_item_checker(x):
+        i = positive_integer(x)
+        if i in allowed_values:
+            return x
+        raise ValueError('Integer must be one of following: %s' % ', '.join(str(j) for j in allowed_values))
+
+    return integer_list_item_checker
+
+
 def network_port(x):
     from . import AWSHelperFn
 


### PR DESCRIPTION
When definining number of retention days for log group, it must be value from strictly defined list; if other value will be provided, CloudFormation will raise an error during stack creation