### PR TITLE
Fixes incorrect class definition.

### DIFF
--- a/troposphere/ssm.py
+++ b/troposphere/ssm.py
@@ -78,7 +78,7 @@ class Rule(AWSProperty):
     props = {
         'ApproveAfterDays': (integer, False),
         'ComplianceLevel': (compliance_level, False),
-        'PatchFilterGroup': (PatchFilter, False),
+        'PatchFilterGroup': (PatchFilterGroup, False),
     }
 
 


### PR DESCRIPTION
Hello,

The template created by this class fails on AWS deployment:

```
Property validation failure: [Encountered unsupported properties in {/ApprovalRules/PatchRules/0/PatchFilterGroup}: [Values, Key]]
```

The expected property from the AWS side is the group property. This update fixes and creates a valid CloudFormation template. 


