### PR TITLE
VPC expansion support

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -695,5 +695,6 @@ class VPCCidrBlock(AWSObject):
 
     props = {
         'AmazonProvidedIpv6CidrBlock': (boolean, False),
+        'CidrBlock': (basestring, False),
         'VpcId': (basestring, True),
     }


### PR DESCRIPTION
Added the `CidrBlock` property to VPCCidrBlock to support [adding a second CIDR block to a VPC](https://aws.amazon.com/about-aws/whats-new/2017/08/amazon-virtual-private-cloud-vpc-now-allows-customers-to-expand-their-existing-vpcs/). Addresses Issue #795. 