### PR TITLE
Rename options parameter to adapt to AWS API

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -582,7 +582,7 @@ class VPNConnection(AWSObject):
         'StaticRoutesOnly': (boolean, False),
         'Tags': ((Tags, list), False),
         'VpnGatewayId': (basestring, True),
-        'VpnTunnelOptionsSpecifications': (
+        'Options': (
             [VpnTunnelOptionsSpecification], False
         ),
     }


### PR DESCRIPTION
Fix #923 
Adapt parameter naming related to https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateVpnConnection.html