### PR TITLE
Allow properties supported by `cloudformation package` to be strings

### DIFF
--- a/troposphere/apigateway.py
+++ b/troposphere/apigateway.py
@@ -293,7 +293,7 @@ class RestApi(AWSObject):
         "ApiKeySourceType": (basestring, False),
         "BinaryMediaTypes": ([basestring], False),
         "Body": (dict, False),
-        "BodyS3Location": (S3Location, False),
+        "BodyS3Location": ((S3Location, basestring), False),
         "CloneFrom": (basestring, False),
         "Description": (basestring, False),
         "EndpointConfiguration": (EndpointConfiguration, False),

--- a/troposphere/awslambda.py
+++ b/troposphere/awslambda.py
@@ -135,7 +135,7 @@ class Function(AWSObject):
     resource_type = "AWS::Lambda::Function"
 
     props = {
-        'Code': (Code, True),
+        'Code': ((Code, basestring), True),
         'Description': (basestring, False),
         'DeadLetterConfig': (DeadLetterConfig, False),
         'Environment': (Environment, False),

--- a/troposphere/elasticbeanstalk.py
+++ b/troposphere/elasticbeanstalk.py
@@ -81,7 +81,7 @@ class ApplicationVersion(AWSObject):
     props = {
         'ApplicationName': (basestring, True),
         'Description': (basestring, False),
-        'SourceBundle': (SourceBundle, False),
+        'SourceBundle': ((SourceBundle, basestring), False),
     }
 
 


### PR DESCRIPTION
When uploading local artifacts using the `cloudformation package`
command, you can specify paths relative to the template instead
of the normal properties.

See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-cli-package.html