### PR TITLE
Add PrivilegedMode option to CodeBuild Environments

### DIFF
--- a/troposphere/codebuild.py
+++ b/troposphere/codebuild.py
@@ -50,6 +50,7 @@ class Environment(AWSProperty):
         'EnvironmentVariables': ((list, [EnvironmentVariable]), False),
         'Image': (basestring, True),
         'Type': (basestring, True),
+        'PrivilegedMode': (boolean, False),
     }
 
     def validate(self):

--- a/troposphere/codebuild.py
+++ b/troposphere/codebuild.py
@@ -4,7 +4,7 @@
 # See LICENSE file for full license.
 
 from . import AWSObject, AWSProperty, Tags
-from .validators import integer
+from .validators import integer, boolean
 
 
 class Artifacts(AWSProperty):


### PR DESCRIPTION
CodeBuild now allows you to run your build containers in `privileged mode`. They rolled this feature out pretty silently it seems because I can't find any announcements or product updates about it. They also haven't added it to the CloudFormation documentation yet either. I can only find a reference to it in this document on creating a project:
http://docs.aws.amazon.com/codebuild/latest/userguide/create-project.html#create-project-cli

I can confirm that CloudFormation supports this option because I have created a template for a CodeBuild project and added this in manually. Worked as expected.