### PR TITLE
Raise ValueError for Outputs and Mappings - Fix Issue #732

### DIFF
--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,6 +1,6 @@
 import unittest
 
-from troposphere import Template, Parameter
+from troposphere import Template, Parameter, Output
 from troposphere.s3 import Bucket
 
 
@@ -39,6 +39,19 @@ class TestValidate(unittest.TestCase):
         with self.assertRaises(ValueError):
             template.add_resource(Bucket(str(201)))
 
+    def test_max_outputs(self):
+        template = Template()
+        for i in range(1, 61):
+            template.add_output(Output("output%d" % i, Value="Output%s" % str(i)))
+        with self.assertRaises(ValueError):
+            template.add_output(Output("output61", Value="Output%s" % str(61)))
+
+    def test_max_mappings(self):
+        template = Template()
+        for i in range(1, 101):
+            template.add_mapping("mapping%d" % i, { "name%d" % i: "value%d" %i })
+        with self.assertRaises(ValueError):
+            template.add_mapping("mapping101", { "name101": "value101" })
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -3,6 +3,12 @@ import unittest
 from troposphere import Template, Parameter, Output
 from troposphere.s3 import Bucket
 
+# Template Limits
+MAX_MAPPINGS = 100
+MAX_OUTPUTS = 60
+MAX_PARAMETERS = 60
+MAX_RESOURCES = 200
+
 
 class TestInitArguments(unittest.TestCase):
     def test_description_default(self):
@@ -27,31 +33,32 @@ class TestInitArguments(unittest.TestCase):
 class TestValidate(unittest.TestCase):
     def test_max_parameters(self):
         template = Template()
-        for i in range(1, 61):
-            template.add_parameter(Parameter("parameter%d" % i, Type='String'))
+        for i in range(0, MAX_PARAMETERS):
+            template.add_parameter(Parameter(str(i), Type='String'))
         with self.assertRaises(ValueError):
-            template.add_parameter(Parameter("Parameter61", Type='String'))
+            template.add_parameter(Parameter("parameter", Type='String'))
 
     def test_max_resources(self):
         template = Template()
-        for i in range(1, 201):
+        for i in range(0, MAX_RESOURCES):
             template.add_resource(Bucket(str(i)))
         with self.assertRaises(ValueError):
-            template.add_resource(Bucket(str(201)))
+            template.add_resource(Bucket("bucket"))
 
     def test_max_outputs(self):
         template = Template()
-        for i in range(1, 61):
-            template.add_output(Output("output%d" % i, Value="Output%s" % str(i)))
+        for i in range(0, MAX_OUTPUTS):
+            template.add_output(Output(str(i), Value=str(i)))
         with self.assertRaises(ValueError):
-            template.add_output(Output("output61", Value="Output%s" % str(61)))
+            template.add_output(Output("output", Value="output"))
 
     def test_max_mappings(self):
         template = Template()
-        for i in range(1, 101):
-            template.add_mapping("mapping%d" % i, { "name%d" % i: "value%d" %i })
+        for i in range(0, MAX_MAPPINGS):
+            template.add_mapping(str(i), {"n": "v"})
         with self.assertRaises(ValueError):
-            template.add_mapping("mapping101", { "name101": "value101" })
+            template.add_mapping("mapping", {"n": "v"})
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -28,6 +28,8 @@ AWS_STACK_ID = 'AWS::StackId'
 AWS_STACK_NAME = 'AWS::StackName'
 
 # Template Limits
+MAX_MAPPINGS = 100
+MAX_OUTPUTS = 60
 MAX_PARAMETERS = 60
 MAX_RESOURCES = 200
 PARAMETER_TITLE_MAX = 255
@@ -532,9 +534,13 @@ class Template(object):
         return values
 
     def add_output(self, output):
+        if len(self.outputs) >= MAX_OUTPUTS:
+            raise ValueError('Maximum outputs %d reached' % MAX_OUTPUTS)
         return self._update(self.outputs, output)
 
     def add_mapping(self, name, mapping):
+        if len(self.mappings) >= MAX_MAPPINGS:
+            raise ValueError('Maximum mappings %d reached' % MAX_MAPPINGS)
         self.mappings[name] = mapping
 
     def add_parameter(self, parameter):


### PR DESCRIPTION
Raises ValueError when CloudFormation template limits are reached for Outputs or Mappings.

Test cases included and passing.

Thanks!