### PR TITLE
Add ResourceLifecycleConfig to ElasticBeanstalk

### DIFF
--- a/troposphere/elasticbeanstalk.py
+++ b/troposphere/elasticbeanstalk.py
@@ -28,7 +28,7 @@ class MaxCountRule(AWSProperty):
     }
 
 
-class VersionLifecycleConfig(AWSProperty):
+class ApplicationVersionLifecycleConfig(AWSProperty):
     props = {
         'MaxAgeRule': (MaxAgeRule, False),
         'MaxCountRule': (MaxCountRule, False),
@@ -52,7 +52,7 @@ class SourceConfiguration(AWSProperty):
 class ResourceLifecycleConfig(AWSProperty):
     props = {
         'ServiceRole': (basestring, False),
-        'VersionLifecycleConfig': (VersionLifecycleConfig, False),
+        'VersionLifecycleConfig': (ApplicationVersionLifecycleConfig, False),
     }
 
 

--- a/troposphere/elasticbeanstalk.py
+++ b/troposphere/elasticbeanstalk.py
@@ -4,12 +4,35 @@
 # See LICENSE file for full license.
 
 from . import AWSObject, AWSProperty, Tags
-
+from .validators import boolean, integer
 
 WebServer = "WebServer"
 Worker = "Worker"
 WebServerType = "Standard"
 WorkerType = "SQS/HTTP"
+
+
+class MaxAgeRule(AWSProperty):
+    props = {
+      'DeleteSourceFromS3': (boolean, False),
+      'Enabled': (boolean, False),
+      'MaxAgeInDays': (integer, False),
+    }
+
+
+class MaxCountRule(AWSProperty):
+    props = {
+      'DeleteSourceFromS3': (boolean, False),
+      'Enabled': (boolean, False),
+      'MaxCount': (integer, False),
+    }
+
+
+class VersionLifecycleConfig(AWSProperty):
+    props = {
+        'MaxAgeRule': (MaxAgeRule, False),
+        'MaxCountRule': (MaxCountRule, False),
+    }
 
 
 class SourceBundle(AWSProperty):
@@ -23,6 +46,13 @@ class SourceConfiguration(AWSProperty):
     props = {
         'ApplicationName': (basestring, True),
         'TemplateName': (basestring, True),
+    }
+
+
+class ResourceLifecycleConfig(AWSProperty):
+    props = {
+        'ServiceRole': (basestring, False),
+        'VersionLifecycleConfig': (VersionLifecycleConfig, False),
     }
 
 
@@ -40,6 +70,7 @@ class Application(AWSObject):
     props = {
         'ApplicationName': (basestring, False),
         'Description': (basestring, False),
+        'ResourceLifecycleConfig': (ResourceLifecycleConfig, False),
     }
 
 

--- a/troposphere/elasticbeanstalk.py
+++ b/troposphere/elasticbeanstalk.py
@@ -49,7 +49,7 @@ class SourceConfiguration(AWSProperty):
     }
 
 
-class ResourceLifecycleConfig(AWSProperty):
+class ApplicationResourceLifecycleConfig(AWSProperty):
     props = {
         'ServiceRole': (basestring, False),
         'VersionLifecycleConfig': (ApplicationVersionLifecycleConfig, False),
@@ -70,7 +70,7 @@ class Application(AWSObject):
     props = {
         'ApplicationName': (basestring, False),
         'Description': (basestring, False),
-        'ResourceLifecycleConfig': (ResourceLifecycleConfig, False),
+        'ResourceLifecycleConfig': (ApplicationResourceLifecycleConfig, False),
     }
 
 


### PR DESCRIPTION
Add the `ResourceLifecycleConfig` property to the `AWS::ElasticBeanstalk::Application` Class.

Closes #827 