### PR TITLE
Added 'GroupName' prop to SecurityGroup

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -407,6 +407,7 @@ class SecurityGroup(AWSObject):
     resource_type = "AWS::EC2::SecurityGroup"
 
     props = {
+        'GroupName': (basestring, True),
         'GroupDescription': (basestring, True),
         'SecurityGroupEgress': (list, False),
         'SecurityGroupIngress': (list, False),


### PR DESCRIPTION
Was missing prior. It is there on CloudFormation docs but not on Troposphere.
Gives the ability to name a SecurityGroup from Troposphere.
http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html