### PR TITLE
Update serverless.py

### DIFF
--- a/tests/test_serverless.py
+++ b/tests/test_serverless.py
@@ -15,11 +15,46 @@ class TestServerless(unittest.TestCase):
         t.add_resource(serverless_func)
         t.to_json()
 
-    def test_required_api(self):
+    def test_required_api_definitionuri(self):
         serverless_api = Api(
             "SomeApi",
             StageName='test',
             DefinitionUri='s3://bucket/swagger.yml',
+        )
+        t = Template()
+        t.add_resource(serverless_api)
+        t.to_json()
+
+    swagger = {
+        "swagger": "2.0",
+        "info": {
+            "title": "swagger test",
+        },
+        "paths": {
+            "/test": {
+                "get": {
+                 },
+            },
+        },
+    }
+
+    def test_required_api_both(self):
+        serverless_api = Api(
+            "SomeApi",
+            StageName='test',
+            DefinitionUri='s3://bucket/swagger.yml',
+            DefinitionBody=self.swagger,
+        )
+        t = Template()
+        t.add_resource(serverless_api)
+        with self.assertRaises(ValueError):
+            t.to_json()
+
+    def test_required_api_definitionbody(self):
+        serverless_api = Api(
+            "SomeApi",
+            StageName='test',
+            DefinitionBody=self.swagger,
         )
         t = Template()
         t.add_resource(serverless_api)

--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -8,7 +8,7 @@ import types
 from . import AWSObject, AWSProperty
 from .awslambda import Environment, VPCConfig, validate_memory_size
 from .dynamodb import ProvisionedThroughput
-from .validators import positive_integer
+from .validators import exactly_one, positive_integer
 
 assert types  # silence pyflakes
 
@@ -54,12 +54,19 @@ class Api(AWSObject):
 
     props = {
         'StageName': (basestring, True),
-        'DefinitionUri': (basestring, True),
         'DefinitionBody': (dict, False),
+        'DefinitionUri': (basestring, False),
         'CacheClusterEnabled': (bool, False),
         'CacheClusterSize': (basestring, False),
-        'Variables': (dict, False)
+        'Variables': (dict, False),
     }
+
+    def validate(self):
+        conds = [
+            'DefinitionBody',
+            'DefinitionUri',
+        ]
+        exactly_one(self.__class__.__name__, self.properties, conds)
 
 
 class PrimaryKey(AWSProperty):

--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -55,6 +55,7 @@ class Api(AWSObject):
     props = {
         'StageName': (basestring, True),
         'DefinitionUri': (basestring, True),
+        'DefinitionBody': (dict, False),
         'CacheClusterEnabled': (bool, False),
         'CacheClusterSize': (basestring, False),
         'Variables': (dict, False)


### PR DESCRIPTION
Adding "DefinitionBody" to serverless::api. Not sure if this is the right type (dict) as the body can either be a YAML or JSON object. Also not sure how to do either/or (True/False) as you can specify either DefinitionBody _or_ DefinitionUri. Would appreciate getting this added to the next release ASAP, as this is a blocking defect. Thanks!