### PR TITLE
Make AWS::Batch::JobQueue::JobQueueName optional

### DIFF
--- a/troposphere/batch.py
+++ b/troposphere/batch.py
@@ -158,5 +158,5 @@ class JobQueue(AWSObject):
         "ComputeEnvironmentOrder": ([ComputeEnvironmentOrder], True),
         "Priority": (positive_integer, True),
         "State": (validate_queue_state, False),
-        "JobQueueName": (basestring, True)
+        "JobQueueName": (basestring, False)
     }


### PR DESCRIPTION
[Cloudformation documentation for AWS::Batch::JobQueue](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-batch-jobqueue.html) specifies that this parameter is not required.