### PR TITLE
Fixes RecordColumns cardinality for InputSchema and ReferenceSchema

### DIFF
--- a/troposphere/analytics.py
+++ b/troposphere/analytics.py
@@ -13,7 +13,7 @@ class InputParallelism(AWSProperty):
     }
 
 
-class RecordColumns(AWSProperty):
+class RecordColumn(AWSProperty):
     props = {
         'Mapping': (basestring, False),
         'Name': (basestring, True),
@@ -50,7 +50,7 @@ class RecordFormat(AWSProperty):
 
 class InputSchema(AWSProperty):
     props = {
-        'RecordColumns': (RecordColumns, True),
+        'RecordColumns': ([RecordColumn], True),
         'RecordEncoding': (basestring, False),
         'RecordFormat': (RecordFormat, True),
     }
@@ -131,7 +131,7 @@ class ApplicationOutput(AWSObject):
 
 class ReferenceSchema(AWSProperty):
     props = {
-        'RecordColumns': (RecordColumns, True),
+        'RecordColumns': ([RecordColumn], True),
         'RecordEncoding': (basestring, False),
         'RecordFormat': (RecordFormat, True),
     }


### PR DESCRIPTION
Both InputSchema[0] and ReferenceSchema[1] should be a list of RecordColumn
instead of a RecordColumns

[0]: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisanalytics-application-inputschema.html
[1]: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisanalytics-applicationreferencedatasource-referenceschema.html