### PR TITLE
Add resource_type value and unit tests for guardduty `AWSObject`s

### DIFF
--- a/tests/test_guardduty.py
+++ b/tests/test_guardduty.py
@@ -1,0 +1,60 @@
+import unittest
+import troposphere.guardduty as guardduty
+
+
+class TestGuardDuty(unittest.TestCase):
+
+    def test_guardduty_detector(self):
+        detector = guardduty.Detector(
+            'detector'
+        )
+
+        with self.assertRaises(ValueError):
+            detector.to_dict()
+
+        detector = guardduty.Detector(
+            'detector',
+            Enable=True
+        )
+
+        result = detector.to_dict()
+        self.assertEqual(result['Type'], 'AWS::GuardDuty::Detector')
+
+    def test_guardduty_ipset(self):
+        ipset = guardduty.IPSet(
+            'ipset'
+        )
+
+        with self.assertRaises(ValueError):
+            ipset.to_dict()
+
+        ipset = guardduty.IPSet(
+            'ipset',
+            Activate=True,
+            DetectorId='aaaabbbbccccddddeeeeffff11112222',
+            Format='TXT',
+            Location='http://example.com/ipset.txt'
+        )
+
+        result = ipset.to_dict()
+
+        self.assertEqual(result['Type'], 'AWS::GuardDuty::IPSet')
+
+    def test_guardduty_threatintelset(self):
+        threat_intel_set = guardduty.ThreatIntelSet(
+            'threatintelset'
+        )
+
+        with self.assertRaises(ValueError):
+            threat_intel_set.to_dict()
+
+        threat_intel_set = guardduty.ThreatIntelSet(
+            'threatintelset',
+            Activate=True,
+            DetectorId='aaaabbbbccccddddeeeeffff11112222',
+            Format='TXT',
+            Location='http://example.com/threatintelset.txt'
+        )
+
+        result = threat_intel_set.to_dict()
+        self.assertEqual(result['Type'], 'AWS::GuardDuty::ThreatIntelSet')

--- a/troposphere/guardduty.py
+++ b/troposphere/guardduty.py
@@ -8,12 +8,16 @@ from .validators import boolean
 
 
 class Detector(AWSObject):
+    resource_type = 'AWS::GuardDuty::Detector'
+
     props = {
         'Enable': (boolean, True),
     }
 
 
 class IPSet(AWSObject):
+    resource_type = 'AWS::GuardDuty::IPSet'
+
     props = {
         'Activate': (boolean, True),
         'DetectorId': (basestring, True),
@@ -24,6 +28,8 @@ class IPSet(AWSObject):
 
 
 class ThreatIntelSet(AWSObject):
+    resource_type = 'AWS::GuardDuty::ThreatIntelSet'
+
     props = {
         'Activate': (boolean, True),
         'DetectorId': (basestring, True),


### PR DESCRIPTION
Unit tests confirm construction of these objects and ensure that the
`Type` field is set properly in the output dict to prevent regressions.

See: https://github.com/cloudtools/troposphere/issues/944