### PR TITLE
Add support for EFS encryption

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - pip install --upgrade pycodestyle pyflakes
 
 before_script:
-  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then 2to3 -n -w --no-diffs troposphere examples/CustomResource.py; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then 2to3 -n -w --no-diffs troposphere scripts/cfn2py examples/CustomResource.py; fi
   - pycodestyle --version
   - pycodestyle --show-source --show-pep8 .
   - pyflakes .

--- a/troposphere/efs.py
+++ b/troposphere/efs.py
@@ -1,11 +1,14 @@
 from . import AWSObject, Tags
+from .validators import boolean
 
 
 class FileSystem(AWSObject):
     resource_type = "AWS::EFS::FileSystem"
 
     props = {
+        'Encrypted': (boolean, False),
         'FileSystemTags': (Tags, False),
+        'KmsKeyId': (basestring, False),
         'PerformanceMode': (basestring, False),
     }
 


### PR DESCRIPTION
Announcement [here](https://aws.amazon.com/blogs/aws/new-encryption-at-rest-for-amazon-elastic-file-system-efs/)
Cfn docs [here](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-efs-filesystem.html)

I also took the opportunity to fix the busted build by expanding the `2to3` usage to `scripts/cfn2py`. Let me know if you'd rather me pull this into a separate PR.