### PR TITLE
EMR AutoScaling Complex Validation and Introduction of an ignore validator type

### DIFF
--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -6,7 +6,7 @@ import troposphere.emr as emr
 
 
 scaling_policy = emr.SimpleScalingPolicyConfiguration(
-                    AdjustmentType="EXACT_CAPACITY",
+                    AdjustmentType=emr.EXACT_CAPACITY,
                     ScalingAdjustment="1",
                     CoolDown="300"
                 )
@@ -131,7 +131,7 @@ class TestEMR(unittest.TestCase):
                     Action=emr.ScalingAction(
                         SimpleScalingPolicyConfiguration=emr.
                         SimpleScalingPolicyConfiguration(
-                            AdjustmentType='CHANGE_IN_CAPACITY',
+                            AdjustmentType=emr.CHANGE_IN_CAPACITY,
                             CoolDown=300,
                             ScalingAdjustment=1
                         )),
@@ -181,7 +181,7 @@ class TestEMR(unittest.TestCase):
                     Action=emr.ScalingAction(
                         SimpleScalingPolicyConfiguration=emr.
                         SimpleScalingPolicyConfiguration(
-                            AdjustmentType='CHANGE_IN_CAPACITY',
+                            AdjustmentType=emr.CHANGE_IN_CAPACITY,
                             CoolDown=300,
                             ScalingAdjustment=-1
                         )),
@@ -212,3 +212,32 @@ class TestEMR(unittest.TestCase):
             Name='Task Instance',
             JobFlowId=Ref(cluster)
         )
+
+    def simple_helper(self, adjustment, scaling):
+        sc = emr.SimpleScalingPolicyConfiguration(
+                 AdjustmentType=adjustment,
+                 ScalingAdjustment=scaling,
+        )
+        sc.validate()
+
+    def test_SimpleScalingPolicyConfiguration(self):
+        self.simple_helper(emr.CHANGE_IN_CAPACITY, 1)
+        self.simple_helper(emr.CHANGE_IN_CAPACITY, -1)
+        self.simple_helper(emr.CHANGE_IN_CAPACITY, "1")
+        self.simple_helper(emr.CHANGE_IN_CAPACITY, "-1")
+
+        self.simple_helper(emr.EXACT_CAPACITY, "1")
+        self.simple_helper(emr.EXACT_CAPACITY, 1)
+        with self.assertRaises(ValueError):
+            self.simple_helper(emr.EXACT_CAPACITY, -1)
+
+        self.simple_helper(emr.PERCENT_CHANGE_IN_CAPACITY, "0.1")
+        self.simple_helper(emr.PERCENT_CHANGE_IN_CAPACITY, 0.1)
+        with self.assertRaises(ValueError):
+            self.simple_helper(emr.PERCENT_CHANGE_IN_CAPACITY, "1.1")
+        with self.assertRaises(ValueError):
+            self.simple_helper(emr.PERCENT_CHANGE_IN_CAPACITY, 1.1)
+        with self.assertRaises(ValueError):
+            self.simple_helper(emr.PERCENT_CHANGE_IN_CAPACITY, -0.1)
+        with self.assertRaises(ValueError):
+            self.simple_helper(emr.PERCENT_CHANGE_IN_CAPACITY, -0.1)

--- a/troposphere/emr.py
+++ b/troposphere/emr.py
@@ -4,7 +4,14 @@
 # See LICENSE file for full license.
 
 from . import AWSObject, AWSProperty, AWSHelperFn
-from .validators import (boolean, integer, positive_integer, float, ignore)
+from .validators import (
+    boolean, integer, positive_integer, floatingpoint, defer
+)
+
+
+CHANGE_IN_CAPACITY = 'CHANGE_IN_CAPACITY'
+PERCENT_CHANGE_IN_CAPACITY = 'PERCENT_CHANGE_IN_CAPACITY'
+EXACT_CAPACITY = 'EXACT_CAPACITY'
 
 
 class KeyValue(AWSProperty):
@@ -156,8 +163,43 @@ class SimpleScalingPolicyConfiguration(AWSProperty):
     props = {
         'AdjustmentType': (basestring, False),
         'CoolDown': (positive_integer, False),
-        'ScalingAdjustment': (ignore, True),
+        'ScalingAdjustment': (defer, True),
     }
+
+    def validate(self):
+        if 'AdjustmentType' in self.properties and \
+           'ScalingAdjustment' in self.properties:
+
+            valid_values = [
+                CHANGE_IN_CAPACITY,
+                PERCENT_CHANGE_IN_CAPACITY,
+                EXACT_CAPACITY,
+            ]
+
+            adjustment_type = self.properties.get('AdjustmentType', None)
+            scaling_adjustment = self.properties.get('ScalingAdjustment', None)
+
+            if adjustment_type not in valid_values:
+                raise ValueError(
+                    'Only CHANGE_IN_CAPACITY, PERCENT_CHANGE_IN_CAPACITY, or'
+                    ' EXACT_CAPACITY are valid AdjustmentTypes'
+                )
+
+            if adjustment_type == CHANGE_IN_CAPACITY:
+                integer(scaling_adjustment)
+            elif adjustment_type == PERCENT_CHANGE_IN_CAPACITY:
+                floatingpoint(scaling_adjustment)
+                f = float(scaling_adjustment)
+                if f < 0.0 or f > 1.0:
+                    raise ValueError(
+                        'ScalingAdjustment value must be between 0.0 and 1.0'
+                        ' value was %0.2f' % f
+                    )
+            elif adjustment_type == EXACT_CAPACITY:
+                positive_integer(scaling_adjustment)
+            else:
+                raise ValueError('ScalingAdjustment value must be'
+                                 ' an integer or a float')
 
 
 class ScalingAction(AWSProperty):
@@ -284,32 +326,3 @@ class Step(AWSObject):
         'JobFlowId': (basestring, True),
         'Name': (basestring, True)
     }
-
-
-def validate(self):
-    if 'AdjustmentType' in self.properties and \
-       'ScalingAdjustment' in self.properties:
-
-        valid_values = ['CHANGE_IN_CAPACITY',
-                        'PERCENT_CHANGE_IN_CAPACITY',
-                        'EXACT_CAPACITY'
-                        ]
-
-        adjustment_type = self.properties.get('AdjustmentType', None)
-        scaling_adjustment = self.properties.get('ScalingAdjustment', None)
-
-        if adjustment_type not in valid_values:
-            raise ValueError(
-                'Only CHANGE_IN_CAPACITY, PERCENT_CHANGE_IN_CAPACITY, or'
-                ' EXACT_CAPACITY are valid AdjustmentTypes'
-            )
-
-        if adjustment_type == 'CHANGE_IN_CAPACITY':
-            integer(scaling_adjustment)
-        elif adjustment_type == 'PERCENT_CHANGE_IN_CAPACITY':
-            float(scaling_adjustment)
-        elif adjustment_type == 'EXACT_CAPACITY':
-            positive_integer(scaling_adjustment)
-        else:
-            raise ValueError('ScalingAdjustment value must be'
-                             ' an integer or a float')

--- a/troposphere/emr.py
+++ b/troposphere/emr.py
@@ -4,7 +4,7 @@
 # See LICENSE file for full license.
 
 from . import AWSObject, AWSProperty, AWSHelperFn
-from .validators import (boolean, integer, positive_integer)
+from .validators import (boolean, integer, positive_integer, float, ignore)
 
 
 class KeyValue(AWSProperty):

--- a/troposphere/emr.py
+++ b/troposphere/emr.py
@@ -245,6 +245,7 @@ class InstanceGroupConfig(AWSObject):
     resource_type = "AWS::EMR::InstanceGroupConfig"
 
     props = {
+        'AutoScalingPolicy': (AutoScalingPolicy, False),
         'BidPrice': (basestring, False),
         'Configurations': ([Configuration], False),
         'EbsConfiguration': (EbsConfiguration, False),
@@ -283,3 +284,32 @@ class Step(AWSObject):
         'JobFlowId': (basestring, True),
         'Name': (basestring, True)
     }
+
+
+def validate(self):
+    if 'AdjustmentType' in self.properties and \
+       'ScalingAdjustment' in self.properties:
+
+        valid_values = ['CHANGE_IN_CAPACITY',
+                        'PERCENT_CHANGE_IN_CAPACITY',
+                        'EXACT_CAPACITY'
+                        ]
+
+        adjustment_type = self.properties.get('AdjustmentType', None)
+        scaling_adjustment = self.properties.get('ScalingAdjustment', None)
+
+        if adjustment_type not in valid_values:
+            raise ValueError(
+                'Only CHANGE_IN_CAPACITY, PERCENT_CHANGE_IN_CAPACITY, or'
+                ' EXACT_CAPACITY are valid AdjustmentTypes'
+            )
+
+        if adjustment_type == 'CHANGE_IN_CAPACITY':
+            integer(scaling_adjustment)
+        elif adjustment_type == 'PERCENT_CHANGE_IN_CAPACITY':
+            float(scaling_adjustment)
+        elif adjustment_type == 'EXACT_CAPACITY':
+            positive_integer(scaling_adjustment)
+        else:
+            raise ValueError('ScalingAdjustment value must be'
+                             ' an integer or a float')

--- a/troposphere/emr.py
+++ b/troposphere/emr.py
@@ -156,7 +156,7 @@ class SimpleScalingPolicyConfiguration(AWSProperty):
     props = {
         'AdjustmentType': (basestring, False),
         'CoolDown': (positive_integer, False),
-        'ScalingAdjustment': (positive_integer, True),
+        'ScalingAdjustment': (ignore, True),
     }
 
 

--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -51,6 +51,38 @@ def integer_list_item(allowed_values):
     return integer_list_item_checker
 
 
+def float(x):
+    try:
+        float(x)
+    except (ValueError, TypeError):
+        raise ValueError("%r is not a valid float" % x)
+    else:
+        return x
+
+
+def ignore(x):
+    """ This method performs ZERO validation.
+
+    The intent of this method is to be used to bypass Troposphere's simple
+    property validation.
+
+    A request was made in PR#736 to perform more complex validation for
+    SimpleScalingPolicyConfiguration's AdjustmentType and ScalingAdjustment
+    class properties.
+
+    In order to facilitate the request, a validate method was introduced in
+    emr.py. However, we now required a way to bypass the simple property
+    validation in the class declaration in order to get to the more complex
+    validator.
+
+    This is the quick and dirty way to achieve that bypass functionality.
+
+    Feel free to modify as the community sees fit.
+    """
+
+    return x
+
+
 def network_port(x):
     from . import AWSHelperFn
 

--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -51,7 +51,7 @@ def integer_list_item(allowed_values):
     return integer_list_item_checker
 
 
-def float(x):
+def floatingpoint(x):
     try:
         float(x)
     except (ValueError, TypeError):
@@ -61,25 +61,12 @@ def float(x):
 
 
 def ignore(x):
-    """ This method performs ZERO validation.
+    """Method to indicate bypassing property validation"""
+    return x
 
-    The intent of this method is to be used to bypass Troposphere's simple
-    property validation.
 
-    A request was made in PR#736 to perform more complex validation for
-    SimpleScalingPolicyConfiguration's AdjustmentType and ScalingAdjustment
-    class properties.
-
-    In order to facilitate the request, a validate method was introduced in
-    emr.py. However, we now required a way to bypass the simple property
-    validation in the class declaration in order to get to the more complex
-    validator.
-
-    This is the quick and dirty way to achieve that bypass functionality.
-
-    Feel free to modify as the community sees fit.
-    """
-
+def defer(x):
+    """Method to indicate defering property validation"""
     return x
 
 


### PR DESCRIPTION
This is my attempt to help button up #736. This should incorporate @alexwen's code with the addition of a `validate` method to perform the more complex `AdjustmentType` and `ScalingAdjustment` validations that @markpeek requested in the original PR. 

This PR also introduces an `ignore` method in validators.py that is implemented to "bypass" (for lack of a better term) so the simple property validation is "skipped' and the new `validate` method in `emr.py` is used.

The reasoning for the `ignore` method is that the `ScalingAdjustment` property in `SimpleScalingPolicyConfiguration` will actually take different types depending on the value of  `AdjustmentType`. 

As a result, we need to skip the initial checking in favor of the more complex validation.

**Old**:
```class SimpleScalingPolicyConfiguration(AWSProperty):
    props = {
        'AdjustmentType': (basestring, False),
        'CoolDown': (positive_integer, False),
        'ScalingAdjustment': (integer, True),
    }
```

**New**:
```
class SimpleScalingPolicyConfiguration(AWSProperty):
    props = {
        'AdjustmentType': (basestring, False),
        'CoolDown': (positive_integer, False),
        'ScalingAdjustment': (ignore, True),
    }
```