### PR TITLE
Add required attribute, JobFlowId, to EMR::InstanceGroupConfig

### DIFF
--- a/troposphere/emr.py
+++ b/troposphere/emr.py
@@ -186,6 +186,7 @@ class InstanceGroupConfig(AWSObject):
         'InstanceCount': (integer, True),
         'InstanceRole': (basestring, True),
         'InstanceType': (basestring, True),
+        'JobFlowId': (basestring, True),
         'Market': (market_validator, False),
         'Name': (basestring, False)
     }


### PR DESCRIPTION
The EMR InstanceGroupConfig is missing JobFlowId which is a required parameter and specifies the EMR cluster in which the instance group should be created. This PR adds that attribute and marks it as required.