### PR TITLE
Validation for parameters that can be numeric or string

### DIFF
--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -580,7 +580,7 @@ class Parameter(AWSDeclaration):
     NUMBER_PROPERTIES = ['MaxValue', 'MinValue']
     props = {
         'Type': (basestring, True),
-        'Default': (basestring, False),
+        'Default': (validators.string_or_integer, False),
         'NoEcho': (bool, False),
         'AllowedValues': (list, False),
         'AllowedPattern': (basestring, False),

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -580,7 +580,7 @@ class Parameter(AWSDeclaration):
     NUMBER_PROPERTIES = ['MaxValue', 'MinValue']
     props = {
         'Type': (basestring, True),
-        'Default': (validators.string_or_integer, False),
+        'Default': (validators.integer, False),
         'NoEcho': (bool, False),
         'AllowedValues': (list, False),
         'AllowedPattern': (basestring, False),

--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -22,6 +22,12 @@ def integer(x):
         return x
 
 
+def string_or_integer(val):
+    if isinstance(val, int) or isinstance(val, str):
+        return str(val)
+    raise ValueError("%r is not a valid integer or string" % val)
+
+
 def positive_integer(x):
     p = integer(x)
     if int(p) < 0:

--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -22,12 +22,6 @@ def integer(x):
         return x
 
 
-def string_or_integer(val):
-    if isinstance(val, int) or isinstance(val, str):
-        return str(val)
-    raise ValueError("%r is not a valid integer or string" % val)
-
-
 def positive_integer(x):
     p = integer(x)
     if int(p) < 0:


### PR DESCRIPTION
This fixes issue #717 

as /script/cfn2py converts some values to integers that are considered strings in AWS, this validation allows numerics or strings to be defined for a parameter, thus preventing a validation exception being thrown when either would be a valid form.