### PR TITLE
EC2 NoDevice should be type boolean not dict

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -121,7 +121,7 @@ class BlockDeviceMapping(AWSProperty):
     props = {
         'DeviceName': (basestring, True),
         'Ebs': (EBSBlockDevice, False),      # Conditional
-        'NoDevice': (dict, False),
+        'NoDevice': (boolean, False),
         'VirtualName': (basestring, False),  # Conditional
     }
 


### PR DESCRIPTION
I've been trying to set NoDevice but am getting errors. Troposphere requires dict but I get a CF error "Value of property NoDevice must be of type String" when I use dict, even if a create an empty one.

http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html

It looks like it always wants "" so I assume changing the type to basestring will enable this to work.

(Sorry I wasn't sure if I should have raised an issue first but just dived in :) )