### PR TITLE
 Adding support ECS Container Healthchecks

### DIFF
--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -198,3 +198,22 @@ class TestECS(unittest.TestCase):
         )
 
         container_definition.to_dict()
+
+    def test_allow_container_healthcheck(self):
+        health_check_def = ecs.HealthCheck(
+            Command=[
+                "CMD-SHELL",
+                "curl -f http://localhost/ || exit 1"
+            ],
+            Interval=5,
+            Timeout=30,
+            Retries=5,
+        )
+        container_definition = ecs.ContainerDefinition(
+            Image="myimage",
+            Memory="300",
+            Name="mycontainer",
+            HealthCheck=health_check_def,
+        )
+
+        container_definition.to_dict()

--- a/troposphere/ecs.py
+++ b/troposphere/ecs.py
@@ -181,7 +181,7 @@ class HealthCheck(AWSProperty):
     props = {
         'Command': ([basestring], True),
         'Interval': (integer, False),
-        'Timeout': (integer, True),
+        'Timeout': (integer, False),
         'Retries': (integer, False),
         'StartPeriod': (integer, False),
     }

--- a/troposphere/ecs.py
+++ b/troposphere/ecs.py
@@ -177,6 +177,16 @@ class Ulimit(AWSProperty):
     }
 
 
+class HealthCheck(AWSProperty):
+    props = {
+        'Command': ([basestring], True),
+        'Interval': (integer, False),
+        'Timeout': (integer, True),
+        'Retries': (integer, False),
+        'StartPeriod': (integer, False),
+    }
+
+
 class ContainerDefinition(AWSProperty):
     props = {
         'Command': ([basestring], False),
@@ -190,6 +200,7 @@ class ContainerDefinition(AWSProperty):
         'Environment': ([Environment], False),
         'Essential': (boolean, False),
         'ExtraHosts': ([HostEntry], False),
+        'HealthCheck': (HealthCheck, False),
         'Hostname': (basestring, False),
         'Image': (basestring, True),
         'Links': ([basestring], False),


### PR DESCRIPTION
AWS released container health checks:
https://aws.amazon.com/about-aws/whats-new/2018/03/amazon-ecs-supports-container-health-checks-and-task-health-mana/

I need this for some apps that don't use a load balancer.

AWS Docs:
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definition_healthcheck