### PR TITLE
Added CloudTrail EventSelectors

### DIFF
--- a/troposphere/cloudtrail.py
+++ b/troposphere/cloudtrail.py
@@ -8,12 +8,14 @@ class DataResource(AWSProperty):
         'Values': ([basestring], False),
     }
 
+
 class EventSelector(AWSProperty):
     props = {
         'DataResources': ([DataResource], False),
         'IncludeManagementEvents': (boolean, False),
         'ReadWriteType': (basestring, False),
     }
+
 
 class Trail(AWSObject):
     resource_type = "AWS::CloudTrail::Trail"

--- a/troposphere/cloudtrail.py
+++ b/troposphere/cloudtrail.py
@@ -1,6 +1,19 @@
-from . import AWSObject, Tags
+from . import AWSObject, Tags, AWSProperty
 from .validators import boolean
 
+
+class DataResource(AWSProperty):
+    props = {
+        'Type': (basestring, True),
+        'Values': ([basestring], False),
+    }
+
+class EventSelector(AWSProperty):
+    props = {
+        'DataResources': ([DataResource], False),
+        'IncludeManagementEvents': (boolean, False),
+        'ReadWriteType': (basestring, False),
+    }
 
 class Trail(AWSObject):
     resource_type = "AWS::CloudTrail::Trail"
@@ -9,6 +22,7 @@ class Trail(AWSObject):
         'CloudWatchLogsLogGroupArn': (basestring, False),
         'CloudWatchLogsRoleArn': (basestring, False),
         'EnableLogFileValidation': (boolean, False),
+        'EventSelectors': ([EventSelector], False),
         'IncludeGlobalServiceEvents': (boolean, False),
         'IsLogging': (boolean, True),
         'IsMultiRegionTrail': (boolean, False),


### PR DESCRIPTION
Enables data source events for CloudTrail. Please have a look here: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-eventselector.html.