### PR TITLE
Ulimit's HardLimit and SoftLimit validator change

### DIFF
--- a/troposphere/ecs.py
+++ b/troposphere/ecs.py
@@ -1,5 +1,5 @@
 from . import AWSObject, AWSProperty
-from .validators import boolean, network_port, positive_integer, integer
+from .validators import boolean, integer, network_port, positive_integer
 
 
 class Cluster(AWSObject):

--- a/troposphere/ecs.py
+++ b/troposphere/ecs.py
@@ -1,5 +1,5 @@
 from . import AWSObject, AWSProperty
-from .validators import boolean, network_port, positive_integer
+from .validators import boolean, network_port, positive_integer, integer
 
 
 class Cluster(AWSObject):
@@ -118,9 +118,9 @@ class LogConfiguration(AWSProperty):
 
 class Ulimit(AWSProperty):
     props = {
-        'HardLimit': (positive_integer, True),
+        'HardLimit': (integer, True),
         'Name': (basestring, False),
-        'SoftLimit': (positive_integer, True),
+        'SoftLimit': (integer, True),
     }
 
 


### PR DESCRIPTION
Ulimit's HardLimit and SoftLimit validator needs to be integer and not positive_integer.
http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definition_limits
For example memlock can be -1:-1 as required by:
https://www.elastic.co/guide/en/elasticsearch/reference/5.4/docker.html#_notes_for_production_use_and_defaults