### PR TITLE
Override object validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - pip install --upgrade pycodestyle pyflakes
 
 before_script:
-  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then 2to3 -n -w --no-diffs troposphere scripts examples/CustomResource.py; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then 2to3 -n -w --no-diffs troposphere scripts/cfn2py examples/CustomResource.py; fi
   - pycodestyle --version
   - pycodestyle --show-source --show-pep8 .
   - pyflakes .

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - pip install --upgrade pycodestyle pyflakes
 
 before_script:
-  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then 2to3 -n -w --no-diffs troposphere examples/CustomResource.py; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then 2to3 -n -w --no-diffs troposphere scripts examples/CustomResource.py; fi
   - pycodestyle --version
   - pycodestyle --show-source --show-pep8 .
   - pyflakes .

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -410,7 +410,7 @@ class TestValidation(unittest.TestCase):
     def test_novalidation(self):
         route = Route(
             'Route66',
-            validate=False,
+            validation=False,
             DestinationCidrBlock='0.0.0.0/0',
             RouteTableId=Ref('RouteTable66'),
             InstanceId=If(
@@ -424,6 +424,26 @@ class TestValidation(unittest.TestCase):
                 Ref('AWS::NoValue')
             )
         )
+        t = Template()
+        t.add_resource(route)
+        t.to_json()
+
+    def test_no_validation_method(self):
+        route = Route(
+            'Route66',
+            DestinationCidrBlock='0.0.0.0/0',
+            RouteTableId=Ref('RouteTable66'),
+            InstanceId=If(
+                'UseNat',
+                Ref('AWS::NoValue'),
+                Ref('UseNat')
+            ),
+            NatGatewayId=If(
+                'UseNat',
+                Ref('UseNat'),
+                Ref('AWS::NoValue')
+            )
+        ).no_validation()
         t = Template()
         t.add_resource(route)
         t.to_json()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -403,7 +403,7 @@ class TestValidation(unittest.TestCase):
             )
         )
         t = Template()
-        resource = t.add_resource(route)
+        t.add_resource(route)
         with self.assertRaises(ValueError):
             t.to_json()
 
@@ -425,7 +425,7 @@ class TestValidation(unittest.TestCase):
             )
         )
         t = Template()
-        resource = t.add_resource(route)
+        t.add_resource(route)
         t.to_json()
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,8 +1,8 @@
 import unittest
 from troposphere import AWSObject, AWSProperty, Output, Parameter
-from troposphere import Join, Ref, Split, Sub, Template
+from troposphere import If, Join, Ref, Split, Sub, Template
 from troposphere import depends_on_helper
-from troposphere.ec2 import Instance, SecurityGroupRule
+from troposphere.ec2 import Instance, Route, SecurityGroupRule
 from troposphere.s3 import Bucket
 from troposphere.elasticloadbalancing import HealthCheck
 from troposphere.validators import positive_integer
@@ -382,6 +382,51 @@ class TestJoin(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             Join(10, "foobar")
+
+
+class TestValidation(unittest.TestCase):
+
+    def test_validation(self):
+        route = Route(
+            'Route66',
+            DestinationCidrBlock='0.0.0.0/0',
+            RouteTableId=Ref('RouteTable66'),
+            InstanceId=If(
+                'UseNat',
+                Ref('AWS::NoValue'),
+                Ref('UseNat')
+            ),
+            NatGatewayId=If(
+                'UseNat',
+                Ref('UseNat'),
+                Ref('AWS::NoValue')
+            )
+        )
+        t = Template()
+        resource = t.add_resource(route)
+        with self.assertRaises(ValueError):
+            t.to_json()
+
+    def test_novalidation(self):
+        route = Route(
+            'Route66',
+            validate=False,
+            DestinationCidrBlock='0.0.0.0/0',
+            RouteTableId=Ref('RouteTable66'),
+            InstanceId=If(
+                'UseNat',
+                Ref('AWS::NoValue'),
+                Ref('UseNat')
+            ),
+            NatGatewayId=If(
+                'UseNat',
+                Ref('UseNat'),
+                Ref('AWS::NoValue')
+            )
+        )
+        t = Template()
+        resource = t.add_resource(route)
+        t.to_json()
 
 
 if __name__ == '__main__':

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -83,9 +83,10 @@ def depends_on_helper(obj):
 
 
 class BaseAWSObject(object):
-    def __init__(self, title, template=None, **kwargs):
+    def __init__(self, title, template=None, validate=True, **kwargs):
         self.title = title
         self.template = template
+        self.do_validation = validate
         # Cache the keys for validity checks
         self.propnames = self.props.keys()
         self.attributes = ['DependsOn', 'DeletionPolicy',
@@ -222,8 +223,9 @@ class BaseAWSObject(object):
         pass
 
     def to_dict(self):
-        self._validate_props()
-        self.validate()
+        if self.do_validation:
+            self._validate_props()
+            self.validate()
 
         if self.properties:
             return encode_to_dict(self.resource)

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -83,10 +83,10 @@ def depends_on_helper(obj):
 
 
 class BaseAWSObject(object):
-    def __init__(self, title, template=None, validate=True, **kwargs):
+    def __init__(self, title, template=None, validation=True, **kwargs):
         self.title = title
         self.template = template
-        self.do_validation = validate
+        self.do_validation = validation
         # Cache the keys for validity checks
         self.propnames = self.props.keys()
         self.attributes = ['DependsOn', 'DeletionPolicy',
@@ -221,6 +221,10 @@ class BaseAWSObject(object):
 
     def validate(self):
         pass
+
+    def no_validation(self):
+        self.do_validation = False
+        return self
 
     def to_dict(self):
         if self.do_validation:


### PR DESCRIPTION
Add a parameter to allow for the override of object validation which has come up due to complex interaction of properties within an object. While longer term a full expression parser may help with the validation logic, there are still some instances that cannot be determined except at runtime with this override allowing for the template author to make the determination on whether to override the validation logic. This is a fix for #778.