### PR TITLE
Tags support for SSM documents #999

### DIFF
--- a/troposphere/ssm.py
+++ b/troposphere/ssm.py
@@ -3,7 +3,7 @@
 #
 # See LICENSE file for full license.
 
-from . import AWSObject, AWSProperty
+from . import AWSObject, AWSProperty, Tags
 from .validators import (integer, boolean, s3_bucket_name, notification_type,
                          notification_event, json_checker, task_type,
                          operating_system, compliance_level)
@@ -129,6 +129,7 @@ class Document(AWSObject):
         # Need a better implementation of the SSM Document
         'Content': (dict, True),
         'DocumentType': (basestring, False),
+        'Tags': (Tags, False),
     }
 
 


### PR DESCRIPTION
SSM Documents now support tags (#999)

Tested by adding tag information to some documents I've generated via Troposphere - when I updated the stack with new template - tags were successfully added to the documents.