### PR TITLE
Allow CreationPolicy override of props on WaitCondition

### DIFF
--- a/tests/test_cloudformation.py
+++ b/tests/test_cloudformation.py
@@ -1,0 +1,39 @@
+import unittest
+from troposphere import Ref
+from troposphere.cloudformation import WaitCondition, WaitConditionHandle
+from troposphere.policies import CreationPolicy, ResourceSignal
+
+
+class TestWaitCondition(unittest.TestCase):
+    def test_CreationPolicy(self):
+        w = WaitCondition(
+            "mycondition",
+            CreationPolicy=CreationPolicy(
+                ResourceSignal=ResourceSignal(
+                    Timeout='PT15M')),
+        )
+        w.validate()
+
+    def test_CreationPolicyWithProps(self):
+        w = WaitCondition(
+            "mycondition",
+            Count=10,
+            CreationPolicy=CreationPolicy(
+                ResourceSignal=ResourceSignal(
+                    Timeout='PT15M')),
+        )
+        with self.assertRaises(ValueError):
+            w.validate()
+
+    def test_RequiredProps(self):
+        handle = WaitConditionHandle("myWaitHandle")
+        w = WaitCondition(
+            "mycondition",
+            Handle=Ref(handle),
+            Timeout="300",
+        )
+        w.validate()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/troposphere/cloudformation.py
+++ b/troposphere/cloudformation.py
@@ -5,7 +5,7 @@
 
 from . import AWSHelperFn, AWSObject, AWSProperty, BaseAWSObject, Tags
 from . import encode_to_dict
-from .validators import integer, boolean, encoding
+from .validators import boolean, check_required, encoding, integer
 
 
 class Stack(AWSObject):
@@ -37,9 +37,21 @@ class WaitCondition(AWSObject):
 
     props = {
         'Count': (integer, False),
-        'Handle': (basestring, True),
-        'Timeout': (integer, True),
+        'Handle': (basestring, False),
+        'Timeout': (integer, False),
     }
+
+    def validate(self):
+        if 'CreationPolicy' in self.resource:
+            for k in self.props.keys():
+                if k in self.properties:
+                    raise ValueError(
+                        "Property %s cannot be specified with CreationPolicy" %
+                        k
+                    )
+        else:
+            required = ['Handle', 'Timeout']
+            check_required(self.__class__.__name__, self.properties, required)
 
 
 class WaitConditionHandle(AWSObject):

--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -217,6 +217,12 @@ def exactly_one(class_name, properties, conditionals):
     return specified_count
 
 
+def check_required(class_name, properties, conditionals):
+    for c in conditionals:
+        if c not in properties:
+            raise ValueError("Resource %s required in %s" % c, class_name)
+
+
 def json_checker(name, prop):
     from . import AWSHelperFn
 


### PR DESCRIPTION
This [reference](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-waitcondition.html) states ```If you use a CreationPolicy with a wait condition, do not specify any of the wait condition's properties.```. This PR enforces this and allows for CreationPolicy to override the "required" fields for WaitCondition. Fixes #986 