### PR TITLE
Update Codebuild Sources to include Github Enterprise

### DIFF
--- a/troposphere/codebuild.py
+++ b/troposphere/codebuild.py
@@ -124,6 +124,7 @@ class Source(AWSProperty):
             'CODECOMMIT',
             'CODEPIPELINE',
             'GITHUB',
+            'GITHUB_ENTERPRISE',
             'S3',
         ]
 


### PR DESCRIPTION
Added support for Github Enterprise as a source for Codebuild. Support for 'GitCloneDepth' and 'InsecureSsl' were added in the last release but the source types were not updated. 