### PR TITLE
Fix misspelling of codepipeline.ActionTypeId to match CF documentation

### DIFF
--- a/troposphere/codepipeline.py
+++ b/troposphere/codepipeline.py
@@ -16,6 +16,10 @@ class ActionTypeID(AWSProperty):
     }
 
 
+class ActionTypeId(ActionTypeID):
+    pass
+
+
 class ArtifactDetails(AWSProperty):
     props = {
         'MaximumCount': (integer, True),


### PR DESCRIPTION
This fixes the issue reported in Issue #1027 while maintaining backwards compatibility for people that used the old spelling.