### PR TITLE
Removed Logging info from SSM

### DIFF
--- a/troposphere/ssm.py
+++ b/troposphere/ssm.py
@@ -17,14 +17,6 @@ class NotificationConfig(AWSProperty):
     }
 
 
-class LoggingInfo(AWSProperty):
-    props = {
-        'Region': (basestring, True),
-        'S3Bucket': (s3_bucket_name, True),
-        'S3Prefix': (basestring, False),
-    }
-
-
 class MaintenanceWindowAutomationParameters(AWSProperty):
     props = {
         'DocumentVersion': (basestring, False),
@@ -162,7 +154,6 @@ class MaintenanceWindowTask(AWSObject):
 
     props = {
         'Description': (basestring, False),
-        'LoggingInfo': (LoggingInfo, False),
         'MaxConcurrency': (integer, False),
         'MaxErrors': (integer, True),
         'Name': (basestring, False),

--- a/troposphere/ssm.py
+++ b/troposphere/ssm.py
@@ -17,6 +17,14 @@ class NotificationConfig(AWSProperty):
     }
 
 
+class LoggingInfo(AWSProperty):
+    props = {
+        'S3Region': (basestring, True),
+        'S3BucketName': (s3_bucket_name, True),
+        'S3KeyPrefix': (basestring, False),
+    }
+
+
 class MaintenanceWindowAutomationParameters(AWSProperty):
     props = {
         'DocumentVersion': (basestring, False),

--- a/troposphere/ssm.py
+++ b/troposphere/ssm.py
@@ -162,6 +162,7 @@ class MaintenanceWindowTask(AWSObject):
 
     props = {
         'Description': (basestring, False),
+        'LoggingInfo': (LoggingInfo, False),
         'MaxConcurrency': (integer, False),
         'MaxErrors': (integer, True),
         'Name': (basestring, False),


### PR DESCRIPTION
Hey,

Recently I found a bug when using Cloudformation and SSM whilst building an automated patching function.  The bug broke the MaintenanceWindowTask Class, this was caused by the LoggingInfo Class being deprecated by AWS - it has been confirmed by them in a support case I raised.  Whilst they worked to remove the API itself and amend the documentation I am updating the code here so that anyone who tries to use this in the foreseeable future won't run into these issues.

The workaround/proper method of enabling logging for Maintenance Window Tasks is to use "TaskInvocationParameters" inside the MaintWindowTask Class and then inside the TaskInvocationParameters, invoke the MaintenanceWindowRunCommandParameters Class to enabled bucket logs and a logging prefix.