### PR TITLE
Add 'Auth' property to CodeBuild Source

### DIFF
--- a/troposphere/codebuild.py
+++ b/troposphere/codebuild.py
@@ -6,6 +6,7 @@
 from . import AWSObject, AWSProperty, Tags
 from .validators import integer, boolean
 
+
 class Auth(AWSProperty):
     props = {
         'Type': (basestring, True),
@@ -19,6 +20,7 @@ class Auth(AWSProperty):
         if auth_types not in valid_types:
             raise ValueError('Auth Type: must be one of %s' %
                              ','.join(valid_types))
+
 
 class Artifacts(AWSProperty):
     props = {

--- a/troposphere/codebuild.py
+++ b/troposphere/codebuild.py
@@ -108,8 +108,8 @@ class Source(AWSProperty):
 
         auth = self.properties.get('Auth')
         if auth is not None and source_type is not 'GITHUB':
-            raise ValueError('Source Auth: must only be defined when using \'GITHUB\' Source Type.')
-
+            raise ValueError("Source Auth: must only be defined when using "
+                             "'GITHUB' Source Type.")
 
 
 class Project(AWSObject):

--- a/troposphere/codebuild.py
+++ b/troposphere/codebuild.py
@@ -6,6 +6,19 @@
 from . import AWSObject, AWSProperty, Tags
 from .validators import integer, boolean
 
+class Auth(AWSProperty):
+    props = {
+        'Type': (basestring, True),
+    }
+
+    def validate(self):
+        valid_types = [
+            'OAUTH'
+        ]
+        auth_types = self.properties.get('Type')
+        if auth_types not in valid_types:
+            raise ValueError('Auth Type: must be one of %s' %
+                             ','.join(valid_types))
 
 class Artifacts(AWSProperty):
     props = {
@@ -68,6 +81,7 @@ class Source(AWSProperty):
         'BuildSpec': (basestring, False),
         'Location': (basestring, False),
         'Type': (basestring, True),
+        'Auth': (Auth, False),
     }
 
     def validate(self):
@@ -89,6 +103,11 @@ class Source(AWSProperty):
                 'Source Location: must be defined when type is %s' %
                 source_type
                 )
+
+        auth = self.properties.get('Auth')
+        if auth is not None and source_type is not 'GITHUB':
+            raise ValueError('Source Auth: must only be defined when using \'GITHUB\' Source Type.')
+
 
 
 class Project(AWSObject):


### PR DESCRIPTION
The Source property in the `AWS::CodeBuild::Project` type can optionally take an `Auth` parameter when the Source Type is 'GITHUB'. This tells CodeBuild to use the OAUTH method of authenticating to private repositories.

There is no direct documentation of this, but they describe it's use in this article:
http://docs.aws.amazon.com/codebuild/latest/userguide/create-project.html#create-project-cli

You can only specify 'Auth' in the Source object when the Type is GITHUB. If you specify Auth in the Source object, the Auth Type can only be 'OAUTH'