### PR TITLE
AWS Batch Support

### DIFF
--- a/troposphere/batch.py
+++ b/troposphere/batch.py
@@ -1,0 +1,162 @@
+from . import AWSObject, AWSProperty
+from .validators import positive_integer
+
+
+class ComputeResources(AWSProperty):
+
+    props = {
+        "SpotIamFleetRole": (basestring, False),
+        "MaxvCpus": (positive_integer, True),
+        "SecurityGroupIds": ([basestring], True),
+        "BidPercentage": (positive_integer, False),
+        "Type": (basestring, True),
+        "Subnets": ([basestring], True),
+        "MinvCpus": (positive_integer, True),
+        "ImageId": (basestring, False),
+        "InstanceRole": (basestring, True),
+        "InstanceTypes": ([basestring], True),
+        "Ec2KeyPair": (basestring, False),
+        "Tags": ([basestring], False),
+        "DesiredvCpus": (positive_integer, False)
+    }
+
+
+class MountPoints(AWSProperty):
+
+    props = {
+        "ReadOnly": (bool, False),
+        "SourceVolume": (basestring, False),
+        "ContainerPath": (basestring, False)
+    }
+
+
+class VolumesHost(AWSProperty):
+
+    props = {
+        "SourcePath": (basestring, False)
+    }
+
+
+class Volumes(AWSProperty):
+
+    props = {
+        "Host": (VolumesHost, False),
+        "Name": (basestring, False)
+    }
+
+
+class Environment(AWSProperty):
+
+    props = {
+        "Value": (basestring, False),
+        "Name": (basestring, False)
+    }
+
+
+class Ulimit(AWSProperty):
+
+    props = {
+        "SoftLimit": (positive_integer, True),
+        "HardLimit": (positive_integer, True),
+        "Name": (basestring, True)
+    }
+
+
+class ContainerProperties(AWSProperty):
+
+    props = {
+        "MountPoints": ([MountPoints], False),
+        "User": (basestring, False),
+        "Volumes": ([Volumes], False),
+        "Command": ([basestring], False),
+        "Memory": (positive_integer, True),
+        "Privileged": (bool, False),
+        "Environment": ([Environment], False),
+        "JobRoleArn": (basestring, False),
+        "ReadonlyRootFilesystem": (bool, False),
+        "Ulimits": ([Ulimit], False),
+        "Vcpus": (positive_integer, True),
+        "Image": (basestring, True)
+    }
+
+
+class RetryStrategy(AWSProperty):
+
+    props = {
+        "Attempts": (positive_integer, False)
+    }
+
+
+class JobDefinition(AWSObject):
+    resource_type = "AWS::Batch::JobDefinition"
+
+    props = {
+        "Type": (basestring, True),
+        "Parameters": (dict, True),
+        "ContainerProperties": (ContainerProperties, False),
+        "JobDefinitionName": (basestring, True),
+        "RetryStrategy": (RetryStrategy, False)
+    }
+
+
+def validate_environment_state(environment_state):
+    """ Validate response type
+    :param environment_state: State of the environment
+    :return: The provided value if valid
+    """
+    valid_states = [
+        "ENABLED",
+        "DISABLED"
+    ]
+    if environment_state not in valid_states:
+        raise ValueError(
+            "{} is not a valid environment state".format(environment_state)
+        )
+    return environment_state
+
+
+class ComputeEnvironment(AWSObject):
+    resource_type = "AWS::Batch::ComputeEnvironment"
+
+    props = {
+        "Type": (basestring, True),
+        "ServiceRole": (basestring, True),
+        "ComputeEnvironmentName": (basestring, False),
+        "ComputeResources": (ComputeResources, True),
+        "State": (validate_environment_state, False)
+    }
+
+
+class ComputeEnvironmentOrder(AWSProperty):
+
+    props = {
+        "ComputeEnvironment": (basestring, True),
+        "Order": (positive_integer, True)
+    }
+
+
+def validate_queue_state(queue_state):
+    """ Validate response type
+    :param queue_state: State of the queue
+    :return: The provided value if valid
+    """
+    valid_states = [
+        "ENABLED",
+        "DISABLED"
+    ]
+    if queue_state not in valid_states:
+        raise ValueError(
+            "{} is not a valid queue state".format(queue_state)
+        )
+    return queue_state
+
+
+class JobQueue(AWSObject):
+    resource_type = "AWS::Batch::JobQueue"
+
+    props = {
+        "ComputeEnvironmentOrder": ([ComputeEnvironmentOrder], True),
+        "Priority": (positive_integer, True),
+        "State": (validate_queue_state, False),
+        "JobQueueName": (basestring, True)
+    }


### PR DESCRIPTION
Support AWS batch per issue #781. This is somewhat of a draft of the whole thing to make sure the overall structure looks sane before I go up and CloudFormation all the things. Note that for the `JobQueue` resource's state property I diverged from the CF documentation and used the REST API documentation for `CreateJobQueue` which states that `ENABLED` or `DISABLED` are valid values. 

The following resources are added:

* [AWS::Batch::ComputeEnvironment](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-batch-computeenvironment.html)
* [AWS::Batch::JobDefinition](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-batch-jobdefinition.html)
* [AWS::Batch::JobQueue](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-batch-jobqueue.html)

The following property types are added:

* [AWS Batch ComputeEnvironment ComputeResources](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-computeenvironment-computeresources.html)
* [AWS Batch JobDefinition ContainerProperties](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties.html)
* [AWS Batch JobDefinition Environment](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-environment.html)
* [AWS Batch JobDefinition MountPoints](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-mountpoints.html)
* [AWS Batch JobDefinition RetryStrategy](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-retrystrategy.html)
* [AWS Batch JobDefinition Ulimit](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-ulimit.html)
* [AWS Batch JobDefinition Volumes](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-volumes.html)
* [AWS Batch JobDefinition VolumesHost](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-volumeshost.html)
* [AWS Batch JobQueue ComputeEnvironmentOrder](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobqueue-computeenvironmentorder.html)

If this looks good I'll go ahead and do the runtime testing. As for updating `README.md`'s list of supported resources do you want that as a separate commit or should I just squash with the python code commit?