### PR TITLE
Added Prop for OriginKeepaliveTimeout

### DIFF
--- a/troposphere/cloudfront.py
+++ b/troposphere/cloudfront.py
@@ -68,6 +68,7 @@ class CustomOrigin(AWSProperty):
         'HTTPSPort': (network_port, False),
         'OriginProtocolPolicy': (basestring, True),
         'OriginSSLProtocols': ([basestring], False),
+        'OriginKeepaliveTimeout': (integer, False),
     }
 
 


### PR DESCRIPTION
Updated to allow OriginKeepAliveTimeout for cloudfront based off of http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-customorigin.html
