### PR TITLE
Update deprecated modules in TemplateGenerator

### DIFF
--- a/troposphere/template_generator.py
+++ b/troposphere/template_generator.py
@@ -30,7 +30,7 @@ from troposphere.policies import UpdatePolicy, CreationPolicy
 
 
 class TemplateGenerator(Template):
-    DEPRECATED_MODULES = ['troposphere.dynamodb']
+    DEPRECATED_MODULES = ['troposphere.dynamodb2']
 
     _inspect_members = set()
     _inspect_resources = {}


### PR DESCRIPTION
When using the TemplateGenerator, the following warning message appears:

UserWarning: This module has replaced by troposphere.dynamodb. Please import that module instead, as troposphere.dynamodb2 will be removed soon.
