### PR TITLE
ApiGateway::DomainName CertificateArn fix

### DIFF
--- a/troposphere/apigateway.py
+++ b/troposphere/apigateway.py
@@ -174,7 +174,7 @@ class DomainName(AWSObject):
     resource_type = "AWS::ApiGateway::DomainName"
 
     props = {
-        "CertificateArn": (basestring, True),
+        "CertificateArn": (basestring, False),
         "DomainName": (basestring, True),
         "EndpointConfiguration": (EndpointConfiguration, False),
         "RegionalCertificateArn": (basestring, False),


### PR DESCRIPTION
- Remove CertificateArn requirement from ApiGateway:DomainName to deploy
ApiGateway REGION deployment w/ssl