### PR TITLE
make Serverless::Function CodeUri optional

### DIFF
--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -58,7 +58,7 @@ class Function(AWSObject):
     props = {
         'Handler': (basestring, True),
         'Runtime': (basestring, True),
-        'CodeUri': ((S3Location, basestring), True),
+        'CodeUri': ((S3Location, basestring), False),
         'FunctionName': (basestring, False),
         'Description': (basestring, False),
         'MemorySize': (validate_memory_size, False),


### PR DESCRIPTION
CodeUri is required in a final CFN template, but should be omitted in
templates that will be processed with `sam package` (it will upload the
function to S3 and create a final template with a generated CodeUri)

Example at
http://docs.aws.amazon.com/lambda/latest/dg/with-api-example-use-app-spec.html#api-tutorial-spec

~Another approach might be to make another class for this?~ EDIT: Alternate approach proposed in #952 
  