### PR TITLE
EFS example: SecurityGroupRule can't be referred to as a Ref

### DIFF
--- a/examples/EFS.py
+++ b/examples/EFS.py
@@ -58,7 +58,7 @@ efs_security_group_rule = SecurityGroupRule(
 # Security group that's applied to the Mount Targets.
 efs_security_group = SecurityGroup(
     "SecurityGroup",
-    SecurityGroupIngress=[Ref(efs_security_group_rule)],
+    SecurityGroupIngress=[efs_security_group_rule],
     VpcId=Ref(vpcid_param),
     GroupDescription="Allow NFS over TCP"
 )

--- a/tests/examples_output/EFS.template
+++ b/tests/examples_output/EFS.template
@@ -134,7 +134,12 @@
                 "GroupDescription": "Allow NFS over TCP",
                 "SecurityGroupIngress": [
                     {
-                        "Ref": null
+                        "FromPort": "2049",
+                        "IpProtocol": "tcp",
+                        "SourceSecurityGroupId": {
+                            "Ref": "EFSHostSecurityGroup"
+                        },
+                        "ToPort": "2049"
                     }
                 ],
                 "VpcId": {


### PR DESCRIPTION
Because the `SecurityGroupRule` isn't added into the template, `Ref` doesn't work here. The `SecurityGroup` constructor should refer to the `SecurityGroupRule` object directly.