### PR TITLE
Add support for Aurora 5.7

### DIFF
--- a/troposphere/rds.py
+++ b/troposphere/rds.py
@@ -15,7 +15,7 @@ VALID_STORAGE_TYPES = ('standard', 'gp2', 'io1')
 VALID_DB_ENGINES = ('MySQL', 'mysql', 'oracle-se1', 'oracle-se2', 'oracle-se',
                     'oracle-ee', 'sqlserver-ee', 'sqlserver-se',
                     'sqlserver-ex', 'sqlserver-web', 'postgres', 'aurora',
-                    'aurora-postgresql', 'mariadb')
+                    'aurora-mysql', 'aurora-postgresql', 'mariadb')
 VALID_LICENSE_MODELS = ('license-included', 'bring-your-own-license',
                         'general-public-license', 'postgresql-license')
 


### PR DESCRIPTION
- This adds aurora-mysql, which is the appropriate identifier for Aurora
5.7, as a valid engine type for rds instances and clusters.

See: https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBCluster.html under "Engine".