### PR TITLE
Add AWS::ApiGateway::GatewayResponse

### DIFF
--- a/tests/test_apigateway.py
+++ b/tests/test_apigateway.py
@@ -1,6 +1,6 @@
 import unittest
 from troposphere import Join
-from troposphere.apigateway import Model
+from troposphere.apigateway import GatewayResponse, Model
 
 
 class TestModel(unittest.TestCase):
@@ -54,6 +54,25 @@ class TestModel(unittest.TestCase):
             Schema=Join(':', ['{"a', ': "b"}']),
         )
         model.validate()
+
+
+class TestGatewayResponse(unittest.TestCase):
+    def test_response_type(self):
+        gateway_response = GatewayResponse(
+            "GatewayResponse",
+            ResponseType="DEFAULT_4XX",
+            RestApiId="apiid",
+            StatusCode="200"
+        )
+        gateway_response.validate()
+
+        with self.assertRaises(ValueError):
+            gateway_response = GatewayResponse(
+                "GatewayResponse",
+                ResponseType="INVALID_RESPONSE_TYPE",
+                RestApiId="apiid",
+                StatusCode="200"
+            )
 
 
 if __name__ == '__main__':

--- a/troposphere/apigateway.py
+++ b/troposphere/apigateway.py
@@ -295,3 +295,49 @@ class UsagePlanKey(AWSObject):
         "KeyType": (basestring, True),
         "UsagePlanId": (basestring, True),
     }
+
+
+def validate_gateway_response_type(response_type):
+    """ Validate response type
+    :param response_type: The GatewayResponse response type
+    :return: The provided value if valid
+    """
+    valid_response_types = [
+        "ACCESS_DENIED",
+        "API_CONFIGURATION_ERROR",
+        "AUTHORIZER_FAILURE",
+        "AUTHORIZER_CONFIGURATION_ERROR",
+        "BAD_REQUEST_PARAMETERS",
+        "BAD_REQUEST_BODY",
+        "DEFAULT_4XX",
+        "DEFAULT_5XX",
+        "EXPIRED_TOKEN",
+        "INVALID_SIGNATURE",
+        "INTEGRATION_FAILURE",
+        "INTEGRATION_TIMEOUT",
+        "INVALID_API_KEY",
+        "MISSING_AUTHENTICATION_TOKEN",
+        "QUOTA_EXCEEDED",
+        "REQUEST_TOO_LARGE",
+        "RESOURCE_NOT_FOUND",
+        "THROTTLED",
+        "UNAUTHORIZED",
+        "UNSUPPORTED_MEDIA_TYPES"
+    ]
+    if response_type not in valid_response_types:
+        raise ValueError(
+            "{} is not a valid ResponseType".format(response_type)
+        )
+    return response_type
+
+
+class GatewayResponse(AWSObject):
+    resource_type = "AWS::ApiGateway::GatewayResponse"
+
+    props = {
+        "ResponseParameters": (dict, False),
+        "ResponseTemplates": (dict, False),
+        "ResponseType": (validate_gateway_response_type, True),
+        "RestApiId": (basestring, True),
+        "StatusCode": (basestring, False)
+    }


### PR DESCRIPTION
Adds support for [AWS::ApiGateway::GatewayResponse](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-gatewayresponse.html). 

Unfortunately, there seems to currently be a bug in CloudFormation which blocks creating GatewayResponses (https://forums.aws.amazon.com/thread.jspa?messageID=801223). However, I think it's still worth adding support for creating these objects according to the spec in the docs.

It's my first PR and I'm not sure about the conventions in the project so please let me know if anything needs to be changed accordingly.