### PR TITLE
Add support for tags in AWS::KMS::Key.

### DIFF
--- a/troposphere/kms.py
+++ b/troposphere/kms.py
@@ -29,4 +29,5 @@ class Key(AWSObject):
         'Enabled': (boolean, False),
         'EnableKeyRotation': (boolean, False),
         'KeyPolicy': (policytypes, True),
+        'Tags': (list, False)
     }


### PR DESCRIPTION
AWS::KMS::Key doesn't currently support the Tags property. This change add this functionality. 

Fixes issue: #889 