### PR TITLE
Revert "Accept Join type as parameter default value as it returns a s…

### DIFF
--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,6 +1,6 @@
 import unittest
 
-from troposphere import Join, Parameter
+from troposphere import Parameter
 
 
 class TestInitArguments(unittest.TestCase):
@@ -8,10 +8,6 @@ class TestInitArguments(unittest.TestCase):
         title = 'i' * 256
         with self.assertRaises(ValueError):
             Parameter(title, Type='String')
-
-    def test_validate_with_a_join_default(self):
-        Parameter(
-            'test', Type='String', Default=Join('', ['a', 'b'])).validate()
 
 
 if __name__ == '__main__':

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -673,8 +673,7 @@ class Parameter(AWSDeclaration):
             # matches (in the case of a String Type) or can be coerced
             # into one of the number formats.
             param_type = self.properties.get('Type')
-            if param_type == 'String' and not \
-                    isinstance(default, (basestring, Join)):
+            if param_type == 'String' and not isinstance(default, basestring):
                 raise ValueError(error_str %
                                  ('String', type(default), default))
             elif param_type == 'Number':


### PR DESCRIPTION
…tring (#752)"

This reverts commit 3b78644106368c195399477f2e47552f4497bd0d.

This was a incorrect change - cloudformation also rejects it with a validation error - "Template validation error: Template format error: Every Default member must be a string."
