### PR TITLE
Adds Tags to Cloudfront Distribution

### DIFF
--- a/troposphere/cloudfront.py
+++ b/troposphere/cloudfront.py
@@ -3,7 +3,7 @@
 #
 # See LICENSE file for full license.
 
-from . import AWSObject, AWSProperty
+from . import AWSObject, AWSProperty, Tags
 from .validators import boolean, integer, positive_integer, network_port
 
 
@@ -153,4 +153,5 @@ class Distribution(AWSObject):
 
     props = {
         'DistributionConfig': (DistributionConfig, True),
+        'Tags': ((Tags, list), False),
     }


### PR DESCRIPTION
Allows Tags to be added to cloudfront distribution as outlined here:
http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution.html#cfn-cloudfront-distribution-tags