### PR TITLE
Change AWS::Batch::ComputeResources.Tags type to dict

### DIFF
--- a/examples/Batch.py
+++ b/examples/Batch.py
@@ -1,0 +1,116 @@
+"""
+Batch.
+
+Create the AWS Batch Compute environment and roles.
+"""
+
+from troposphere import GetAtt, Output, Parameter, Ref, Tags, Template
+from troposphere.batch import (ComputeEnvironment, ComputeEnvironmentOrder,
+                               ComputeResources, JobQueue)
+from troposphere.ec2 import SecurityGroup
+from troposphere.iam import InstanceProfile, Role
+
+t = Template('AWS Batch')
+t.add_version()
+
+PrivateSubnetA = t.add_parameter(Parameter(
+    'PrivateSubnetA',
+    Type='String'
+))
+
+PrivateSubnetB = t.add_parameter(Parameter(
+    'PrivateSubnetB',
+    Type='String'
+))
+
+Vpc = t.add_parameter(Parameter(
+    'Vpc',
+    ConstraintDescription='Must be a valid VPC ID.',
+    Type='AWS::EC2::VPC::Id'
+))
+
+BatchServiceRole = t.add_resource(Role(
+    'BatchServiceRole',
+    Path='/',
+    Policies=[],
+    ManagedPolicyArns=[
+        'arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole',
+    ],
+    AssumeRolePolicyDocument={'Statement': [{
+        'Action': ['sts:AssumeRole'],
+        'Effect': 'Allow',
+        'Principal': {'Service': ['batch.amazonaws.com']}
+    }]},
+))
+
+BatchInstanceRole = t.add_resource(Role(
+    'BatchInstanceRole',
+    Path='/',
+    Policies=[],
+    ManagedPolicyArns=[
+        'arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role',  # NOQA
+    ],
+    AssumeRolePolicyDocument={'Statement': [{
+        'Action': ['sts:AssumeRole'],
+        'Effect': 'Allow',
+        'Principal': {'Service': ['ec2.amazonaws.com']}
+    }]},
+))
+
+BatchInstanceProfile = t.add_resource(InstanceProfile(
+    'BatchInstanceProfile',
+    Path='/',
+    Roles=[Ref(BatchInstanceRole)],
+))
+
+BatchSecurityGroup = t.add_resource(SecurityGroup(
+    'BatchSecurityGroup',
+    VpcId=Ref(Vpc),
+    GroupDescription='Enable access to Batch instances',
+    Tags=Tags(Name='batch-sg')
+))
+
+BatchComputeEnvironment = t.add_resource(ComputeEnvironment(
+    'BatchComputeEnvironment',
+    Type='MANAGED',
+    ServiceRole=Ref(BatchServiceRole),
+    ComputeResources=ComputeResources(
+        'BatchComputeResources',
+        Type='EC2',
+        DesiredvCpus=0,
+        MinvCpus=0,
+        MaxvCpus=10,
+        InstanceTypes=['m4.large'],
+        InstanceRole=Ref(BatchInstanceProfile),
+        SecurityGroupIds=[GetAtt(BatchSecurityGroup, 'GroupId')],
+        Subnets=[
+            Ref(PrivateSubnetA),
+            Ref(PrivateSubnetB)
+        ],
+        Tags=dict(
+            Name='batch-compute-environment',
+            Project='example'
+        )
+    )
+))
+
+ExampleJobQueue = t.add_resource(JobQueue(
+    'ExampleJobQueue',
+    ComputeEnvironmentOrder=[
+        ComputeEnvironmentOrder(
+            ComputeEnvironment=Ref(BatchComputeEnvironment),
+            Order=1
+        ),
+    ],
+    Priority=1,
+    State='ENABLED',
+    JobQueueName='example-job-queue'
+))
+
+t.add_output([
+    Output('BatchComputeEnvironment', Value=Ref(BatchComputeEnvironment)),
+    Output('BatchSecurityGroup', Value=Ref(BatchSecurityGroup)),
+    Output('ExampleJobQueue', Value=Ref(ExampleJobQueue))
+])
+
+print(t.to_json())

--- a/tests/examples_output/Batch.template
+++ b/tests/examples_output/Batch.template
@@ -1,0 +1,168 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "AWS Batch",
+    "Outputs": {
+        "BatchComputeEnvironment": {
+            "Value": {
+                "Ref": "BatchComputeEnvironment"
+            }
+        },
+        "BatchSecurityGroup": {
+            "Value": {
+                "Ref": "BatchSecurityGroup"
+            }
+        },
+        "ExampleJobQueue": {
+            "Value": {
+                "Ref": "ExampleJobQueue"
+            }
+        }
+    },
+    "Parameters": {
+        "PrivateSubnetA": {
+            "Type": "String"
+        },
+        "PrivateSubnetB": {
+            "Type": "String"
+        },
+        "Vpc": {
+            "ConstraintDescription": "Must be a valid VPC ID.",
+            "Type": "AWS::EC2::VPC::Id"
+        }
+    },
+    "Resources": {
+        "BatchComputeEnvironment": {
+            "Properties": {
+                "ComputeResources": {
+                    "DesiredvCpus": 0,
+                    "InstanceRole": {
+                        "Ref": "BatchInstanceProfile"
+                    },
+                    "InstanceTypes": [
+                        "m4.large"
+                    ],
+                    "MaxvCpus": 10,
+                    "MinvCpus": 0,
+                    "SecurityGroupIds": [
+                        {
+                            "Fn::GetAtt": [
+                                "BatchSecurityGroup",
+                                "GroupId"
+                            ]
+                        }
+                    ],
+                    "Subnets": [
+                        {
+                            "Ref": "PrivateSubnetA"
+                        },
+                        {
+                            "Ref": "PrivateSubnetB"
+                        }
+                    ],
+                    "Tags": {
+                        "Name": "batch-compute-environment",
+                        "Project": "example"
+                    },
+                    "Type": "EC2"
+                },
+                "ServiceRole": {
+                    "Ref": "BatchServiceRole"
+                },
+                "Type": "MANAGED"
+            },
+            "Type": "AWS::Batch::ComputeEnvironment"
+        },
+        "BatchInstanceProfile": {
+            "Properties": {
+                "Path": "/",
+                "Roles": [
+                    {
+                        "Ref": "BatchInstanceRole"
+                    }
+                ]
+            },
+            "Type": "AWS::IAM::InstanceProfile"
+        },
+        "BatchInstanceRole": {
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [
+                        {
+                            "Action": [
+                                "sts:AssumeRole"
+                            ],
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "ec2.amazonaws.com"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "ManagedPolicyArns": [
+                    "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+                ],
+                "Path": "/",
+                "Policies": []
+            },
+            "Type": "AWS::IAM::Role"
+        },
+        "BatchSecurityGroup": {
+            "Properties": {
+                "GroupDescription": "Enable access to Batch instances",
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "batch-sg"
+                    }
+                ],
+                "VpcId": {
+                    "Ref": "Vpc"
+                }
+            },
+            "Type": "AWS::EC2::SecurityGroup"
+        },
+        "BatchServiceRole": {
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [
+                        {
+                            "Action": [
+                                "sts:AssumeRole"
+                            ],
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "batch.amazonaws.com"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "ManagedPolicyArns": [
+                    "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"
+                ],
+                "Path": "/",
+                "Policies": []
+            },
+            "Type": "AWS::IAM::Role"
+        },
+        "ExampleJobQueue": {
+            "Properties": {
+                "ComputeEnvironmentOrder": [
+                    {
+                        "ComputeEnvironment": {
+                            "Ref": "BatchComputeEnvironment"
+                        },
+                        "Order": 1
+                    }
+                ],
+                "JobQueueName": "example-job-queue",
+                "Priority": 1,
+                "State": "ENABLED"
+            },
+            "Type": "AWS::Batch::JobQueue"
+        }
+    }
+}

--- a/troposphere/batch.py
+++ b/troposphere/batch.py
@@ -10,13 +10,13 @@ class ComputeResources(AWSProperty):
         "SecurityGroupIds": ([basestring], True),
         "BidPercentage": (positive_integer, False),
         "Type": (basestring, True),
-        "Subnets": ([basestring], True),
+        "Subnets": (list, True),
         "MinvCpus": (positive_integer, True),
         "ImageId": (basestring, False),
         "InstanceRole": (basestring, True),
         "InstanceTypes": ([basestring], True),
         "Ec2KeyPair": (basestring, False),
-        "Tags": ([basestring], False),
+        "Tags": (dict, False),
         "DesiredvCpus": (positive_integer, False)
     }
 

--- a/troposphere/batch.py
+++ b/troposphere/batch.py
@@ -10,7 +10,7 @@ class ComputeResources(AWSProperty):
         "SecurityGroupIds": ([basestring], True),
         "BidPercentage": (positive_integer, False),
         "Type": (basestring, True),
-        "Subnets": (list, True),
+        "Subnets": ([basestring], True),
         "MinvCpus": (positive_integer, True),
         "ImageId": (basestring, False),
         "InstanceRole": (basestring, True),


### PR DESCRIPTION
AWS Batch seems to use a different Tag format. Instead of the usual
```
{
  'Key': 'TagKey',
  'Value': 'TagValue'
}
```
AWS Batch expects a regular map `{'TagKey': 'TagValue'}`.

This commit also adds an example template for AWS Batch.