### PR TITLE
Add long form parameter to to_yaml

### DIFF
--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -623,8 +623,8 @@ class Template(object):
         return json.dumps(self.to_dict(), indent=indent,
                           sort_keys=sort_keys, separators=separators)
 
-    def to_yaml(self):
-        return cfn_flip.to_yaml(self.to_json())
+    def to_yaml(self, long_form=False):
+        return cfn_flip.to_yaml(self.to_json(), long_form)
 
 
 class Export(AWSHelperFn):


### PR DESCRIPTION
currently, troposphere to_yaml function will by default use the short form.  This causes tag issue with yaml parsers.  cfn_flip already has the option to turn on the long form, so this should be passed through so that it can be used in troposphere.