### PR TITLE
Update PyPI Information

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include LICENSE
-include README.md
+include README.rst
 include .gitignore
 recursive-include examples *.py

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,15 @@
 from setuptools import setup
 
+
+def readme():
+    with open('README.rst') as f:
+        return f.read()
+
 setup(
     name='troposphere',
     version='1.9.5',
     description="AWS CloudFormation creation library",
+    long_description=readme(),
     author="Mark Peek",
     author_email="mark@peek.org",
     url="https://github.com/cloudtools/troposphere",

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ def readme():
     with open('README.rst') as f:
         return f.read()
 
+
 setup(
     name='troposphere',
     version='1.9.5',


### PR DESCRIPTION
I noticed that the MANIFEST.in file was referencing a Markdown README instead of a reStructuredText README.

Also, the PyPI website for this library has practically no information. I think it would be beneficial to copy the README.rst file over to the PyPI page as well.