### PR TITLE
Correct Spot Fleet TagSpecifications

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -706,7 +706,7 @@ class LaunchSpecifications(AWSProperty):
         'SecurityGroups': ([SecurityGroups], False),
         'SpotPrice': (basestring, False),
         'SubnetId': (basestring, False),
-        'TagSpecification': (SpotFleetTagSpecification, False),
+        'TagSpecifications': ([SpotFleetTagSpecification], False),
         'UserData': (basestring, False),
         'WeightedCapacity': (positive_integer, False),
     }

--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -685,7 +685,7 @@ class IamInstanceProfile(AWSProperty):
 
 class SpotFleetTagSpecification(AWSProperty):
     props = {
-        'ResourceType': (basestring, False),
+        'ResourceType': (basestring, True),
         'Tags': ((Tags, list), False),
     }
 


### PR DESCRIPTION
The new support for adding tags to Spot Fleets created in CloudFormation [works a bit differently](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-spotfleet-spotfleetrequestconfigdata-launchspecifications.html#cfn-ec2-spotfleet-spotfleetlaunchspecification-tagspecifications) than was added in c4ee115e -- the property is TagSpecifications (vs. TagSpecification) and it must be a list.

The SpotFleetTagSpecification property ResourceType [claims it's not required](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-spotfleet-spotfleetrequestconfigdata-launchspecifications-tagspecifications.html#cfn-ec2-spotfleet-spotfleettagspecification-resourcetype) but I get "Tag specification resource type must have a value" in CloudFormation when I omit it, so I marked it required. (There is only one valid value, so it's a bit silly, but oh well.)