### PR TITLE
Fixes ApplicationOutput/Output cardinality

### DIFF
--- a/troposphere/analytics.py
+++ b/troposphere/analytics.py
@@ -125,7 +125,7 @@ class ApplicationOutput(AWSObject):
 
     props = {
         'ApplicationName': (basestring, True),
-        'Output': ([Output], True),
+        'Output': (Output, True),
     }
 
 


### PR DESCRIPTION
The Output[0] property should be an object instead of a list of objects.
The official documentation is not clear about this but creating an
ApplicationOutput with a list of Output objects will fail with the message:

Property validation failure: [Value of property {/Output} does not match type {Object}]

while creating an ApplicationOutput with an Ouput object will succeed.

[0]: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalytics-applicationoutput.html