### PR TITLE
Allow passing in a dict into DashboardBody

### DIFF
--- a/tests/test_cloudwatch.py
+++ b/tests/test_cloudwatch.py
@@ -1,0 +1,40 @@
+import unittest
+from troposphere.cloudwatch import Dashboard
+
+
+class TestModel(unittest.TestCase):
+    def test_dashboard(self):
+        # Check valid json dashboard string
+        dashboard = Dashboard(
+            "dashboard",
+            DashboardBody='{"a": "b"}',
+        )
+        dashboard.validate()
+
+        # Check invalid json dashboard string
+        dashboard = Dashboard(
+            "dashboard",
+            DashboardBody='{"a: "b"}',
+        )
+        with self.assertRaises(ValueError):
+            dashboard.validate()
+
+        # Check accepting dict and converting to string in validate
+        d = {"c": "d"}
+        dashboard = Dashboard(
+            "dashboard",
+            DashboardBody=d
+        )
+        dashboard.validate()
+        self.assertEqual(dashboard.properties['DashboardBody'], '{"c": "d"}')
+
+        # Check invalid Dashboard type
+        with self.assertRaises(TypeError):
+            dashboard = Dashboard(
+                "dashboard",
+                DashboardBody=1
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/troposphere/cloudwatch.py
+++ b/troposphere/cloudwatch.py
@@ -5,6 +5,7 @@
 
 from . import AWSObject, AWSProperty
 from .validators import positive_integer, boolean, exactly_one
+import json
 
 
 class MetricDimension(AWSProperty):
@@ -50,6 +51,18 @@ class Dashboard(AWSObject):
     resource_type = "AWS::CloudWatch::Dashboard"
 
     props = {
-        'DashboardBody': (basestring, True),
+        'DashboardBody': ((basestring, dict), True),
         'DashboardName': (basestring, False),
     }
+
+    def validate(self):
+        if 'DashboardBody' in self.properties:
+            dashboard_body = self.properties.get('DashboardBody')
+            if isinstance(dashboard_body, basestring):
+                # Verify it is a valid json string
+                json.loads(dashboard_body)
+            elif isinstance(dashboard_body, dict):
+                # Convert the dict to a basestring
+                self.properties['DashboardBody'] = json.dumps(dashboard_body)
+            else:
+                raise ValueError("DashboardBody must be a str or dict")


### PR DESCRIPTION
The dict should be converted into a json encoded string

This logic is taken from the [ApiGateway Model](https://github.com/cloudtools/troposphere/blob/d583dfb78b8d207b26070ae1894f7e36a1b39017/troposphere/apigateway.py#L188), whose Schema property also returns a json encoded string.

An example of using this, where both dashboard resources produce the same Cloudformation:

```python
from troposphere import Template
from troposphere.cloudwatch import Dashboard

t = Template()

t.add_resource(Dashboard(
    "dashboard",
    DashboardBody={"c": "d"}
))

t.add_resource(Dashboard(
    "dashboardstring",
    DashboardBody='{"c": "d"}'
))

print(t.to_json())
```