### PR TITLE
Allow ref on Parameter

### DIFF
--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,6 +1,6 @@
 import unittest
 
-from troposphere import Parameter
+from troposphere import Parameter, Ref
 
 
 class TestInitArguments(unittest.TestCase):
@@ -8,6 +8,13 @@ class TestInitArguments(unittest.TestCase):
         title = 'i' * 256
         with self.assertRaises(ValueError):
             Parameter(title, Type='String')
+
+    def test_ref_can_be_requested(self):
+        param = Parameter('title', Type='String')
+        reference = param.ref()
+
+        self.assertIsInstance(reference, Ref)
+        self.assertDictEqual(reference.data, {'Ref': 'title'})
 
 
 if __name__ == '__main__':

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -322,6 +322,11 @@ class AWSDeclaration(BaseAWSObject):
     def __init__(self, title, **kwargs):
         super(AWSDeclaration, self).__init__(title, **kwargs)
 
+    def ref(self):
+        return Ref(self)
+
+    Ref = ref
+
 
 class AWSProperty(BaseAWSObject):
     """


### PR DESCRIPTION
Parameters also allow being used in a reference. Right now it's only possible by using the string reference. Being able to use the `ref()` function makes it a bit more convenient.