### PR TITLE
Add Tags, Tracing, KmsKeyArn, DLQ to serverless(SAM)

### DIFF
--- a/tests/test_serverless.py
+++ b/tests/test_serverless.py
@@ -1,9 +1,39 @@
 import unittest
 from troposphere import Template
-from troposphere.serverless import Function, Api, SimpleTable
+from troposphere.serverless import Function, Api, SimpleTable, DeadLetterQueue
 
 
 class TestServerless(unittest.TestCase):
+    def test_tags(self):
+        serverless_func = Function(
+            "SomeHandler",
+            Handler="index.handler",
+            Runtime="nodejs",
+            CodeUri="s3://bucket/handler.zip",
+            Tags={
+                'Tag1': 'TagValue1',
+                'Tag2': 'TagValue2'
+            }
+        )
+        t = Template()
+        t.add_resource(serverless_func)
+        t.to_json()
+
+    def test_DLQ(self):
+        serverless_func = Function(
+            "SomeHandler",
+            Handler="index.handler",
+            Runtime="nodejs",
+            CodeUri="s3://bucket/handler.zip",
+            DeadLetterQueue=DeadLetterQueue(
+                Type='SNS',
+                TargetArn='arn:aws:sns:us-east-1:000000000000:SampleTopic'
+            )
+        )
+        t = Template()
+        t.add_resource(serverless_func)
+        t.to_json()
+
     def test_required_function(self):
         serverless_func = Function(
             "SomeHandler",

--- a/tests/test_serverless.py
+++ b/tests/test_serverless.py
@@ -1,6 +1,6 @@
 import unittest
 from troposphere import Template
-from troposphere.serverless import Function, Api, SimpleTable, DeadLetterQueue
+from troposphere.serverless import Api, DeadLetterQueue, Function, SimpleTable
 
 
 class TestServerless(unittest.TestCase):

--- a/tests/test_serverless.py
+++ b/tests/test_serverless.py
@@ -1,9 +1,25 @@
 import unittest
 from troposphere import Template
-from troposphere.serverless import Api, DeadLetterQueue, Function, SimpleTable
+from troposphere.serverless import (
+    Api, DeadLetterQueue, Function, S3Location, SimpleTable
+)
 
 
 class TestServerless(unittest.TestCase):
+    def test_s3_location(self):
+        serverless_func = Function(
+            "SomeHandler",
+            Handler="index.handler",
+            Runtime="nodejs",
+            CodeUri=S3Location(
+                Bucket="mybucket",
+                Key="mykey",
+            )
+        )
+        t = Template()
+        t.add_resource(serverless_func)
+        t.to_json()
+
     def test_tags(self):
         serverless_func = Function(
             "SomeHandler",

--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -31,6 +31,19 @@ def policy_validator(x):
                          + " policy documents")
 
 
+class DeadLetterQueue(AWSProperty):
+    props = {
+        'Type': (basestring, False),
+        'TargetArn': (basestring, False)
+    }
+
+    def validate(self):
+        valid_types = ['SQS', 'SNS']
+        if self.properties['Type'] not in valid_types:
+            raise ValueError('Type must be either SQS or SNS')
+        return self.properties['Type']
+
+
 class Function(AWSObject):
     resource_type = "AWS::Serverless::Function"
 
@@ -45,7 +58,11 @@ class Function(AWSObject):
         'Policies': (policy_validator, False),
         'Environment': (Environment, False),
         'VpcConfig': (VPCConfig, False),
-        'Events': (dict, False)
+        'Events': (dict, False),
+        'Tags': (dict, False),
+        'Tracing': (basestring, False),
+        'KmsKeyArn': (basestring, False),
+        'DeadLetterQueue': (DeadLetterQueue, False)
     }
 
 

--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -39,9 +39,9 @@ class DeadLetterQueue(AWSProperty):
 
     def validate(self):
         valid_types = ['SQS', 'SNS']
-        if self.properties['Type'] not in valid_types:
+        if ('Type' in self.properties and
+                self.properties['Type'] not in valid_types):
             raise ValueError('Type must be either SQS or SNS')
-        return self.properties['Type']
 
 
 class Function(AWSObject):

--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -44,13 +44,21 @@ class DeadLetterQueue(AWSProperty):
             raise ValueError('Type must be either SQS or SNS')
 
 
+class S3Location(AWSProperty):
+    props = {
+        "Bucket": (basestring, True),
+        "Key": (basestring, True),
+        "Version": (basestring, False)
+    }
+
+
 class Function(AWSObject):
     resource_type = "AWS::Serverless::Function"
 
     props = {
         'Handler': (basestring, True),
         'Runtime': (basestring, True),
-        'CodeUri': (basestring, True),
+        'CodeUri': ((S3Location, basestring), True),
         'Description': (basestring, False),
         'MemorySize': (validate_memory_size, False),
         'Timeout': (positive_integer, False),


### PR DESCRIPTION
SAM(Serverless) is missing some of the function properties, add following properties to the template:
* Tags
* Tracing
* KmsKeyArn
* DeadLetterQueue
* CodeUri, This has been covered in another PR [#852](https://github.com/cloudtools/troposphere/pull/852)
