### PR TITLE
remove elasticloadbalancingv2 LoadBalancer Validation

### DIFF
--- a/troposphere/elasticloadbalancingv2.py
+++ b/troposphere/elasticloadbalancingv2.py
@@ -3,7 +3,7 @@
 #
 # See LICENSE file for full license.
 
-from . import AWSObject, AWSProperty, Tags
+from . import AWSObject, AWSProperty, If, Tags
 from .validators import (
     elb_name, exactly_one, network_port,
     tg_healthcheck_port, integer
@@ -145,4 +145,14 @@ class LoadBalancer(AWSObject):
             'SubnetMappings',
             'Subnets',
         ]
+
+        def check_if(names, props):
+            validated = []
+            for name in names:
+                validated.append(name in props and isinstance(props[name], If))
+            return all(validated)
+
+        if check_if(conds, self.properties):
+            return
+
         exactly_one(self.__class__.__name__, self.properties, conds)


### PR DESCRIPTION
This change removes the validation step from the LoadBalancer class to allow for conditionally setting one of these properties, while setting the other to `AWS_NO_VALUE`

Fixes cloudtools/troposphere#933