### PR TITLE
Change Cognito UserPool SchemaAttribute "Required" value to boolean from basestring

### DIFF
--- a/troposphere/cognito.py
+++ b/troposphere/cognito.py
@@ -161,7 +161,7 @@ class SchemaAttribute(AWSProperty):
         'Name': (basestring, False),
         'NumberAttributeConstraints': (NumberAttributeConstraints, False),
         'StringAttributeConstraints': (StringAttributeConstraints, False),
-        'Required': (basestring, False),
+        'Required': (boolean, False),
     }
 
 


### PR DESCRIPTION
SchemaAttribute documentation mentions that the "Required" field is a boolean, similar to the "Mutable" field. Wasn't sure if it was just an oversight but to avoid confusion I thought it should also accept plain boolean values.

http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-userpool-schemaattribute.html