### PR TITLE
Allow AWSHelperFn for CodeCommit Trigger Event(s)

### DIFF
--- a/troposphere/codecommit.py
+++ b/troposphere/codecommit.py
@@ -3,7 +3,7 @@
 #
 # See LICENSE file for full license.
 
-from . import AWSObject, AWSProperty
+from . import AWSHelperFn, AWSObject, AWSProperty
 
 
 class Trigger(AWSProperty):
@@ -23,12 +23,12 @@ class Trigger(AWSProperty):
             'updateReference',
         ]
         events = self.properties.get('Events')
-        if events:
+        if events and not isinstance(events, AWSHelperFn):
             if 'all' in events and len(events) != 1:
                 raise ValueError('Trigger events: all must be used alone')
             else:
                 for e in events:
-                    if e not in valid:
+                    if e not in valid and not isinstance(e, AWSHelperFn):
                         raise ValueError('Trigger: invalid event %s' % e)
 
 


### PR DESCRIPTION
Updates `Trigger` validation to also accept `AWSHelperFn` objects or a list of `AWSHelperFn` objects.

Fixes #868 