### PR TITLE
Add Tags to NATGateway

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -102,6 +102,7 @@ class NatGateway(AWSObject):
     props = {
             'AllocationId': (basestring, True),
             'SubnetId': (basestring, True),
+            'Tags': (list, False),
     }
 
 


### PR DESCRIPTION
Add Tags support to the `AWS::EC2::NatGateway` class

Closes #826 