### PR TITLE
Check that FIFO Queues end with .fifo

### DIFF
--- a/troposphere/sqs.py
+++ b/troposphere/sqs.py
@@ -34,6 +34,12 @@ class Queue(AWSObject):
         'VisibilityTimeout': (integer, False),
     }
 
+    def validate(self):
+        if self.properties.get('FifoQueue'):
+            if not self.properties.get('QueueName', '').endswith('.fifo'):
+                raise ValueError("SQS: FIFO queues need to provide a "
+                                 "QueueName that ends with '.fifo'")
+
 
 class QueuePolicy(AWSObject):
     resource_type = "AWS::SQS::QueuePolicy"


### PR DESCRIPTION
Add a validate() method in sqs.py that checks that FIFO queues
(*) have a QueueName parameter and (*) QueueName ends with '.fifo'
as required by AWS:

http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html