### PR TITLE
Accept Join type as parameter default value as it returns a string

### DIFF
--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,6 +1,6 @@
 import unittest
 
-from troposphere import Parameter
+from troposphere import Join, Parameter
 
 
 class TestInitArguments(unittest.TestCase):
@@ -8,6 +8,10 @@ class TestInitArguments(unittest.TestCase):
         title = 'i' * 256
         with self.assertRaises(ValueError):
             Parameter(title, Type='String')
+
+    def test_validate_with_a_join_default(self):
+        Parameter(
+            'test', Type='String', Default=Join('', ['a', 'b'])).validate()
 
 
 if __name__ == '__main__':

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -659,7 +659,8 @@ class Parameter(AWSDeclaration):
             # matches (in the case of a String Type) or can be coerced
             # into one of the number formats.
             param_type = self.properties.get('Type')
-            if param_type == 'String' and not isinstance(default, basestring):
+            if param_type == 'String' and not \
+                    isinstance(default, (basestring, Join)):
                 raise ValueError(error_str %
                                  ('String', type(default), default))
             elif param_type == 'Number':


### PR DESCRIPTION
I'm getting a validation error with valid parameter:
Parameter default type mismatch: expecting type String got <class 'troposphere.Join'> with value <troposphere.Join object at 0x7f786b807d10>
due to using a Join as the default.

Changed validation check to allow Join type.