### PR TITLE
Fix validation failure for fifo queues in the case that no QueueName …

### DIFF
--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -22,6 +22,11 @@ class TestQueue(unittest.TestCase):
             QueueName=Join("foo", "bar"),
         ).validate()
 
+        Queue(
+            "q",
+            FifoQueue=True,
+        ).validate()
+
         with self.assertRaises(ValueError):
             Queue(
                 "q",

--- a/troposphere/sqs.py
+++ b/troposphere/sqs.py
@@ -38,8 +38,8 @@ class Queue(AWSObject):
 
     def validate(self):
         if self.properties.get('FifoQueue'):
-            queuename = self.properties.get('QueueName', '')
-            if isinstance(queuename, AWSHelperFn):
+            queuename = self.properties.get('QueueName')
+            if queuename is None or isinstance(queuename, AWSHelperFn):
                 pass
             elif not queuename.endswith('.fifo'):
                 raise ValueError("SQS: FIFO queues need to provide a "


### PR DESCRIPTION
…is specified.  Note that Cloudformation *does* now automatically give a QueueName ending with .fifo in this case, contrary to the comment on PR #757.