### PR TITLE
Added support for AutoPublishAlias to AWS::Serverless::Function

### DIFF
--- a/tests/test_serverless.py
+++ b/tests/test_serverless.py
@@ -61,6 +61,18 @@ class TestServerless(unittest.TestCase):
         t.add_resource(serverless_func)
         t.to_json()
 
+    def test_optional_auto_publish_alias(self):
+        serverless_func = Function(
+            "SomeHandler",
+            Handler="index.handler",
+            Runtime="nodejs",
+            CodeUri="s3://bucket/handler.zip",
+            AutoPublishAlias="alias"
+        )
+        t = Template()
+        t.add_resource(serverless_func)
+        t.to_json()
+
     def test_required_api_definitionuri(self):
         serverless_api = Api(
             "SomeApi",

--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -71,7 +71,8 @@ class Function(AWSObject):
         'Tags': (dict, False),
         'Tracing': (basestring, False),
         'KmsKeyArn': (basestring, False),
-        'DeadLetterQueue': (DeadLetterQueue, False)
+        'DeadLetterQueue': (DeadLetterQueue, False),
+        'AutoPublishAlias': (basestring, False)
     }
 
 


### PR DESCRIPTION
Hi there -

Thanks for troposphere!

I was trying to use it to build a Serverless Application Model (SAM) definition and discovered that the `AutoPublishAlias` attribute was not supported.  
Based on the [SAM spec](https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md), `AutoPublishAlias` should be allowed as an optional attribute.

I've added support for it and a test.  LMK if all looks right as this is my first PR here.

Best,
-Donnie