### PR TITLE
Make AdjustmentType an optional property of ScalingPolicy

### DIFF
--- a/troposphere/autoscaling.py
+++ b/troposphere/autoscaling.py
@@ -245,7 +245,7 @@ class ScalingPolicy(AWSObject):
     resource_type = "AWS::AutoScaling::ScalingPolicy"
 
     props = {
-        'AdjustmentType': (basestring, True),
+        'AdjustmentType': (basestring, False),
         'AutoScalingGroupName': (basestring, True),
         'Cooldown': (integer, False),
         'EstimatedInstanceWarmup': (integer, False),


### PR DESCRIPTION
Per the AWS docs, the `AdjustmentType` property is only supported for simple and step scaling policies and is no longer a required property of `AWS::AutoScaling::ScalingPolicy`. This change will allow for creating target tracking scaling policies without having to specify `AdjustmentType`, which is not used.

http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-policy.html#cfn-as-scalingpolicy-adjustmenttype
http://docs.aws.amazon.com/AutoScaling/latest/APIReference/API_PutScalingPolicy.html#API_PutScalingPolicy_RequestParameters