### PR TITLE
Completed AWS SAM support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 4
+
+[Makefile]
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # Packages
 *.egg
+*.eggs
 *.egg-info
 dist
 build

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ nosetests.xml
 
 # Vim
 *.sw*
+
+# Jetbrains
+*.iml

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ nosetests.xml
 
 # Jetbrains
 *.iml
+
+# Git
+*.diff
+*.patch

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: 2to3 3to2
+
+2to3:
+	2to3 -n -w examples > 2to3-examples.patch
+	2to3 -n -w troposphere > 2to3-troposphere.patch
+
+3to2:
+	git -C examples apply ../2to3-examples.patch -R
+	git -C troposphere apply ../2to3-troposphere.patch -R

--- a/examples/Serverless_Api_Backend.py
+++ b/examples/Serverless_Api_Backend.py
@@ -1,0 +1,87 @@
+# Converted from api_backend located at:
+# https://github.com/awslabs/serverless-application-model/blob/dbc54b5d0cd31bf5cebd16d765b74aee9eb34641/examples/2016-10-31/api_backend/template.yaml
+
+from troposphere import Template, Ref
+from troposphere.awslambda import Environment
+from troposphere.serverless import Function, ApiEvent, SimpleTable
+
+t = Template()
+
+t.add_description(
+    "Simple CRUD webservice. State is stored in a SimpleTable (DynamoDB) "
+    "resource.")
+
+t.add_transform('AWS::Serverless-2016-10-31')
+
+simple_table = t.add_resource(
+    SimpleTable("Table")
+)
+
+t.add_resource(
+    Function(
+        "GetFunction",
+        Handler='index.get',
+        Runtime='nodejs4.3',
+        CodeUri='s3://<bucket>/api_backend.zip',
+        Policies='AmazonDynamoDBReadOnlyAccess',
+        Environment=Environment(
+            Variables={
+                'TABLE_NAME': Ref(simple_table)
+            }
+        ),
+        Events={
+            'GetResource': ApiEvent(
+                'GetResource',
+                Path='/resource/{resourceId}',
+                Method='get'
+            )
+        }
+    )
+)
+
+t.add_resource(
+    Function(
+        "PutFunction",
+        Handler='index.put',
+        Runtime='nodejs4.3',
+        CodeUri='s3://<bucket>/api_backend.zip',
+        Policies='AmazonDynamoDBReadOnlyAccess',
+        Environment=Environment(
+            Variables={
+                'TABLE_NAME': Ref(simple_table)
+            }
+        ),
+        Events={
+            'PutResource': ApiEvent(
+                'PutResource',
+                Path='/resource/{resourceId}',
+                Method='put'
+            )
+        }
+    )
+)
+
+t.add_resource(
+    Function(
+        "DeleteFunction",
+        Handler='index.delete',
+        Runtime='nodejs4.3',
+        CodeUri='s3://<bucket>/api_backend.zip',
+        Policies='AmazonDynamoDBReadOnlyAccess',
+        Environment=Environment(
+            Variables={
+                'TABLE_NAME': Ref(simple_table)
+            }
+        ),
+        Events={
+            'DeleteResource': ApiEvent(
+                'DeleteResource',
+                Path='/resource/{resourceId}',
+                Method='delete'
+            )
+        }
+    )
+)
+
+
+print(t.to_json())

--- a/examples/Serverless_S3_Processor.py
+++ b/examples/Serverless_S3_Processor.py
@@ -1,0 +1,38 @@
+# Converted from s3_processor located at:
+# https://github.com/awslabs/serverless-application-model/blob/dbc54b5d0cd31bf5cebd16d765b74aee9eb34641/examples/2016-10-31/s3_processor/template.yaml
+
+from troposphere import Template, Ref
+from troposphere.s3 import Bucket
+from troposphere.serverless import Function, EventSource
+
+t = Template()
+
+t.add_description(
+    "A function is triggered off an upload to a bucket. It logs the content "
+    "type of the uploaded object.")
+
+t.add_transform('AWS::Serverless-2016-10-31')
+
+
+s3_bucket = t.add_resource(
+    Bucket("Bucket")
+)
+
+t.add_resource(
+    Function(
+        "ProcessorFunction",
+        Handler='index.handler',
+        Runtime='nodejs4.3',
+        CodeUri='s3://<bucket>/s3_processor.zip',
+        Policies='AmazonS3ReadOnlyAccess',
+        Events={
+            'PhotoUpload': EventSource(
+                Type='S3',
+                Bucket=Ref(s3_bucket),
+                Events=['s3:ObjectCreated:*']
+            )
+        }
+    )
+)
+
+print(t.to_json())

--- a/examples/Serverless_S3_Processor.py
+++ b/examples/Serverless_S3_Processor.py
@@ -3,7 +3,7 @@
 
 from troposphere import Template, Ref
 from troposphere.s3 import Bucket
-from troposphere.serverless import Function, EventSource
+from troposphere.serverless import Function, S3Event
 
 t = Template()
 
@@ -26,8 +26,8 @@ t.add_resource(
         CodeUri='s3://<bucket>/s3_processor.zip',
         Policies='AmazonS3ReadOnlyAccess',
         Events={
-            'PhotoUpload': EventSource(
-                Type='S3',
+            'PhotoUpload': S3Event(
+                'PhotoUpload',
                 Bucket=Ref(s3_bucket),
                 Events=['s3:ObjectCreated:*']
             )

--- a/tests/examples_output/Serverless_Api_Backend.template
+++ b/tests/examples_output/Serverless_Api_Backend.template
@@ -1,0 +1,84 @@
+{
+    "Description": "Simple CRUD webservice. State is stored in a SimpleTable (DynamoDB) resource.",
+    "Resources": {
+        "DeleteFunction": {
+            "Properties": {
+                "CodeUri": "s3://<bucket>/api_backend.zip",
+                "Environment": {
+                    "Variables": {
+                        "TABLE_NAME": {
+                            "Ref": "Table"
+                        }
+                    }
+                },
+                "Events": {
+                    "DeleteResource": {
+                        "Properties": {
+                            "Method": "delete",
+                            "Path": "/resource/{resourceId}"
+                        },
+                        "Type": "Api"
+                    }
+                },
+                "Handler": "index.delete",
+                "Policies": "AmazonDynamoDBReadOnlyAccess",
+                "Runtime": "nodejs4.3"
+            },
+            "Type": "AWS::Serverless::Function"
+        },
+        "GetFunction": {
+            "Properties": {
+                "CodeUri": "s3://<bucket>/api_backend.zip",
+                "Environment": {
+                    "Variables": {
+                        "TABLE_NAME": {
+                            "Ref": "Table"
+                        }
+                    }
+                },
+                "Events": {
+                    "GetResource": {
+                        "Properties": {
+                            "Method": "get",
+                            "Path": "/resource/{resourceId}"
+                        },
+                        "Type": "Api"
+                    }
+                },
+                "Handler": "index.get",
+                "Policies": "AmazonDynamoDBReadOnlyAccess",
+                "Runtime": "nodejs4.3"
+            },
+            "Type": "AWS::Serverless::Function"
+        },
+        "PutFunction": {
+            "Properties": {
+                "CodeUri": "s3://<bucket>/api_backend.zip",
+                "Environment": {
+                    "Variables": {
+                        "TABLE_NAME": {
+                            "Ref": "Table"
+                        }
+                    }
+                },
+                "Events": {
+                    "PutResource": {
+                        "Properties": {
+                            "Method": "put",
+                            "Path": "/resource/{resourceId}"
+                        },
+                        "Type": "Api"
+                    }
+                },
+                "Handler": "index.put",
+                "Policies": "AmazonDynamoDBReadOnlyAccess",
+                "Runtime": "nodejs4.3"
+            },
+            "Type": "AWS::Serverless::Function"
+        },
+        "Table": {
+            "Type": "AWS::Serverless::SimpleTable"
+        }
+    },
+    "Transform": "AWS::Serverless-2016-10-31"
+}

--- a/tests/examples_output/Serverless_S3_Processor.template
+++ b/tests/examples_output/Serverless_S3_Processor.template
@@ -9,12 +9,14 @@
                 "CodeUri": "s3://<bucket>/s3_processor.zip",
                 "Events": {
                     "PhotoUpload": {
-                        "Bucket": {
-                            "Ref": "Bucket"
+                        "Properties": {
+                            "Bucket": {
+                                "Ref": "Bucket"
+                            },
+                            "Events": [
+                                "s3:ObjectCreated:*"
+                            ]
                         },
-                        "Events": [
-                            "s3:ObjectCreated:*"
-                        ],
                         "Type": "S3"
                     }
                 },

--- a/tests/examples_output/Serverless_S3_Processor.template
+++ b/tests/examples_output/Serverless_S3_Processor.template
@@ -1,0 +1,29 @@
+{
+    "Description": "A function is triggered off an upload to a bucket. It logs the content type of the uploaded object.",
+    "Resources": {
+        "Bucket": {
+            "Type": "AWS::S3::Bucket"
+        },
+        "ProcessorFunction": {
+            "Properties": {
+                "CodeUri": "s3://<bucket>/s3_processor.zip",
+                "Events": {
+                    "PhotoUpload": {
+                        "Bucket": {
+                            "Ref": "Bucket"
+                        },
+                        "Events": [
+                            "s3:ObjectCreated:*"
+                        ],
+                        "Type": "S3"
+                    }
+                },
+                "Handler": "index.handler",
+                "Policies": "AmazonS3ReadOnlyAccess",
+                "Runtime": "nodejs4.3"
+            },
+            "Type": "AWS::Serverless::Function"
+        }
+    },
+    "Transform": "AWS::Serverless-2016-10-31"
+}

--- a/tests/test_serverless.py
+++ b/tests/test_serverless.py
@@ -2,6 +2,7 @@ import unittest
 from troposphere import Template
 from troposphere.serverless import Function, Api, SimpleTable
 
+
 class TestServerless(unittest.TestCase):
     def test_required_function(self):
         serverless_func = Function(
@@ -31,6 +32,7 @@ class TestServerless(unittest.TestCase):
         t = Template()
         t.add_resource(serverless_table)
         t.to_json()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_serverless.py
+++ b/tests/test_serverless.py
@@ -1,0 +1,36 @@
+import unittest
+from troposphere import Template
+from troposphere.serverless import Function, Api, SimpleTable
+
+class TestServerless(unittest.TestCase):
+    def test_required_function(self):
+        serverless_func = Function(
+            "SomeHandler",
+            Handler="index.handler",
+            Runtime="nodejs",
+            CodeUri="s3://bucket/handler.zip"
+        )
+        t = Template()
+        t.add_resource(serverless_func)
+        t.to_json()
+
+    def test_required_api(self):
+        serverless_api = Api(
+            "SomeApi",
+            StageName='test',
+            DefinitionUri='s3://bucket/swagger.yml',
+        )
+        t = Template()
+        t.add_resource(serverless_api)
+        t.to_json()
+
+    def test_simple_table(self):
+        serverless_table = SimpleTable(
+            "SomeTable"
+        )
+        t = Template()
+        t.add_resource(serverless_table)
+        t.to_json()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -23,6 +23,12 @@ class TestInitArguments(unittest.TestCase):
         template = Template(Metadata=value)
         self.assertEqual(template.metadata, value)
 
+    def test_transform(self):
+        transform = 'AWS::Serverless-2016-10-31'
+        template = Template()
+        template.add_transform(transform)
+        self.assertEqual(template.transform, transform)
+
 
 class TestValidate(unittest.TestCase):
     def test_max_parameters(self):

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -458,6 +458,7 @@ class Tags(AWSHelperFn):
 class Template(object):
     props = {
         'AWSTemplateFormatVersion': (basestring, False),
+        'Transform': (basestring, False),
         'Description': (basestring, False),
         'Parameters': (dict, False),
         'Mappings': (dict, False),
@@ -474,6 +475,7 @@ class Template(object):
         self.parameters = {}
         self.resources = {}
         self.version = None
+        self.transform = None
 
     def add_description(self, description):
         self.description = description
@@ -522,6 +524,9 @@ class Template(object):
         else:
             self.version = "2010-09-09"
 
+    def add_transform(self, transform):
+        self.transform = transform
+
     def to_dict(self):
         t = {}
         if self.description:
@@ -538,6 +543,8 @@ class Template(object):
             t['Parameters'] = self.parameters
         if self.version:
             t['AWSTemplateFormatVersion'] = self.version
+        if self.transform:
+            t['Transform'] = self.transform
         t['Resources'] = self.resources
 
         return encode_to_dict(t)

--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2017, Fernando Freire <fernando.freire@nike.com>
+# All rights reserved.
+#
+# See LICENSE file for full license.
+
+from . import AWSObject, AWSProperty
+from .awslambda import Environment, VPCConfig, validate_memory_size
+from .dynamodb import ProvisionedThroughput
+from .iam import policytypes
+from .validators import positive_integer
+
+
+def primary_key_type_validator(x):
+    valid_types = ["String", "Number", "Binary"]
+    if x not in valid_types:
+        raise ValueError("KeyType must be one of: %s" % ", ".join(valid_types))
+    return x
+
+
+class Function(AWSObject):
+    resource_type = "AWS::Serverless::Function"
+
+    props = {
+        'Handler': (basestring, True),
+        'Runtime': (basestring, True),
+        'CodeUri': (basestring, True),
+        'Description': (basestring, False),
+        'MemorySize': (validate_memory_size, False),
+        'Timeout': (positive_integer, False),
+        'Role': (basestring, False),
+        'Policies': (policytypes, False),  # TODO not sure this is the righht approach
+        'Environment': (Environment, False),
+        'VpcConfig': (VPCConfig, False),
+        'Events': (dict, False)  # TODO this is certainly not the right approach
+    }
+
+
+class Api(AWSObject):
+    resource_type = "AWS::Serverless::Api"
+
+    props = {
+        'StageName': (basestring, True),
+        'DefinitionUri': (basestring, True),
+        'CacheClusterEnabled': (bool, False),
+        'CacheClusterSize': (basestring, False),
+        'Variables': (dict, False)
+    }
+
+
+class PrimaryKey(AWSProperty):
+    props = {
+        'Name': (basestring, False),
+        'Type': (primary_key_type_validator, False)
+    }
+
+
+class SimpleTable(AWSObject):
+    resource_type = "AWS::Serverless::SimpleTable"
+
+    props = {
+        'PrimaryKey': (PrimaryKey, False),
+        'ProvisionedThroughput': (ProvisionedThroughput, False)
+    }
+
+class S3EventSource(AWSObject):
+    resource_type = 'S3'
+
+    props = {
+        'Bucket': (basestring, True),
+        'Events': (basestring, True),
+        'Filter': (basestring, False)
+    }

--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -10,6 +10,7 @@ from .awslambda import Environment, VPCConfig, validate_memory_size
 from .dynamodb import ProvisionedThroughput
 from .validators import positive_integer
 
+
 def primary_key_type_validator(x):
     valid_types = ["String", "Number", "Binary"]
     if x not in valid_types:

--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -17,6 +17,7 @@ def primary_key_type_validator(x):
         raise ValueError("KeyType must be one of: %s" % ", ".join(valid_types))
     return x
 
+
 def policy_validator(x):
     if isinstance(x, types.StringTypes):
         return x
@@ -73,12 +74,90 @@ class SimpleTable(AWSObject):
         'ProvisionedThroughput': (ProvisionedThroughput, False)
     }
 
-class EventSource(AWSProperty):
+
+class S3Event(AWSObject):
     resource_type = 'S3'
 
     props = {
-        'Type': (basestring, True),
         'Bucket': (basestring, True),
         'Events': (list, True),
         'Filter': (basestring, False)
     }
+
+
+class SNSEvent(AWSObject):
+    resource_type = 'SNS'
+
+    props = {
+        'Topic': (basestring, True)
+    }
+
+
+def starting_position_validator(x):
+    valid_types = ['TRIM_HORIZON', 'LATEST']
+    if x not in valid_types:
+        raise ValueError("StartingPosition must be one of: %s" % ", ".join(valid_types))
+    return x
+
+
+class KinesisEvent(AWSObject):
+    resource_type = 'Kinesis'
+
+    props = {
+        'Stream': (basestring, True),
+        'StartingPosition': (starting_position_validator, True),
+        'BatchSize': (positive_integer, False)
+    }
+
+
+class DynamoDBEvent(AWSObject):
+    resource_type = 'DynamoDB'
+
+    props = {
+        'Stream': (basestring, True),
+        'StartingPosition': (starting_position_validator, True),
+        'BatchSize': (positive_integer, False)
+    }
+
+
+class ApiEvent(AWSObject):
+    resource_type = 'Api'
+
+    props = {
+        'Path': (basestring, True),
+        'Method': (basestring, True),
+        'RestApiId': (basestring, False)
+    }
+
+
+class ScheduleEvent(AWSObject):
+    resource_type = 'Schedule'
+
+    props = {
+        'Schedule': (basestring, True),
+        'Input': (basestring, False)
+    }
+
+
+class CloudWatchEvent(AWSObject):
+    resource_type = 'CloudWatchEvent'
+
+    props = {
+        'Pattern': (dict, True),
+        'Input': (basestring, False),
+        'InputPath': (basestring, False)
+    }
+
+
+class IoTRuleEvent(AWSObject):
+    resource_type = 'IoTRule'
+
+    props = {
+        'Sql': (basestring, True),
+        'AwsIotSqlVersion': (basestring, False)
+    }
+
+
+class AlexaSkillEvent(AWSObject):
+    resource_type = 'AlexaSkill'
+    props = {}

--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -4,12 +4,13 @@
 # See LICENSE file for full license.
 
 import types
-assert types  # silence pyflakes
 
 from . import AWSObject, AWSProperty
 from .awslambda import Environment, VPCConfig, validate_memory_size
 from .dynamodb import ProvisionedThroughput
 from .validators import positive_integer
+
+assert types  # silence pyflakes
 
 
 def primary_key_type_validator(x):

--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -4,6 +4,7 @@
 # See LICENSE file for full license.
 
 import types
+assert types  # silence pyflakes
 
 from . import AWSObject, AWSProperty
 from .awslambda import Environment, VPCConfig, validate_memory_size

--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -3,6 +3,8 @@
 #
 # See LICENSE file for full license.
 
+import types
+
 from . import AWSObject, AWSProperty
 from .awslambda import Environment, VPCConfig, validate_memory_size
 from .dynamodb import ProvisionedThroughput

--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -3,13 +3,10 @@
 #
 # See LICENSE file for full license.
 
-import types
-
 from . import AWSObject, AWSProperty
 from .awslambda import Environment, VPCConfig, validate_memory_size
 from .dynamodb import ProvisionedThroughput
 from .validators import positive_integer
-
 
 def primary_key_type_validator(x):
     valid_types = ["String", "Number", "Binary"]

--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -96,7 +96,10 @@ class SNSEvent(AWSObject):
 def starting_position_validator(x):
     valid_types = ['TRIM_HORIZON', 'LATEST']
     if x not in valid_types:
-        raise ValueError("StartingPosition must be one of: %s" % ", ".join(valid_types))
+        raise ValueError(
+            "StartingPosition must be one of: %s"
+            % ", ".join(valid_types)
+        )
     return x
 
 

--- a/troposphere/template_generator.py
+++ b/troposphere/template_generator.py
@@ -30,7 +30,7 @@ from troposphere.policies import UpdatePolicy, CreationPolicy
 
 
 class TemplateGenerator(Template):
-    DEPRECATED_MODULES = ['troposphere.dynamodb']
+    DEPRECATED_MODULES = ['troposphere.dynamodb', 'troposphere.serverless']
 
     _inspect_members = set()
     _inspect_resources = {}

--- a/troposphere/template_generator.py
+++ b/troposphere/template_generator.py
@@ -58,7 +58,10 @@ class TemplateGenerator(Template):
         for k, v in cf_template.get('Conditions', {}).iteritems():
             self.add_condition(k, self._convert_definition(v, k))
         for k, v in cf_template.get('Resources', {}).iteritems():
-            self.add_resource(self._convert_definition(v, k, self._get_resource_type_cls(v)))
+            self.add_resource(self._convert_definition(
+                                    v, k,
+                                    self._get_resource_type_cls(v)
+            ))
         for k, v in cf_template.get('Outputs', {}).iteritems():
             self.add_output(self._create_instance(Output, v, k))
 
@@ -100,11 +103,10 @@ class TemplateGenerator(Template):
 
         return self._inspect_functions
 
-
     def _get_resource_type_cls(self, resource):
-        """Attempts to return troposphere class that represents Type of provided resource.
-        Attempts to find the troposphere class who's `resource_type` field is the same as the provided resources `Type`
-        field.
+        """Attempts to return troposphere class that represents Type of provided
+        resource. Attempts to find the troposphere class who's `resource_type`
+        field is the same as the provided resources `Type` field.
 
         :param resource: Resource to find troposphere class for
         :return: None: If provided resource does not have a `Type` field
@@ -115,7 +117,8 @@ class TemplateGenerator(Template):
         if 'Type' not in resource:
             return None
 
-        # Attempt to find troposphere resource with `resource_type` == resource['Type']
+        # Attempt to find troposphere resource with:
+        #   `resource_type` == resource['Type']
         try:
             return self.inspect_resources[resource['Type']]
         except KeyError:
@@ -129,7 +132,8 @@ class TemplateGenerator(Template):
         additional objects as necessary.
 
         :param {*} definition: Object to convert
-        :param str ref: Name of key in parent dict that the provided definition is from, can be None
+        :param str ref: Name of key in parent dict that the provided definition
+                        is from, can be None
         :param type cls: Troposphere class which represents provided definition
         """
         if isinstance(definition, Mapping):
@@ -145,8 +149,12 @@ class TemplateGenerator(Template):
                         expected_type = self._generate_custom_type(
                             definition['Type'])
                     except TypeError:
-                        # If definition['Type'] turns out not to be a custom type (aka doesn't start with "Custom::")
-                        assert not expected_type  # Make sure expected_type is nothing (as it always should be)
+                        # If definition['Type'] turns out not to be a custom
+                        # type (aka doesn't start with "Custom::")
+
+                        # Make sure expected_type is nothing (as
+                        # it always should be)
+                        assert not expected_type
 
                 if expected_type:
                     args = self._normalize_properties(definition)

--- a/troposphere/template_generator.py
+++ b/troposphere/template_generator.py
@@ -45,6 +45,8 @@ class TemplateGenerator(Template):
         self._reference_map = {}
         if 'AWSTemplateFormatVersion' in cf_template:
             self.add_version(cf_template['AWSTemplateFormatVersion'])
+        if 'Transform' in cf_template:
+            self.add_transform(cf_template['Transform'])
         if 'Description' in cf_template:
             self.add_description(cf_template['Description'])
         if 'Metadata' in cf_template:

--- a/troposphere/template_generator.py
+++ b/troposphere/template_generator.py
@@ -30,7 +30,7 @@ from troposphere.policies import UpdatePolicy, CreationPolicy
 
 
 class TemplateGenerator(Template):
-    DEPRECATED_MODULES = ['troposphere.dynamodb', 'troposphere.serverless']
+    DEPRECATED_MODULES = ['troposphere.dynamodb']
 
     _inspect_members = set()
     _inspect_resources = {}

--- a/troposphere/template_generator.py
+++ b/troposphere/template_generator.py
@@ -58,7 +58,7 @@ class TemplateGenerator(Template):
         for k, v in cf_template.get('Conditions', {}).iteritems():
             self.add_condition(k, self._convert_definition(v, k))
         for k, v in cf_template.get('Resources', {}).iteritems():
-            self.add_resource(self._convert_definition(v, k))
+            self.add_resource(self._convert_definition(v, k, self._get_resource_type_cls(v)))
         for k, v in cf_template.get('Outputs', {}).iteritems():
             self.add_output(self._create_instance(Output, v, k))
 
@@ -100,18 +100,44 @@ class TemplateGenerator(Template):
 
         return self._inspect_functions
 
-    def _convert_definition(self, definition, ref=None):
+
+    def _get_resource_type_cls(self, resource):
+        """Attempts to return troposphere class that represents Type of provided resource.
+        Attempts to find the troposphere class who's `resource_type` field is the same as the provided resources `Type`
+        field.
+
+        :param resource: Resource to find troposphere class for
+        :return: None: If provided resource does not have a `Type` field
+                       If no class found for provided resource
+                 type: Type of provided resource
+        """
+        # If provided resource does not have `Type` field
+        if 'Type' not in resource:
+            return None
+
+        # Attempt to find troposphere resource with `resource_type` == resource['Type']
+        try:
+            return self.inspect_resources[resource['Type']]
+        except KeyError:
+            # If no resource with `resource_type` == resource['Type'] found
+            return None
+
+    def _convert_definition(self, definition, ref=None, cls=None):
         """
         Converts any object to its troposphere equivalent, if applicable.
         This function will recurse into lists and mappings to create
         additional objects as necessary.
+
+        :param {*} definition: Object to convert
+        :param str ref: Name of key in parent dict that the provided definition is from, can be None
+        :param type cls: Troposphere class which represents provided definition
         """
         if isinstance(definition, Mapping):
             if 'Type' in definition:  # this is an AWS Resource
                 expected_type = None
-                try:
-                    expected_type = self.inspect_resources[definition['Type']]
-                except KeyError:
+                if cls is not None:
+                    expected_type = cls
+                else:
                     # if the user uses the custom way to name custom resources,
                     # we'll dynamically create a new subclass for this use and
                     # pass that instead of the typical CustomObject resource
@@ -119,7 +145,8 @@ class TemplateGenerator(Template):
                         expected_type = self._generate_custom_type(
                             definition['Type'])
                     except TypeError:
-                        assert not expected_type
+                        # If definition['Type'] turns out not to be a custom type (aka doesn't start with "Custom::")
+                        assert not expected_type  # Make sure expected_type is nothing (as it always should be)
 
                 if expected_type:
                     args = self._normalize_properties(definition)


### PR DESCRIPTION
@dogonthehorizon did almost all the heavy lifting for this one. I fixed the bug mentioned in the previous PR #671.

I did this by adding a `cls` argument to the `TemplateGenerator._convert_definition` method. If the `cls` argument is provided it will attempt to create an instance of the provided class. If it is not provided then no classes will be made.

Then the only place where this `cls` argument is provided is in the `TemplateGenerator.__init__` method when adding resources.

All the tests pass but I am suspicious of my fix, it seemed too simple for such and annoying bug.