### PR TITLE
Add dictionary param support to resources that have AWSHelperFn props.

### DIFF
--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -1,7 +1,8 @@
 import unittest
-from troposphere import Template, Ref
+from troposphere import Template, Ref, Tags
 from troposphere import ecs
 from troposphere import iam
+from troposphere import s3
 
 
 class TestDict(unittest.TestCase):
@@ -32,7 +33,14 @@ class TestDict(unittest.TestCase):
                     "HostPort": 5001
                 }
             ],
-            "Links": ["containerA", "containerB"],
+            "Links": ["containerA", "containerB"]
+        }
+
+        self.b = {
+            "BucketName": "bucketname",
+            "Tags": {
+                "tagname": "mytag"
+            }
         }
 
     def test_valid_data(self):
@@ -73,6 +81,10 @@ class TestDict(unittest.TestCase):
         self.d["Environment"][0] = "BadValue"
         with self.assertRaises(ValueError):
             ecs.ContainerDefinition.from_dict("mycontainer", self.d)
+
+    def test_sub_property_aws_helper_fn(self):
+        bkt = s3.Bucket.from_dict("mybucket", self.b)
+        self.assertIsInstance(bkt.Tags, Tags)
 
 
 if __name__ == '__main__':

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -50,6 +50,16 @@ def is_aws_object_subclass(cls):
     return is_aws_object
 
 
+def is_aws_helper_function_subclass(cls):
+    is_aws_helper_function = False
+    try:
+        is_aws_helper_function = issubclass(cls, AWSHelperFn)
+    # prop_type isn't a class
+    except TypeError:
+        pass
+    return is_aws_helper_function
+
+
 def encode_to_dict(obj):
     if hasattr(obj, 'to_dict'):
         # Calling encode_to_dict to ensure object is
@@ -257,12 +267,15 @@ class BaseAWSObject(object):
                                                        prop_name))
             prop_type = prop_attrs[0]
             value = kwargs[prop_name]
-            is_aws_object = is_aws_object_subclass(prop_type)
-            if is_aws_object:
+
+            if is_aws_object_subclass(prop_type):
                 if not isinstance(value, collections.Mapping):
                     raise ValueError("Property definition for %s must be "
                                      "a Mapping type" % prop_name)
                 value = prop_type._from_dict(**value)
+
+            if is_aws_helper_function_subclass(prop_type):
+                value = prop_type(**value)
 
             if isinstance(prop_type, list):
                 if not isinstance(value, list):
@@ -277,6 +290,8 @@ class BaseAWSObject(object):
                                 "Property definition for %s must be "
                                 "a list of Mapping types" % prop_name)
                         new_v = prop_type[0]._from_dict(**v)
+                    if is_aws_helper_function_subclass(prop_type[0]):
+                        new_v = prop_type(**v)
                     new_value.append(new_v)
                 value = new_value
             props[prop_name] = value


### PR DESCRIPTION
Adds support to resources that use AWSHelperFn as properties so they can be instantiated by using a python dictionary type instead of having to pass the instantiated helper function. This is necessary if your resource creation is driven by a generic YAML config setup.
e.g.
`YAML -> Dictionary -> Troposphere Resource`