### PR TITLE
Explicitly convert allocated_storage to integer before using it in comparisons

### DIFF
--- a/troposphere/rds.py
+++ b/troposphere/rds.py
@@ -226,7 +226,7 @@ class DBInstance(AWSObject):
         iops = self.properties.get('Iops', None)
         if iops and not isinstance(iops, AWSHelperFn):
             if not isinstance(allocated_storage, AWSHelperFn) and \
-                    allocated_storage < 100:
+                    int(allocated_storage) < 100:
                 raise ValueError("AllocatedStorage must be at least 100 when "
                                  "Iops is set.")
             if not isinstance(allocated_storage, AWSHelperFn) and not \


### PR DESCRIPTION
DBInstance::validate() fails when using Python3 if AllocatedStorage is set to the string representation of an integer,  even through positive_integer() accepts the string representation of a positive integer.
DBInstance::validate() attempts to compare the value of AllocatedStorage with integers, leading to an implicit conversion that throws a TypeError with Python3.

Explicitly converting allocated_storage when comparing it to integers solves the issue without impacting the same use case when executed with python2.

Test results:
test_response_type (tests.test_apigateway.TestGatewayResponse) ... <class 'troposphere.apigateway.GatewayResponse'>: GatewayResponse.ResponseType function validator 'validate_gateway_response_type' threw exception:
ok
test_schema (tests.test_apigateway.TestModel) ... ok
test_exclusive (tests.test_asg.TestAutoScalingGroup) ... ok
test_helperfn_as_AutoScalingRollingUpdate (tests.test_asg.TestAutoScalingGroup) ... ok
test_helperfn_as_updatepolicy (tests.test_asg.TestAutoScalingGroup) ... ok
test_instanceid (tests.test_asg.TestAutoScalingGroup) ... ok
test_launchconfigurationname (tests.test_asg.TestAutoScalingGroup) ... ok
test_none (tests.test_asg.TestAutoScalingGroup) ... ok
test_size_if (tests.test_asg.TestAutoScalingGroup) ... ok
test_check_zip_file (tests.test_awslambda.TestAWSLambda) ... ok
test_exclusive (tests.test_awslambda.TestAWSLambda) ... ok
test_zip_file (tests.test_awslambda.TestAWSLambda) ... ok
test_badproperty (tests.test_basic.TestBasic) ... ok
test_badrequired (tests.test_basic.TestBasic) ... ok
test_badtype (tests.test_basic.TestBasic) ... ok
test_depends_on_helper_with_resource (tests.test_basic.TestBasic) ... ok
test_depends_on_helper_with_string (tests.test_basic.TestBasic) ... ok
test_extraattribute (tests.test_basic.TestBasic) ... ok
test_goodrequired (tests.test_basic.TestBasic) ... ok
test_required_title_error (tests.test_basic.TestBasic) ... ok
test_resource_depends_on (tests.test_basic.TestBasic) ... ok
test_resource_depends_on_attr (tests.test_basic.TestBasic) ... ok
test_resource_depends_on_list (tests.test_basic.TestBasic) ... ok
test_output (tests.test_basic.TestDuplicate) ... ok
test_parameter (tests.test_basic.TestDuplicate) ... ok
test_resource (tests.test_basic.TestDuplicate) ... ok
test_healthy_interval_ok (tests.test_basic.TestHealthCheck) ... ok
test_healthy_interval_too_low (tests.test_basic.TestHealthCheck) ... <class 'troposphere.elasticloadbalancing.HealthCheck'>: None.HealthyThreshold function validator 'integer_range_checker' threw exception:
ok
test_join (tests.test_basic.TestJoin) ... ok
test_ref (tests.test_basic.TestName) ... ok
test_empty_awsproperty_outputs_empty_object (tests.test_basic.TestOutput) ... ok
test_noproperty (tests.test_basic.TestOutput) ... ok
test_invalid_parameter_property_in_template (tests.test_basic.TestParameter) ... ok
test_noproperty (tests.test_basic.TestParameter) ... ok
test_property_default (tests.test_basic.TestParameter) ... ok
test_property_validator (tests.test_basic.TestParameter) ... ok
test_awsproperty_invalid_property (tests.test_basic.TestProperty) ... ok
test_noproperty (tests.test_basic.TestProperty) ... ok
test_ref (tests.test_basic.TestRef) ... ok
test_split (tests.test_basic.TestSplit) ... ok
test_sub_with_vars (tests.test_basic.TestSub) ... ok
test_sub_without_vars (tests.test_basic.TestSub) ... ok
test_no_validation_method (tests.test_basic.TestValidation) ... ok
test_novalidation (tests.test_basic.TestValidation) ... ok
test_validation (tests.test_basic.TestValidation) ... ok
test_badlist (tests.test_basic.TestValidators) ... ok
test_badmultilist (tests.test_basic.TestValidators) ... ok
test_callcorrect (tests.test_basic.TestValidators) ... ok
test_callincorrect (tests.test_basic.TestValidators) ... <class 'tests.test_basic.FakeAWSObject'>: fake.callincorrect function validator 'call_incorrect' threw exception:
ok
test_exception (tests.test_basic.TestValidators) ... <class 'tests.test_basic.ExceptionAWSProperty'>: None.foo function validator 'ExceptionValidator' threw exception:
ok
test_helperfun (tests.test_basic.TestValidators) ... ok
test_list (tests.test_basic.TestValidators) ... ok
test_multilist (tests.test_basic.TestValidators) ... ok
test_mutualexclusion (tests.test_basic.TestValidators) ... ok
test_tuples (tests.test_basic.TestValidators) ... ok
test_dashboard (tests.test_cloudwatch.TestModel) ... ok
test_trigger (tests.test_codecommit.TestCodeCommit) ... ok
test_SourceDetails (tests.test_config.TestConfig) ... ok
test_invalid_SourceDetails_MaximumExecutionFrequency (tests.test_config.TestConfig) ... ok
test_invalid_sub_property (tests.test_dict.TestDict) ... ok
test_invalid_subproperty_definition (tests.test_dict.TestDict) ... ok
test_invalid_toplevel_property (tests.test_dict.TestDict) ... ok
test_sub_property_helper_fn (tests.test_dict.TestDict) ... ok
test_toplevel_helper_fn (tests.test_dict.TestDict) ... ok
test_valid_data (tests.test_dict.TestDict) ... ok
test_securitygroupegress (tests.test_ec2.TestEC2) ... ok
test_allow_placement_strategy_constraint (tests.test_ecs.TestECS) ... ok
test_allow_port_mapping_protocol (tests.test_ecs.TestECS) ... ok
test_allow_ref_cluster (tests.test_ecs.TestECS) ... ok
test_allow_ref_task_role_arn (tests.test_ecs.TestECS) ... ok
test_allow_string_cluster (tests.test_ecs.TestECS) ... ok
test_allow_string_task_role_arn (tests.test_ecs.TestECS) ... ok
test_fargate_launch_type (tests.test_ecs.TestECS) ... ok
test_port_mapping_does_not_require_protocol (tests.test_ecs.TestECS) ... ok
test_task_role_arn_is_optional (tests.test_ecs.TestECS) ... ok
test_SimpleScalingPolicyConfiguration (tests.test_emr.TestEMR) ... ok
test_allow_string_cluster (tests.test_emr.TestEMR) ... ok
test_example (tests.test_examples.test_ApiGateway) ... ok
test_example (tests.test_examples.test_ApplicationAutoScalingSample) ... ok
test_example (tests.test_examples.test_ApplicationELB) ... ok
test_example (tests.test_examples.test_Autoscaling) ... ok
test_example (tests.test_examples.test_AutoscalingHTTPRequests) ... ok
test_example (tests.test_examples.test_Batch) ... ok
test_example (tests.test_examples.test_CertificateManagerSample) ... ok
test_example (tests.test_examples.test_ClassExtensions) ... ok
test_example (tests.test_examples.test_CloudFormation_Init_ConfigSet) ... ok
test_example (tests.test_examples.test_CloudFront_S3) ... ok
test_example (tests.test_examples.test_CloudTrail) ... ok
test_example (tests.test_examples.test_CloudWatchEventsSample) ... ok
test_example (tests.test_examples.test_CodeBuild) ... ok
test_example (tests.test_examples.test_CodeDeploy) ... ok
test_example (tests.test_examples.test_CodePipeline) ... ok
test_example (tests.test_examples.test_CustomResource) ... ok
test_example (tests.test_examples.test_DynamoDB_Table) ... ok
test_example (tests.test_examples.test_DynamoDB_Table_With_GlobalSecondaryIndex) ... ok
test_example (tests.test_examples.test_DynamoDB_Table_With_GSI_And_NonKeyAttributes_Projection) ... ok
test_example (tests.test_examples.test_EC2_Remove_Ephemeral_Drive) ... ok
test_example (tests.test_examples.test_EC2Conditions) ... ok
test_example (tests.test_examples.test_EC2InstanceSample) ... ok
test_example (tests.test_examples.test_ECRSample) ... ok
test_example (tests.test_examples.test_ECSCluster) ... ok
test_example (tests.test_examples.test_ECSFargate) ... ok
test_example (tests.test_examples.test_EFS) ... ok
test_example (tests.test_examples.test_ElastiCacheRedis) ... ok
test_example (tests.test_examples.test_ElasticBeanstalk_Nodejs_Sample) ... ok
test_example (tests.test_examples.test_ElasticsearchDomain) ... ok
test_example (tests.test_examples.test_ELBSample) ... ok
test_example (tests.test_examples.test_EMR_Cluster) ... ok
test_example (tests.test_examples.test_Firehose_with_Redshift) ... ok
test_example (tests.test_examples.test_IAM_Policies_SNS_Publish_To_SQS) ... ok
test_example (tests.test_examples.test_IAM_Roles_and_InstanceProfiles) ... ok
test_example (tests.test_examples.test_IAM_Users_Groups_and_Policies) ... ok
test_example (tests.test_examples.test_IAM_Users_snippet) ... ok
test_example (tests.test_examples.test_IoTSample) ... ok
test_example (tests.test_examples.test_Kinesis_Stream) ... ok
test_example (tests.test_examples.test_Lambda) ... ok
test_example (tests.test_examples.test_Metadata) ... ok
test_example (tests.test_examples.test_NatGateway) ... ok
test_example (tests.test_examples.test_NetworkLB) ... ok
test_example (tests.test_examples.test_OpenStack_AutoScaling) ... ok
test_example (tests.test_examples.test_OpenStack_Server) ... ok
test_example (tests.test_examples.test_OpsWorksSnippet) ... ok
test_example (tests.test_examples.test_RDS_Snapshot_On_Delete) ... ok
test_example (tests.test_examples.test_RDS_VPC) ... ok
test_example (tests.test_examples.test_RDS_with_DBParameterGroup) ... ok
test_example (tests.test_examples.test_Redshift) ... ok
test_example (tests.test_examples.test_RedshiftClusterInVpc) ... ok
test_example (tests.test_examples.test_Route53_A) ... ok
test_example (tests.test_examples.test_Route53_CNAME) ... ok
test_example (tests.test_examples.test_Route53_RoundRobin) ... ok
test_example (tests.test_examples.test_S3_Bucket) ... ok
test_example (tests.test_examples.test_S3_Bucket_With_AccelerateConfiguration) ... ok
test_example (tests.test_examples.test_S3_Bucket_With_Versioning_And_Lifecycle_Rules) ... ok
test_example (tests.test_examples.test_S3_Website_Bucket_With_Retain_On_Delete) ... ok
test_example (tests.test_examples.test_Serverless_Api_Backend) ... ok
test_example (tests.test_examples.test_Serverless_S3_Processor) ... ok
test_example (tests.test_examples.test_SQS_With_CloudWatch_Alarms) ... ok
test_example (tests.test_examples.test_SQSDLQ) ... ok
test_example (tests.test_examples.test_SQSEncrypt) ... ok
test_example (tests.test_examples.test_VPC_EC2_Instance_With_Multiple_Dynamic_IPAddresses) ... ok
test_example (tests.test_examples.test_VPC_single_instance_in_subnet) ... ok
test_example (tests.test_examples.test_VPC_With_VPN_Connection) ... ok
test_example (tests.test_examples.test_WAF_Common_Attacks_Sample) ... ok
test_example (tests.test_examples.test_WAF_Regional_Common_Attacks_Sample) ... ok
test_example (tests.test_examples.test_WaitObject) ... ok
test_template_generator (tests.test_examples_template_generator.test_ApiGateway) ... /Users/fredlef/src/tropo/troposphere/dynamodb2.py:33: UserWarning: This module has replaced by troposphere.dynamodb. Please import that module instead, as troposphere.dynamodb2 will be removed soon.
  warnings.warn("This module has replaced by troposphere.dynamodb. Please "
ok
test_template_generator (tests.test_examples_template_generator.test_ApplicationAutoScalingSample) ... ok
test_template_generator (tests.test_examples_template_generator.test_ApplicationELB) ... ok
test_template_generator (tests.test_examples_template_generator.test_Autoscaling) ... ok
test_template_generator (tests.test_examples_template_generator.test_AutoscalingHTTPRequests) ... ok
test_template_generator (tests.test_examples_template_generator.test_Batch) ... ok
test_template_generator (tests.test_examples_template_generator.test_CertificateManagerSample) ... ok
test_template_generator (tests.test_examples_template_generator.test_ClassExtensions) ... ok
test_template_generator (tests.test_examples_template_generator.test_CloudFormation_Init_ConfigSet) ... ok
test_template_generator (tests.test_examples_template_generator.test_CloudFront_S3) ... ok
test_template_generator (tests.test_examples_template_generator.test_CloudTrail) ... ok
test_template_generator (tests.test_examples_template_generator.test_CloudWatchEventsSample) ... ok
test_template_generator (tests.test_examples_template_generator.test_CodeBuild) ... ok
test_template_generator (tests.test_examples_template_generator.test_CodeDeploy) ... ok
test_template_generator (tests.test_examples_template_generator.test_CodePipeline) ... ok
test_template_generator (tests.test_examples_template_generator.test_CustomResource) ... ok
test_template_generator (tests.test_examples_template_generator.test_DynamoDB_Table) ... ok
test_template_generator (tests.test_examples_template_generator.test_DynamoDB_Table_With_GlobalSecondaryIndex) ... ok
test_template_generator (tests.test_examples_template_generator.test_DynamoDB_Table_With_GSI_And_NonKeyAttributes_Projection) ... ok
test_template_generator (tests.test_examples_template_generator.test_EC2_Remove_Ephemeral_Drive) ... ok
test_template_generator (tests.test_examples_template_generator.test_EC2Conditions) ... ok
test_template_generator (tests.test_examples_template_generator.test_EC2InstanceSample) ... ok
test_template_generator (tests.test_examples_template_generator.test_ECRSample) ... ok
test_template_generator (tests.test_examples_template_generator.test_ECSCluster) ... ok
test_template_generator (tests.test_examples_template_generator.test_ECSFargate) ... ok
test_template_generator (tests.test_examples_template_generator.test_EFS) ... ok
test_template_generator (tests.test_examples_template_generator.test_ElastiCacheRedis) ... ok
test_template_generator (tests.test_examples_template_generator.test_ElasticBeanstalk_Nodejs_Sample) ... ok
test_template_generator (tests.test_examples_template_generator.test_ElasticsearchDomain) ... ok
test_template_generator (tests.test_examples_template_generator.test_ELBSample) ... ok
test_template_generator (tests.test_examples_template_generator.test_EMR_Cluster) ... ok
test_template_generator (tests.test_examples_template_generator.test_Firehose_with_Redshift) ... ok
test_template_generator (tests.test_examples_template_generator.test_IAM_Policies_SNS_Publish_To_SQS) ... ok
test_template_generator (tests.test_examples_template_generator.test_IAM_Roles_and_InstanceProfiles) ... ok
test_template_generator (tests.test_examples_template_generator.test_IAM_Users_Groups_and_Policies) ... ok
test_template_generator (tests.test_examples_template_generator.test_IAM_Users_snippet) ... ok
test_template_generator (tests.test_examples_template_generator.test_IoTSample) ... ok
test_template_generator (tests.test_examples_template_generator.test_Kinesis_Stream) ... ok
test_template_generator (tests.test_examples_template_generator.test_Lambda) ... ok
test_template_generator (tests.test_examples_template_generator.test_Metadata) ... ok
test_template_generator (tests.test_examples_template_generator.test_NatGateway) ... ok
test_template_generator (tests.test_examples_template_generator.test_NetworkLB) ... ok
test_template_generator (tests.test_examples_template_generator.test_OpenStack_AutoScaling) ... ok
test_template_generator (tests.test_examples_template_generator.test_OpenStack_Server) ... ok
test_template_generator (tests.test_examples_template_generator.test_OpsWorksSnippet) ... ok
test_template_generator (tests.test_examples_template_generator.test_RDS_Snapshot_On_Delete) ... ok
test_template_generator (tests.test_examples_template_generator.test_RDS_VPC) ... ok
test_template_generator (tests.test_examples_template_generator.test_RDS_with_DBParameterGroup) ... ok
test_template_generator (tests.test_examples_template_generator.test_Redshift) ... ok
test_template_generator (tests.test_examples_template_generator.test_RedshiftClusterInVpc) ... ok
test_template_generator (tests.test_examples_template_generator.test_Route53_A) ... ok
test_template_generator (tests.test_examples_template_generator.test_Route53_CNAME) ... ok
test_template_generator (tests.test_examples_template_generator.test_Route53_RoundRobin) ... ok
test_template_generator (tests.test_examples_template_generator.test_S3_Bucket) ... ok
test_template_generator (tests.test_examples_template_generator.test_S3_Bucket_With_AccelerateConfiguration) ... ok
test_template_generator (tests.test_examples_template_generator.test_S3_Bucket_With_Versioning_And_Lifecycle_Rules) ... ok
test_template_generator (tests.test_examples_template_generator.test_S3_Website_Bucket_With_Retain_On_Delete) ... ok
test_template_generator (tests.test_examples_template_generator.test_Serverless_Api_Backend) ... ok
test_template_generator (tests.test_examples_template_generator.test_Serverless_S3_Processor) ... ok
test_template_generator (tests.test_examples_template_generator.test_SQS_With_CloudWatch_Alarms) ... ok
test_template_generator (tests.test_examples_template_generator.test_SQSDLQ) ... ok
test_template_generator (tests.test_examples_template_generator.test_SQSEncrypt) ... ok
test_template_generator (tests.test_examples_template_generator.test_VPC_EC2_Instance_With_Multiple_Dynamic_IPAddresses) ... ok
test_template_generator (tests.test_examples_template_generator.test_VPC_single_instance_in_subnet) ... ok
test_template_generator (tests.test_examples_template_generator.test_VPC_With_VPN_Connection) ... ok
test_template_generator (tests.test_examples_template_generator.test_WAF_Common_Attacks_Sample) ... ok
test_template_generator (tests.test_examples_template_generator.test_WAF_Regional_Common_Attacks_Sample) ... ok
test_template_generator (tests.test_examples_template_generator.test_WaitObject) ... ok
test_guardduty_detector (tests.test_guardduty.TestGuardDuty) ... ok
test_guardduty_ipset (tests.test_guardduty.TestGuardDuty) ... ok
test_guardduty_threatintelset (tests.test_guardduty.TestGuardDuty) ... ok
test_there_should_not_be_any_awsobject_with_int_in_props (tests.test_int_type.TestIntTypeShouldNotBeUsed) ... ok
test_log_destination (tests.test_logs.TestLogs) ... ok
test_loggroup_deletionpolicy_is_preserved (tests.test_logs.TestLogs) ... ok
test_custom_json (tests.test_opsworks.TestOpsWorksStack) ... ok
test_no_required (tests.test_opsworks.TestOpsWorksStack) ... ok
test_nosubnet (tests.test_opsworks.TestOpsWorksStack) ... ok
test_required (tests.test_opsworks.TestOpsWorksStack) ... ok
test_stack (tests.test_opsworks.TestOpsWorksStack) ... ok
test_ref_can_be_requested (tests.test_parameters.TestInitArguments) ... ok
test_title_max_length (tests.test_parameters.TestInitArguments) ... ok
test_auto_scaling_creation_policy (tests.test_policies.TestCreationPolicy) ... ok
test_auto_scaling_creation_policy_json (tests.test_policies.TestCreationPolicy) ... ok
test_invalid_pausetime (tests.test_policies.TestCreationPolicy) ... <class 'troposphere.policies.ResourceSignal'>: None.Timeout function validator 'validate_pausetime' threw exception:
ok
test_json (tests.test_policies.TestCreationPolicy) ... ok
test_works (tests.test_policies.TestCreationPolicy) ... ok
test_invalid_pausetime (tests.test_policies.TestUpdatePolicy) ... <class 'troposphere.policies.AutoScalingRollingUpdate'>: None.PauseTime function validator 'validate_pausetime' threw exception:
ok
test_json (tests.test_policies.TestUpdatePolicy) ... ok
test_mininstances (tests.test_policies.TestUpdatePolicy) ... ok
test_mininstances_maxsize_is_ref (tests.test_policies.TestUpdatePolicy) ... ok
test_mininstances_mininstancesinservice_is_ref (tests.test_policies.TestUpdatePolicy) ... ok
test_works (tests.test_policies.TestUpdatePolicy) ... ok
test_az_and_multiaz_funcs (tests.test_rds.TestRDS) ... ok
test_fail_az_and_multiaz (tests.test_rds.TestRDS) ... ok
test_io1_storage_type_and_iops (tests.test_rds.TestRDS) ... ok
test_it_allows_an_rds_instance_created_from_a_snapshot (tests.test_rds.TestRDS) ... ok
test_it_allows_an_rds_instance_with_iops (tests.test_rds.TestRDS) ... ok
test_it_allows_an_rds_instance_with_master_username_and_password (tests.test_rds.TestRDS) ... ok
test_it_allows_an_rds_replica (tests.test_rds.TestRDS) ... ok
test_it_rds_instances_require_either_a_snapshot_or_credentials (tests.test_rds.TestRDS) ... ok
test_it_rds_instances_require_encryption_if_kms_key_provided (tests.test_rds.TestRDS) ... ok
test_no_snapshot_or_engine (tests.test_rds.TestRDS) ... ok
test_optiongroup (tests.test_rds.TestRDS) ... ok
test_replica_settings_are_inherited (tests.test_rds.TestRDS) ... ok
test_snapshot (tests.test_rds.TestRDS) ... ok
test_snapshot_and_engine (tests.test_rds.TestRDS) ... ok
test_storage_to_iops_ratio (tests.test_rds.TestRDS) ... ok
test_validate_backup_retention_period (tests.test_rds.TestRDSValidators) ... ok
test_validate_backup_window (tests.test_rds.TestRDSValidators) ... ok
test_validate_engine (tests.test_rds.TestRDSValidators) ... ok
test_validate_iops (tests.test_rds.TestRDSValidators) ... ok
test_validate_license_model (tests.test_rds.TestRDSValidators) ... ok
test_validate_maintenance_window (tests.test_rds.TestRDSValidators) ... ok
test_validate_storage_type (tests.test_rds.TestRDSValidators) ... ok
test_bucket_accesscontrol (tests.test_s3.TestBucket) ... ok
test_bucket_accesscontrol_bad_string (tests.test_s3.TestBucket) ... ok
test_bucket_accesscontrol_bad_type (tests.test_s3.TestBucket) ... ok
test_bucket_accesscontrol_ref (tests.test_s3.TestBucket) ... ok
test_bucket_template (tests.test_s3.TestBucketTemplate) ... ok
test_accelerate_configuration_enabled (tests.test_s3.TestS3AccelerateConfiguration) ... ok
test_accelerate_configuration_invalid_value (tests.test_s3.TestS3AccelerateConfiguration) ... <class 'troposphere.s3.AccelerateConfiguration'>: None.AccelerationStatus function validator 's3_transfer_acceleration_status' threw exception:
ok
test_accelerate_configuration_suspended (tests.test_s3.TestS3AccelerateConfiguration) ... ok
test_s3_bucket_accelerate_configuration (tests.test_s3.TestS3AccelerateConfiguration) ... ok
test_DLQ (tests.test_serverless.TestServerless) ... ok
test_optional_auto_publish_alias (tests.test_serverless.TestServerless) ... ok
test_packaging (tests.test_serverless.TestServerless) ... ok
test_policy_document (tests.test_serverless.TestServerless) ... ok
test_required_api_both (tests.test_serverless.TestServerless) ... ok
test_required_api_definitionbody (tests.test_serverless.TestServerless) ... ok
test_required_api_definitionuri (tests.test_serverless.TestServerless) ... ok
test_required_function (tests.test_serverless.TestServerless) ... ok
test_s3_filter (tests.test_serverless.TestServerless) ... ok
test_s3_location (tests.test_serverless.TestServerless) ... ok
test_simple_table (tests.test_serverless.TestServerless) ... ok
test_tags (tests.test_serverless.TestServerless) ... ok
test_QueueName (tests.test_sqs.TestQueue) ... ok
test_activity (tests.test_stepfunctions.TestStepFunctions) ... ok
test_statemachine (tests.test_stepfunctions.TestStepFunctions) ... ok
test_statemachine_missing_parameter (tests.test_stepfunctions.TestStepFunctions) ... ok
test_ASTagAddition (tests.test_tags.TestTags) ... ok
test_Formats (tests.test_tags.TestTags) ... ok
test_TagAddition (tests.test_tags.TestTags) ... ok
test_description (tests.test_template.TestInitArguments) ... ok
test_description_default (tests.test_template.TestInitArguments) ... ok
test_metadata (tests.test_template.TestInitArguments) ... ok
test_metadata_default (tests.test_template.TestInitArguments) ... ok
test_transform (tests.test_template.TestInitArguments) ... ok
test_max_mappings (tests.test_template.TestValidate) ... ok
test_max_outputs (tests.test_template.TestValidate) ... ok
test_max_parameters (tests.test_template.TestValidate) ... ok
test_max_resources (tests.test_template.TestValidate) ... ok
test_char_escaping (tests.test_userdata.TestUserdata) ... ok
test_empty_file (tests.test_userdata.TestUserdata) ... ok
test_nonexistant_file (tests.test_userdata.TestUserdata) ... ok
test_one_line_file (tests.test_userdata.TestUserdata) ... ok
test_simple (tests.test_userdata.TestUserdata) ... ok
test_boolean (tests.test_validators.TestValidators) ... ok
test_compliance_level (tests.test_validators.TestValidators) ... ok
test_elb_name (tests.test_validators.TestValidators) ... ok
test_encoding (tests.test_validators.TestValidators) ... ok
test_iam_group_name (tests.test_validators.TestValidators) ... ok
test_iam_names (tests.test_validators.TestValidators) ... ok
test_iam_path (tests.test_validators.TestValidators) ... ok
test_iam_role_name (tests.test_validators.TestValidators) ... ok
test_iam_user_name (tests.test_validators.TestValidators) ... ok
test_integer (tests.test_validators.TestValidators) ... ok
test_integer_range (tests.test_validators.TestValidators) ... ok
test_mutually_exclusive (tests.test_validators.TestValidators) ... ok
test_network_port (tests.test_validators.TestValidators) ... ok
test_network_port_ref (tests.test_validators.TestValidators) ... ok
test_notification_event (tests.test_validators.TestValidators) ... ok
test_notification_type (tests.test_validators.TestValidators) ... ok
test_operating_system (tests.test_validators.TestValidators) ... ok
test_positive_integer (tests.test_validators.TestValidators) ... ok
test_s3_bucket_name (tests.test_validators.TestValidators) ... ok
test_status (tests.test_validators.TestValidators) ... ok
test_task_type (tests.test_validators.TestValidators) ... ok
test_tg_healthcheck_port (tests.test_validators.TestValidators) ... ok
test_tg_healthcheck_port_ref (tests.test_validators.TestValidators) ... ok
test_s3_bucket (tests.test_yaml.TestYAML) ... ok