### PR TITLE
removed forgotten & replaced ignore validator method

### DIFF
--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -60,11 +60,6 @@ def floatingpoint(x):
         return x
 
 
-def ignore(x):
-    """Method to indicate bypassing property validation"""
-    return x
-
-
 def defer(x):
     """Method to indicate defering property validation"""
     return x


### PR DESCRIPTION
Forgot to remove the ignore method in `validators.py`when `defer` was introduced.