### PR TITLE
Make handling of DependsOn more pythonic

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,7 +1,9 @@
 import unittest
 from troposphere import AWSObject, AWSProperty, Output, Parameter
 from troposphere import Join, Ref, Split, Sub, Template
+from troposphere import depends_on_helper
 from troposphere.ec2 import Instance, SecurityGroupRule
+from troposphere.s3 import Bucket
 from troposphere.elasticloadbalancing import HealthCheck
 from troposphere.validators import positive_integer
 
@@ -40,6 +42,20 @@ class TestBasic(unittest.TestCase):
             t = Template()
             t.add_resource(Instance('ec2instance'))
             t.to_json()
+
+    def test_depends_on_helper_with_resource(self):
+        resource_name = "Bucket1"
+        b1 = Bucket(resource_name)
+        self.assertEqual(depends_on_helper(b1), resource_name)
+
+    def test_depends_on_helper_with_string(self):
+        resource_name = "Bucket1"
+        self.assertEqual(depends_on_helper(resource_name), resource_name)
+
+    def test_resource_depends_on(self):
+        b1 = Bucket("B1")
+        b2 = Bucket("B2", DependsOn=b1)
+        self.assertEqual(b1.title, b2.resource["DependsOn"])
 
 
 def call_correct(x):

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -71,6 +71,18 @@ def encode_to_dict(obj):
     return obj
 
 
+def depends_on_helper(obj):
+    """ Handles using .title if the given object is a troposphere resource.
+
+    If the given object is a troposphere resource, use the `.title` attribute
+    of that resource. If it's a string, just use the string. This should allow
+    more pythonic use of DependsOn.
+    """
+    if isinstance(obj, AWSObject):
+        return obj.title
+    return obj
+
+
 class BaseAWSObject(object):
     def __init__(self, title, template=None, **kwargs):
         self.title = title
@@ -128,7 +140,10 @@ class BaseAWSObject(object):
                 or '_BaseAWSObject__initialized' not in self.__dict__:
             return dict.__setattr__(self, name, value)
         elif name in self.attributes:
-            self.resource[name] = value
+            if name == "DependsOn":
+                self.resource[name] = depends_on_helper(value)
+            else:
+                self.resource[name] = value
             return None
         elif name in self.propnames:
             # Check the type of the object and compare against what we were


### PR DESCRIPTION
Now you can pass troposphere resources directly into the DependsOn
attribute, and troposphere will figure out the title of that resource
for you automatically.