### PR TITLE
Add WAFRegional support

### DIFF
--- a/examples/WAF_Regional_Common_Attacks_Sample.py
+++ b/examples/WAF_Regional_Common_Attacks_Sample.py
@@ -1,0 +1,228 @@
+# Converted from AWS WAF Sample located at:
+# https://s3.amazonaws.com/cloudformation-examples/community/common-attacks.json
+
+from troposphere import (
+    Template,
+    Parameter,
+    Join,
+    Ref
+)
+from troposphere.wafregional import (
+    Rule,
+    SqlInjectionMatchSet,
+    WebACL,
+    SizeConstraintSet,
+    IPSet,
+    XssMatchSet,
+    Predicates,
+    SqlInjectionMatchTuples,
+    FieldToMatch,
+    Action,
+    Rules,
+    SizeConstraint,
+    XssMatchTuple
+)
+
+t = Template()
+
+t.add_version("2010-09-09")
+
+t.add_description(
+    "Creates an AWS WAF configuration that protects against common attacks"
+)
+
+WebACLName = t.add_parameter(Parameter(
+    "WebACLName",
+    Default="CommonAttackProtection",
+    Type="String",
+    Description="Enter the name you want to use for the WebACL. "
+    "This value is also added as a prefix for the names of the rules, "
+    "conditions, and CloudWatch metrics created by this template.",
+))
+
+SqliMatchSet = t.add_resource(SqlInjectionMatchSet(
+    "SqliMatchSet",
+    Name=Join("", [Ref(WebACLName), "SqliMatch"]),
+    SqlInjectionMatchTuples=[
+        SqlInjectionMatchTuples(
+            FieldToMatch=FieldToMatch(
+                Type="QUERY_STRING"
+            ),
+            TextTransformation="URL_DECODE"
+        ),
+        SqlInjectionMatchTuples(
+            FieldToMatch=FieldToMatch(
+                Type="QUERY_STRING"
+            ),
+            TextTransformation="HTML_ENTITY_DECODE"
+        ),
+        SqlInjectionMatchTuples(
+            FieldToMatch=FieldToMatch(
+                Type="BODY"
+            ),
+            TextTransformation="URL_DECODE"
+        ),
+        SqlInjectionMatchTuples(
+            FieldToMatch=FieldToMatch(
+                Type="BODY"
+            ),
+            TextTransformation="HTML_ENTITY_DECODE"
+        ),
+        SqlInjectionMatchTuples(
+            FieldToMatch=FieldToMatch(
+                Type="URI"
+            ),
+            TextTransformation="URL_DECODE"
+        )
+    ]
+))
+
+SqliRule = t.add_resource(Rule(
+    "SqliRule",
+    Predicates=[
+        Predicates(
+            DataId=Ref(SqliMatchSet),
+            Type="SqlInjectionMatch",
+            Negated=False
+        )
+    ],
+    Name=Join("", [Ref(WebACLName), "SqliRule"]),
+    MetricName=Join("", [Ref(WebACLName), "SqliRule"]),
+))
+
+XssMatchSet = t.add_resource(XssMatchSet(
+    "XssMatchSet",
+    Name=Join("", [Ref(WebACLName), "XssMatch"]),
+    XssMatchTuples=[
+        XssMatchTuple(
+            FieldToMatch=FieldToMatch(
+                Type="QUERY_STRING",
+            ),
+            TextTransformation="URL_DECODE"
+        ),
+        XssMatchTuple(
+            FieldToMatch=FieldToMatch(
+                Type="QUERY_STRING",
+            ),
+            TextTransformation="HTML_ENTITY_DECODE"
+        ),
+        XssMatchTuple(
+            FieldToMatch=FieldToMatch(
+                Type="BODY",
+            ),
+            TextTransformation="URL_DECODE"
+        ),
+        XssMatchTuple(
+            FieldToMatch=FieldToMatch(
+                Type="BODY",
+            ),
+            TextTransformation="HTML_ENTITY_DECODE"
+        ),
+        XssMatchTuple(
+            FieldToMatch=FieldToMatch(
+                Type="URI",
+            ),
+            TextTransformation="URL_DECODE"
+        )
+    ]
+))
+
+XssRule = t.add_resource(Rule(
+    "XssRule",
+    Name=Join("", [Ref(WebACLName), "XssRule"]),
+    Predicates=[
+        Predicates(
+            DataId=Ref(XssMatchSet),
+            Type="XssMatch",
+            Negated=False
+        )
+    ],
+    MetricName=Join("", [Ref(WebACLName), "XssRule"]),
+))
+
+WAFManualIPBlockSet = t.add_resource(IPSet(
+    "WAFManualIPBlockSet",
+    Name="Manual IP Block Set",
+))
+
+ManualIPBlockRule = t.add_resource(Rule(
+    "ManualIPBlockRule",
+    Name=Join("", [Ref(WebACLName), "ManualIPBlockRule"]),
+    MetricName=Join("", [Ref(WebACLName), "ManualIPBlockRule"]),
+    Predicates=[
+        Predicates(
+            DataId=Ref(WAFManualIPBlockSet),
+            Type="IPMatch",
+            Negated=False
+        )
+    ]
+))
+
+SizeMatchSet = t.add_resource(SizeConstraintSet(
+    "SizeMatchSet",
+    Name=Join("", [Ref(WebACLName), "LargeBodyMatch"]),
+    SizeConstraints=[
+        SizeConstraint(
+            ComparisonOperator="GT",
+            TextTransformation="NONE",
+            FieldToMatch=FieldToMatch(
+                Type="BODY"
+            ),
+            Size="8192"
+        )
+    ]
+))
+
+SizeMatchRule = t.add_resource(Rule(
+    "SizeMatchRule",
+    Name=Join("", [Ref(WebACLName), "LargeBodyMatchRule"]),
+    MetricName=Join("", [Ref(WebACLName), "DetectLargeBody"]),
+    Predicates=[
+        Predicates(
+            DataId=Ref(SizeMatchSet),
+            Type="SizeConstraint",
+            Negated=False
+        )
+    ]
+))
+
+MyWebACL = t.add_resource(WebACL(
+    "MyWebACL",
+    Name=Ref(WebACLName),
+    DefaultAction=Action(
+        Type="ALLOW"
+    ),
+    Rules=[
+        Rules(
+            Action=Action(
+                Type="BLOCK"
+            ),
+            Priority=1,
+            RuleId=Ref(ManualIPBlockRule)
+        ),
+        Rules(
+            Action=Action(
+                Type="COUNT"
+            ),
+            Priority=2,
+            RuleId=Ref(SizeMatchRule)
+        ),
+        Rules(
+            Action=Action(
+                Type="BLOCK"
+            ),
+            Priority=3,
+            RuleId=Ref(SqliRule)
+        ),
+        Rules(
+            Action=Action(
+                Type="BLOCK"
+            ),
+            Priority=4,
+            RuleId=Ref(XssRule)
+        )
+    ],
+    MetricName=Ref(WebACLName),
+))
+
+print(t.to_json())

--- a/tests/examples_output/WAF_Regional_Common_Attacks_Sample.template
+++ b/tests/examples_output/WAF_Regional_Common_Attacks_Sample.template
@@ -1,0 +1,337 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Creates an AWS WAF configuration that protects against common attacks",
+    "Parameters": {
+        "WebACLName": {
+            "Default": "CommonAttackProtection",
+            "Description": "Enter the name you want to use for the WebACL. This value is also added as a prefix for the names of the rules, conditions, and CloudWatch metrics created by this template.",
+            "Type": "String"
+        }
+    },
+    "Resources": {
+        "ManualIPBlockRule": {
+            "Properties": {
+                "MetricName": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            {
+                                "Ref": "WebACLName"
+                            },
+                            "ManualIPBlockRule"
+                        ]
+                    ]
+                },
+                "Name": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            {
+                                "Ref": "WebACLName"
+                            },
+                            "ManualIPBlockRule"
+                        ]
+                    ]
+                },
+                "Predicates": [
+                    {
+                        "DataId": {
+                            "Ref": "WAFManualIPBlockSet"
+                        },
+                        "Negated": "false",
+                        "Type": "IPMatch"
+                    }
+                ]
+            },
+            "Type": "AWS::WAFRegional::Rule"
+        },
+        "MyWebACL": {
+            "Properties": {
+                "DefaultAction": {
+                    "Type": "ALLOW"
+                },
+                "MetricName": {
+                    "Ref": "WebACLName"
+                },
+                "Name": {
+                    "Ref": "WebACLName"
+                },
+                "Rules": [
+                    {
+                        "Action": {
+                            "Type": "BLOCK"
+                        },
+                        "Priority": 1,
+                        "RuleId": {
+                            "Ref": "ManualIPBlockRule"
+                        }
+                    },
+                    {
+                        "Action": {
+                            "Type": "COUNT"
+                        },
+                        "Priority": 2,
+                        "RuleId": {
+                            "Ref": "SizeMatchRule"
+                        }
+                    },
+                    {
+                        "Action": {
+                            "Type": "BLOCK"
+                        },
+                        "Priority": 3,
+                        "RuleId": {
+                            "Ref": "SqliRule"
+                        }
+                    },
+                    {
+                        "Action": {
+                            "Type": "BLOCK"
+                        },
+                        "Priority": 4,
+                        "RuleId": {
+                            "Ref": "XssRule"
+                        }
+                    }
+                ]
+            },
+            "Type": "AWS::WAFRegional::WebACL"
+        },
+        "SizeMatchRule": {
+            "Properties": {
+                "MetricName": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            {
+                                "Ref": "WebACLName"
+                            },
+                            "DetectLargeBody"
+                        ]
+                    ]
+                },
+                "Name": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            {
+                                "Ref": "WebACLName"
+                            },
+                            "LargeBodyMatchRule"
+                        ]
+                    ]
+                },
+                "Predicates": [
+                    {
+                        "DataId": {
+                            "Ref": "SizeMatchSet"
+                        },
+                        "Negated": "false",
+                        "Type": "SizeConstraint"
+                    }
+                ]
+            },
+            "Type": "AWS::WAFRegional::Rule"
+        },
+        "SizeMatchSet": {
+            "Properties": {
+                "Name": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            {
+                                "Ref": "WebACLName"
+                            },
+                            "LargeBodyMatch"
+                        ]
+                    ]
+                },
+                "SizeConstraints": [
+                    {
+                        "ComparisonOperator": "GT",
+                        "FieldToMatch": {
+                            "Type": "BODY"
+                        },
+                        "Size": "8192",
+                        "TextTransformation": "NONE"
+                    }
+                ]
+            },
+            "Type": "AWS::WAFRegional::SizeConstraintSet"
+        },
+        "SqliMatchSet": {
+            "Properties": {
+                "Name": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            {
+                                "Ref": "WebACLName"
+                            },
+                            "SqliMatch"
+                        ]
+                    ]
+                },
+                "SqlInjectionMatchTuples": [
+                    {
+                        "FieldToMatch": {
+                            "Type": "QUERY_STRING"
+                        },
+                        "TextTransformation": "URL_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "QUERY_STRING"
+                        },
+                        "TextTransformation": "HTML_ENTITY_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "BODY"
+                        },
+                        "TextTransformation": "URL_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "BODY"
+                        },
+                        "TextTransformation": "HTML_ENTITY_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "URI"
+                        },
+                        "TextTransformation": "URL_DECODE"
+                    }
+                ]
+            },
+            "Type": "AWS::WAFRegional::SqlInjectionMatchSet"
+        },
+        "SqliRule": {
+            "Properties": {
+                "MetricName": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            {
+                                "Ref": "WebACLName"
+                            },
+                            "SqliRule"
+                        ]
+                    ]
+                },
+                "Name": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            {
+                                "Ref": "WebACLName"
+                            },
+                            "SqliRule"
+                        ]
+                    ]
+                },
+                "Predicates": [
+                    {
+                        "DataId": {
+                            "Ref": "SqliMatchSet"
+                        },
+                        "Negated": "false",
+                        "Type": "SqlInjectionMatch"
+                    }
+                ]
+            },
+            "Type": "AWS::WAFRegional::Rule"
+        },
+        "WAFManualIPBlockSet": {
+            "Properties": {
+                "Name": "Manual IP Block Set"
+            },
+            "Type": "AWS::WAFRegional::IPSet"
+        },
+        "XssMatchSet": {
+            "Properties": {
+                "Name": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            {
+                                "Ref": "WebACLName"
+                            },
+                            "XssMatch"
+                        ]
+                    ]
+                },
+                "XssMatchTuples": [
+                    {
+                        "FieldToMatch": {
+                            "Type": "QUERY_STRING"
+                        },
+                        "TextTransformation": "URL_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "QUERY_STRING"
+                        },
+                        "TextTransformation": "HTML_ENTITY_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "BODY"
+                        },
+                        "TextTransformation": "URL_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "BODY"
+                        },
+                        "TextTransformation": "HTML_ENTITY_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "URI"
+                        },
+                        "TextTransformation": "URL_DECODE"
+                    }
+                ]
+            },
+            "Type": "AWS::WAFRegional::XssMatchSet"
+        },
+        "XssRule": {
+            "Properties": {
+                "MetricName": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            {
+                                "Ref": "WebACLName"
+                            },
+                            "XssRule"
+                        ]
+                    ]
+                },
+                "Name": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            {
+                                "Ref": "WebACLName"
+                            },
+                            "XssRule"
+                        ]
+                    ]
+                },
+                "Predicates": [
+                    {
+                        "DataId": {
+                            "Ref": "XssMatchSet"
+                        },
+                        "Negated": "false",
+                        "Type": "XssMatch"
+                    }
+                ]
+            },
+            "Type": "AWS::WAFRegional::Rule"
+        }
+    }
+}

--- a/troposphere/wafregional.py
+++ b/troposphere/wafregional.py
@@ -1,0 +1,151 @@
+# Copyright (c) 2012-2015, Mark Peek <mark@peek.org>
+# All rights reserved.
+#
+# See LICENSE file for full license.
+
+from . import AWSObject, AWSProperty
+from .validators import boolean, integer
+
+
+class Action(AWSProperty):
+    props = {
+        'Type': (basestring, True)
+    }
+
+
+class FieldToMatch(AWSProperty):
+    props = {
+        'Data': (basestring, False),  # Conditional
+        'Type': (basestring, True)
+    }
+
+
+class ByteMatchTuples(AWSProperty):
+    props = {
+        'FieldToMatch': (FieldToMatch, True),
+        'PositionalConstraint': (basestring, True),
+        'TargetString': (basestring, False),  # Conditional
+        'TargetStringBase64': (basestring, False),  # Conditional
+        'TextTransformation': (basestring, True)
+    }
+
+
+class IPSetDescriptors(AWSProperty):
+    props = {
+        'Type': (basestring, True),
+        'Value': (basestring, True)
+    }
+
+
+class Predicates(AWSProperty):
+    props = {
+        'DataId': (basestring, True),
+        'Negated': (boolean, True),
+        'Type': (basestring, True)
+    }
+
+
+class Rules(AWSProperty):
+    props = {
+        'Action': (Action, True),
+        'Priority': (integer, True),
+        'RuleId': (basestring, True)
+    }
+
+
+class SqlInjectionMatchTuples(AWSProperty):
+    props = {
+        'FieldToMatch': (FieldToMatch, True),
+        'TextTransformation': (basestring, True)
+    }
+
+
+class ByteMatchSet(AWSObject):
+    resource_type = "AWS::WAFRegional::ByteMatchSet"
+
+    props = {
+        'ByteMatchTuples': ([ByteMatchTuples], False),
+        'Name': (basestring, True)
+    }
+
+
+class IPSet(AWSObject):
+    resource_type = "AWS::WAFRegional::IPSet"
+
+    props = {
+        'IPSetDescriptors': ([IPSetDescriptors], False),
+        'Name': (basestring, True)
+    }
+
+
+class Rule(AWSObject):
+    resource_type = "AWS::WAFRegional::Rule"
+
+    props = {
+        'MetricName': (basestring, True),
+        'Name': (basestring, True),
+        'Predicates': ([Predicates], False)
+    }
+
+
+class SqlInjectionMatchSet(AWSObject):
+    resource_type = "AWS::WAFRegional::SqlInjectionMatchSet"
+
+    props = {
+        'Name': (basestring, True),
+        'SqlInjectionMatchTuples': ([SqlInjectionMatchTuples], False)
+    }
+
+
+class WebACL(AWSObject):
+    resource_type = "AWS::WAFRegional::WebACL"
+
+    props = {
+        'DefaultAction': (Action, True),
+        'MetricName': (basestring, True),
+        'Name': (basestring, True),
+        'Rules': ([Rules], False)
+    }
+
+
+class WebACLAssociation(AWSObject):
+    resource_type = "AWS::WAFRegional::WebACLAssociation"
+
+    props = {
+        'ResourceArn': (basestring, True),
+        'WebACLId': (basestring, True),
+    }
+
+
+class SizeConstraint(AWSProperty):
+    props = {
+        'ComparisonOperator': (basestring, True),
+        'FieldToMatch': (FieldToMatch, True),
+        'Size': (integer, True),
+        'TextTransformation': (basestring, True),
+    }
+
+
+class SizeConstraintSet(AWSObject):
+    resource_type = "AWS::WAFRegional::SizeConstraintSet"
+
+    props = {
+        'Name': (basestring, True),
+        'SizeConstraints': ([SizeConstraint], False),
+    }
+
+
+class XssMatchTuple(AWSProperty):
+    props = {
+        'FieldToMatch': (FieldToMatch, True),
+        'TextTransformation': (basestring, True),
+    }
+
+
+class XssMatchSet(AWSObject):
+    resource_type = "AWS::WAFRegional::XssMatchSet"
+
+    props = {
+        'Name': (basestring, True),
+        'XssMatchTuples': ([XssMatchTuple], False),
+    }


### PR DESCRIPTION
Add WAFRegional (WAF for ElasticLoadbalancingv2) support introduced in https://aws.amazon.com/about-aws/whats-new/2017/05/cloudformation-support-for-aws-waf-on-alb/