### PR TITLE
Parameter instantiated with template= adds itself as a resource

### DIFF
--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -125,6 +125,9 @@ class BaseAWSObject(object):
         for k, v in kwargs.items():
             self.__setattr__(k, v)
 
+        self.add_to_template()
+
+    def add_to_template(self):
         # Bound it to template if we know it
         if self.template is not None:
             self.template.add_resource(self)
@@ -651,6 +654,11 @@ class Output(AWSDeclaration):
         'Value': (basestring, True),
     }
 
+    def add_to_template(self):
+        # Bound it to template if we know it
+        if self.template is not None:
+            self.template.add_output(self)
+
 
 class Parameter(AWSDeclaration):
     STRING_PROPERTIES = ['AllowedPattern', 'MaxLength', 'MinLength']
@@ -668,6 +676,11 @@ class Parameter(AWSDeclaration):
         'Description': (basestring, False),
         'ConstraintDescription': (basestring, False),
     }
+
+    def add_to_template(self):
+        # Bound it to template if we know it
+        if self.template is not None:
+            self.template.add_parameter(self)
 
     def validate_title(self):
         if len(self.title) > PARAMETER_TITLE_MAX:


### PR DESCRIPTION
When you create a param by passing it a template object, such as
`MyParam = troposphere.Parameter("MyParam", template=t, ...)`
it is added to the template as a resource, not a parameter, as happens when instantiated as follows
`MyParam = template.add_parameter(troposphere.Parameter("MyParam", ...))`

`troposphere.Parameter` extends `troposphere.BaseAWSObject` (through `AWSDeclaration`).
`BaseAWSObject.__init__` does the following
```
if self.template is not None:
    self.template.add_resource(self)
```
This means Parameters and Outputs (not sure if there are other types?) add themselves as resources.

Would the best solution to be to break the above code snippet into its own `add_self_to_template` function so it can be overridden by Parameter and Output?