### PR TITLE
Adding kinesis stream source to firehose

### DIFF
--- a/troposphere/firehose.py
+++ b/troposphere/firehose.py
@@ -136,13 +136,22 @@ class ExtendedS3DestinationConfiguration(AWSProperty):
     }
 
 
+class KinesisStreamSourceConfiguration(AWSProperty):
+    props = {
+        'KinesisStreamARN': (basestring, True),
+        'RoleARN': (basestring, True)
+    }
+
+
 class DeliveryStream(AWSObject):
     resource_type = "AWS::KinesisFirehose::DeliveryStream"
 
     props = {
         'DeliveryStreamName': (basestring, False),
+        'DeliveryStreamType': (basestring, False),
         'ElasticsearchDestinationConfiguration': (ElasticsearchDestinationConfiguration, False),  # noqa
         'ExtendedS3DestinationConfiguration': (ExtendedS3DestinationConfiguration, False),  # noqa
+        'KinesisStreamSourceConfiguration': (KinesisStreamSourceConfiguration, False),  # noqa
         'RedshiftDestinationConfiguration': (RedshiftDestinationConfiguration, False),  # noqa
         'S3DestinationConfiguration': (S3DestinationConfiguration, False),
     }


### PR DESCRIPTION
The `KinesisStreamSourceConfiguration` is missing from `firehose.py`. Official docs are [here](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisfirehose-deliverystream.html).

One thing to note is `DeliveryStreamType` is missing from the docs but is present in the examples - it's required to make the source configuration work.