### PR TITLE
Recursively validate JSON while preserving helper function types

### DIFF
--- a/tests/test_apigateway.py
+++ b/tests/test_apigateway.py
@@ -37,7 +37,7 @@ class TestModel(unittest.TestCase):
             Schema=d
         )
         model.validate()
-        self.assertEqual(model.properties['Schema'], '{"c": "d"}')
+        self.assertEqual(model.properties['Schema'], {"c": "d"})
 
         # Check invalid Schema type
         with self.assertRaises(TypeError):

--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -224,10 +224,15 @@ def json_checker(name, prop):
         # Verify it is a valid json string
         json.loads(prop)
         return prop
-    elif isinstance(prop, dict):
-        # Convert the dict to a basestring
-        return json.dumps(prop)
     elif isinstance(prop, AWSHelperFn):
+        return prop
+    elif isinstance(prop, dict):
+        # Recursively validate JSON
+        for attr, attr_val in prop.items():
+            if isinstance(attr_val, basestring):
+                json.dumps(attr_val)
+            elif isinstance(attr_val, dict):
+                prop[attr] = json_checker(attr, attr_val)
         return prop
     else:
         raise ValueError("%s must be a str or dict" % name)


### PR DESCRIPTION
Currently, using a Ref inside the Schema parameter to create a new apigateway.Model resource will result in an Exception from attempting to validate the dictionary via json.dumps(). This PR is an attempt to enable this use-case by only attempting json.dumps() on the values of type basestring in the dictionary.