### PR TITLE
Add support for aurora-postgresql as a valid DB engine

### DIFF
--- a/troposphere/rds.py
+++ b/troposphere/rds.py
@@ -15,7 +15,7 @@ VALID_STORAGE_TYPES = ('standard', 'gp2', 'io1')
 VALID_DB_ENGINES = ('MySQL', 'mysql', 'oracle-se1', 'oracle-se2', 'oracle-se',
                     'oracle-ee', 'sqlserver-ee', 'sqlserver-se',
                     'sqlserver-ex', 'sqlserver-web', 'postgres', 'aurora',
-                    'mariadb')
+                    'aurora-postgresql', 'mariadb')
 VALID_LICENSE_MODELS = ('license-included', 'bring-your-own-license',
                         'general-public-license', 'postgresql-license')
 


### PR DESCRIPTION
Aurora PostgreSQL is currently in preview and is accessible via CloudFormation. This requires aurora-postgresql to be a valid DB engine selection.