### PR TITLE
Set EC2 BlockDeviceMapping NoDevice property to type dict

### DIFF
--- a/examples/EC2_Remove_Ephemeral_Drive.py
+++ b/examples/EC2_Remove_Ephemeral_Drive.py
@@ -1,4 +1,6 @@
 from troposphere import FindInMap, GetAtt, Output, Parameter, Ref, Template
+from troposphere.ec2 import NO_DEVICE
+
 import troposphere.ec2 as ec2
 
 
@@ -37,10 +39,10 @@ ec2_instance = template.add_resource(ec2.Instance(
     BlockDeviceMappings=[
         ec2.BlockDeviceMapping(
             DeviceName='/dev/sdb',
-            NoDevice={}),
+            NoDevice=NO_DEVICE),
         ec2.BlockDeviceMapping(
             DeviceName='/dev/sdc',
-            NoDevice={}),
+            NoDevice=NO_DEVICE),
     ]
 ))
 

--- a/examples/EC2_Remove_Ephemeral_Drive.py
+++ b/examples/EC2_Remove_Ephemeral_Drive.py
@@ -1,0 +1,80 @@
+from troposphere import FindInMap, GetAtt, Output, Parameter, Ref, Template
+import troposphere.ec2 as ec2
+
+
+template = Template()
+
+keyname_param = template.add_parameter(Parameter(
+    "KeyName",
+    Description="Name of an existing EC2 KeyPair to enable SSH "
+                "access to the instance",
+    Type="String",
+))
+
+template.add_mapping('RegionMap', {
+      "ap-northeast-1": {"AMI": "ami-6959870f"},
+      "ap-northeast-2": {"AMI": "ami-08d77266"},
+      "ap-south-1": {"AMI": "ami-50591a3f"},
+      "ap-southeast-1": {"AMI": "ami-d9dca7ba"},
+      "ap-southeast-2": {"AMI": "ami-02ad4060"},
+      "ca-central-1": {"AMI": "ami-13e45c77"},
+      "eu-central-1": {"AMI": "ami-e613ac89"},
+      "eu-west-1": {"AMI": "ami-eed00d97"},
+      "eu-west-2": {"AMI": "ami-ba5f42de"},
+      "sa-east-1": {"AMI": "ami-1ca7d970"},
+      "us-east-1": {"AMI": "ami-bcdc16c6"},
+      "us-east-2": {"AMI": "ami-49426e2c"},
+      "us-west-1": {"AMI": "ami-1b17257b"},
+      "us-west-2": {"AMI": "ami-19e92861"}
+    })
+
+ec2_instance = template.add_resource(ec2.Instance(
+    "Ec2Instance",
+    ImageId=FindInMap("RegionMap", Ref("AWS::Region"), "AMI"),
+    InstanceType="t2.micro",
+    KeyName=Ref(keyname_param),
+    SecurityGroups=["default"],
+    BlockDeviceMappings=[
+        ec2.BlockDeviceMapping(
+            DeviceName='/dev/sdb',
+            NoDevice={}),
+        ec2.BlockDeviceMapping(
+            DeviceName='/dev/sdc',
+            NoDevice={}),
+    ]
+))
+
+template.add_output([
+    Output(
+        "InstanceId",
+        Description="InstanceId of the newly created EC2 instance",
+        Value=Ref(ec2_instance),
+    ),
+    Output(
+        "AZ",
+        Description="Availability Zone of the newly created EC2 instance",
+        Value=GetAtt(ec2_instance, "AvailabilityZone"),
+    ),
+    Output(
+        "PublicIP",
+        Description="Public IP address of the newly created EC2 instance",
+        Value=GetAtt(ec2_instance, "PublicIp"),
+    ),
+    Output(
+        "PrivateIP",
+        Description="Private IP address of the newly created EC2 instance",
+        Value=GetAtt(ec2_instance, "PrivateIp"),
+    ),
+    Output(
+        "PublicDNS",
+        Description="Public DNSName of the newly created EC2 instance",
+        Value=GetAtt(ec2_instance, "PublicDnsName"),
+    ),
+    Output(
+        "PrivateDNS",
+        Description="Private DNSName of the newly created EC2 instance",
+        Value=GetAtt(ec2_instance, "PrivateDnsName"),
+    ),
+])
+
+print(template.to_json())

--- a/tests/examples_output/EC2_Remove_Ephemeral_Drive.template
+++ b/tests/examples_output/EC2_Remove_Ephemeral_Drive.template
@@ -1,0 +1,140 @@
+{
+    "Mappings": {
+        "RegionMap": {
+            "ap-northeast-1": {
+                "AMI": "ami-6959870f"
+            },
+            "ap-northeast-2": {
+                "AMI": "ami-08d77266"
+            },
+            "ap-south-1": {
+                "AMI": "ami-50591a3f"
+            },
+            "ap-southeast-1": {
+                "AMI": "ami-d9dca7ba"
+            },
+            "ap-southeast-2": {
+                "AMI": "ami-02ad4060"
+            },
+            "ca-central-1": {
+                "AMI": "ami-13e45c77"
+            },
+            "eu-central-1": {
+                "AMI": "ami-e613ac89"
+            },
+            "eu-west-1": {
+                "AMI": "ami-eed00d97"
+            },
+            "eu-west-2": {
+                "AMI": "ami-ba5f42de"
+            },
+            "sa-east-1": {
+                "AMI": "ami-1ca7d970"
+            },
+            "us-east-1": {
+                "AMI": "ami-bcdc16c6"
+            },
+            "us-east-2": {
+                "AMI": "ami-49426e2c"
+            },
+            "us-west-1": {
+                "AMI": "ami-1b17257b"
+            },
+            "us-west-2": {
+                "AMI": "ami-19e92861"
+            }
+        }
+    },
+    "Outputs": {
+        "AZ": {
+            "Description": "Availability Zone of the newly created EC2 instance",
+            "Value": {
+                "Fn::GetAtt": [
+                    "Ec2Instance",
+                    "AvailabilityZone"
+                ]
+            }
+        },
+        "InstanceId": {
+            "Description": "InstanceId of the newly created EC2 instance",
+            "Value": {
+                "Ref": "Ec2Instance"
+            }
+        },
+        "PrivateDNS": {
+            "Description": "Private DNSName of the newly created EC2 instance",
+            "Value": {
+                "Fn::GetAtt": [
+                    "Ec2Instance",
+                    "PrivateDnsName"
+                ]
+            }
+        },
+        "PrivateIP": {
+            "Description": "Private IP address of the newly created EC2 instance",
+            "Value": {
+                "Fn::GetAtt": [
+                    "Ec2Instance",
+                    "PrivateIp"
+                ]
+            }
+        },
+        "PublicDNS": {
+            "Description": "Public DNSName of the newly created EC2 instance",
+            "Value": {
+                "Fn::GetAtt": [
+                    "Ec2Instance",
+                    "PublicDnsName"
+                ]
+            }
+        },
+        "PublicIP": {
+            "Description": "Public IP address of the newly created EC2 instance",
+            "Value": {
+                "Fn::GetAtt": [
+                    "Ec2Instance",
+                    "PublicIp"
+                ]
+            }
+        }
+    },
+    "Parameters": {
+        "KeyName": {
+            "Description": "Name of an existing EC2 KeyPair to enable SSH access to the instance",
+            "Type": "String"
+        }
+    },
+    "Resources": {
+        "Ec2Instance": {
+            "Properties": {
+                "BlockDeviceMappings": [
+                    {
+                        "DeviceName": "/dev/sdb",
+                        "NoDevice": {}
+                    },
+                    {
+                        "DeviceName": "/dev/sdc",
+                        "NoDevice": {}
+                    }
+                ],
+                "ImageId": {
+                    "Fn::FindInMap": [
+                        "RegionMap",
+                        {
+                            "Ref": "AWS::Region"
+                        },
+                        "AMI"
+                    ]
+                },
+                "InstanceType": "t2.micro",
+                "KeyName": {
+                    "Ref": "KeyName"
+                },
+                "SecurityGroups": [
+                    "default"
+                ]
+            },
+            "Type": "AWS::EC2::Instance"
+        }
+    }
+}

--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -117,6 +117,9 @@ class EBSBlockDevice(AWSProperty):
     }
 
 
+NO_DEVICE = {}
+
+
 class BlockDeviceMapping(AWSProperty):
     props = {
         'DeviceName': (basestring, True),

--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -121,7 +121,7 @@ class BlockDeviceMapping(AWSProperty):
     props = {
         'DeviceName': (basestring, True),
         'Ebs': (EBSBlockDevice, False),      # Conditional
-        'NoDevice': (boolean, False),
+        'NoDevice': (dict, False),
         'VirtualName': (basestring, False),  # Conditional
     }
 


### PR DESCRIPTION
Reverts EC2->BlockDeviceMapping->NoDevice property to type dict, allowing for a value of `{}` as shown in the [documentation](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-blockdev-mapping.html#cfn-ec2-blockdev-mapping-nodevice) under the `Unmapping an AMI-defined Device` example.

Also adds an example template of unmapping ephemeral devices on an EC2 instance.

Fixes #865 