### PR TITLE
EFS DependsOn Ref to String fix

### DIFF
--- a/examples/EFS.py
+++ b/examples/EFS.py
@@ -118,7 +118,7 @@ ec2_instance = Instance(
     KeyName=Ref(keyname_param),
     SecurityGroups=[Ref(efs_host_security_group)],
     IamInstanceProfile=Ref(efs_host_instance_profile),
-    DependsOn="MyEFSMountTarget"
+    DependsOn=efs_mount_target
 )
 template.add_resource(ec2_instance)
 

--- a/examples/EFS.py
+++ b/examples/EFS.py
@@ -68,7 +68,7 @@ template.add_resource(efs_security_group)
 # mount targets. Give it some tags so we can identify it later.
 tags = Tags(Name='MyEFSFileSystem')
 efs_file_system = FileSystem(
-    title='MyEFSFileSystem',
+    "MyEFSFileSystem",
     FileSystemTags=tags
 )
 template.add_resource(efs_file_system)
@@ -77,7 +77,7 @@ template.add_resource(efs_file_system)
 # it's required, but for the purpose of this example we'll
 # put it in just one.
 efs_mount_target = MountTarget(
-    title='MyEFSMountTarget',
+    "MyEFSMountTarget",
     FileSystemId=Ref(efs_file_system),
     SecurityGroups=[Ref(efs_security_group)],
     SubnetId=Ref(subnetid_param)
@@ -118,7 +118,7 @@ ec2_instance = Instance(
     KeyName=Ref(keyname_param),
     SecurityGroups=[Ref(efs_host_security_group)],
     IamInstanceProfile=Ref(efs_host_instance_profile),
-    DependsOn=Ref(efs_mount_target)
+    DependsOn="MyEFSMountTarget"
 )
 template.add_resource(ec2_instance)
 

--- a/tests/examples_output/EFS.template
+++ b/tests/examples_output/EFS.template
@@ -76,9 +76,7 @@
             "Type": "AWS::IAM::InstanceProfile"
         },
         "Ec2Instance": {
-            "DependsOn": {
-                "Ref": "MyEFSMountTarget"
-            },
+            "DependsOn": "MyEFSMountTarget",
             "Properties": {
                 "IamInstanceProfile": {
                     "Ref": "EFSInstanceProfile"


### PR DESCRIPTION
Closes low hanging fruit #709

As part of this change, I removed the `title` usage in favor of the positional argument for naming a resource. Using the positional seems to be the defacto standard looking at other examples and code within Troposphere.