### PR TITLE
SSM Notification config fix

### DIFF
--- a/troposphere/ssm.py
+++ b/troposphere/ssm.py
@@ -12,7 +12,7 @@ from .validators import (integer, boolean, s3_bucket_name, notification_type,
 class NotificationConfig(AWSProperty):
     props = {
         'NotificationArn': (basestring, False),
-        'NotificationEvents': ([notification_event], False),
+        'NotificationEvents': (notification_event, False),
         'NotificationType': (notification_type, False),
     }
 


### PR DESCRIPTION
fix the validator, otherwise it raises the `error isinstance() arg 2 must be a type or tuple of types`
```
File ".../templates/common/ssm/common_ssm_v1.py", line 165, in main
    NotificationType=utils.parse_arg(notification_config, name="type")
  File ".../lib/python3.6/site-packages/troposphere/__init__.py", line 341, in __init__
    super(AWSProperty, self).__init__(title, **kwargs)
  File ".../lib/python3.6/site-packages/troposphere/__init__.py", line 124, in __init__
    self.__setattr__(k, v)
  File ".../lib/python3.6/site-packages/troposphere/__init__.py", line 189, in __setattr__
    if not isinstance(v, tuple(expected_type)) \
TypeError: isinstance() arg 2 must be a type or tuple of types
```