### PR TITLE
Adding Azure ARM template generation capabilities 

### DIFF
--- a/tests/azure_tests/test_compute.py
+++ b/tests/azure_tests/test_compute.py
@@ -1,0 +1,36 @@
+import unittest
+
+from azure import ARMTemplate
+from azure.compute import VirtualMachine, HardwareProfile, StorageProfile, ImageReference, OsDisk, \
+    ManagedDiskParameters, OSProfile, LinuxConfiguration, NetworkProfile, NetworkInterfaceReference
+from azure.network import NetworkInterface
+
+
+class TestAzureCompute(unittest.TestCase):
+    def test_simple_vm(self):
+        template = ARMTemplate()
+        network_interface = NetworkInterface('tesmvm_nic1')
+        vm = VirtualMachine('testvm',
+                            template=template,
+                            hardwareProfile=HardwareProfile(vmSize='Basic_A0'),
+                            storageProfile=StorageProfile(imageReference=ImageReference(publisher='Canonical',
+                                                                                        offer='UbuntuServer',
+                                                                                        sku='16.04-LTS'),
+                                                          osDisk=OsDisk(createOption='FromImage',
+                                                                        diskSizeGB=50,
+                                                                        managedDisk=ManagedDiskParameters(
+                                                                            storageAccountType='Standard_LRS'))),
+                            osProfile=OSProfile(computerName='testvm',
+                                                adminUsername='adminuser',
+                                                adminPassword='S0m3Str0ngP@ss0wd',
+                                                linuxConfiguration=LinuxConfiguration(
+                                                    disablePasswordAuthentication=False)),
+                            networkProfile=NetworkProfile(networkInterfaces=
+                                                          [NetworkInterfaceReference(id=network_interface.Ref())]))
+        vm.to_dict()
+        self.assertIn(vm, template.resources)
+
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/tests/azure_tests/test_network.py
+++ b/tests/azure_tests/test_network.py
@@ -1,0 +1,50 @@
+import unittest
+
+from azure import ARMTemplate
+from azure.network import VirtualNetwork, AddressSpace, Subnet, NetworkSecurityGroup, SecurityRule, PublicIPAddress, \
+    NetworkInterface, NetworkInterfaceIPConfiguration, SubResource
+
+
+class TestAzureCompute(unittest.TestCase):
+    def test_simple_vm(self):
+        vnet = VirtualNetwork("test_vnet",
+                              addressSpace=AddressSpace(addressPrefixes=['10.0.0.0/24']),
+                              subnets=[Subnet('subnet1', addressPrefix='10.0.0.0/24')],
+                              tags={'Key1': 'tag-key1', 'Key2': 'tag-key2', 'Key3': 'tag-key3'})
+
+        nsg = NetworkSecurityGroup("testvmNsg",
+                                   securityRules=[
+                                       SecurityRule('ssh',
+                                                    description='public ssh access',
+                                                    protocol='Tcp',
+                                                    destinationPortRange="22",
+                                                    destinationAddressPrefix="*",
+                                                    sourceAddressPrefix='Internet',
+                                                    sourcePortRange='*',
+                                                    access='Allow',
+                                                    direction='Inbound',
+                                                    priority=200)])
+
+        public_ip = PublicIPAddress('testvm_nic1_pubip', publicIPAllocationMethod='dynamic')
+
+        network_interface = NetworkInterface('tesmvm_nic1',
+                                             ipConfigurations=
+                                             [NetworkInterfaceIPConfiguration('tesmvm_nic1_ip_config',
+                                                                              privateIPAllocationMethod='Dynamic',
+                                                                              subnet=SubResource(
+                                                                                  id=vnet.SubnetRef('subnet1')),
+                                                                              publicIPAddress=SubResource(
+                                                                                  id=public_ip.Ref()))],
+                                             networkSecurityGroup=SubResource(id=nsg.Ref()))
+        network_interface.with_depends_on([public_ip, vnet])
+
+        template = ARMTemplate(Description='test template')
+        template.add_resource([vnet, nsg, public_ip, network_interface])
+
+        self.assertIn(vnet, template.resources)
+        self.assertIn(nsg, template.resources)
+        self.assertIn(public_ip, template.resources)
+        self.assertIn(network_interface, template.resources)
+
+    if __name__ == '__main__':
+        unittest.main()

--- a/troposphere/azure/__init__.py
+++ b/troposphere/azure/__init__.py
@@ -1,0 +1,285 @@
+import json
+import re
+import cfn_flip as cfn_flip
+
+from troposphere import  encode_to_dict, AWSObject, AWSProperty, Parameter, validators
+
+# Template Limits
+MAX_VARIABLES = 256
+MAX_OUTPUTS = 64
+MAX_PARAMETERS = 256
+MAX_RESOURCES = 800
+PARAMETER_TITLE_MAX = 255
+
+valid_names_azure = re.compile(r'^[a-zA-Z0-9_-]+$')
+
+
+class ARMTemplate(object):
+    props = {
+        '$schema': (str, False),
+        'contentVersion': (str, False),
+        'description': (str, False),
+        'variables': (str, False),
+        'parameters': (dict, False),
+        'resources': (dict, False),
+        'outputs': (dict, False),
+    }
+
+    def __init__(self, Description=None, ContentVersion="1.0.0.0"):
+        self.contentVersion = ContentVersion
+        self.description = Description
+        self.variables = []
+        self.parameters = {}
+        self.resources = []
+        self.outputs = {}
+
+    def add_description(self, description):
+        self.description = description
+
+    def handle_duplicate_key(self, key):
+        raise ValueError('duplicate key "%s" detected' % key)
+
+    def _update(self, d, values):
+        if isinstance(values, list):
+            for v in values:
+                if v.title in d:
+                    self.handle_duplicate_key(v.title)
+                d[v.title] = v
+        else:
+            if values.title in d:
+                self.handle_duplicate_key(values.title)
+            d[values.title] = values
+        return values
+
+    def _update_list(self, lst, values):
+        if isinstance(values, list):
+            for v in values:
+                item = next(
+                    iter(filter(lambda x: hasattr(x, 'title') and hasattr(v, 'title') and x.title == v.title, lst)),
+                    None)
+                if item:
+                    self.handle_duplicate_key(v.title)
+                else:
+                    lst.append(v)
+        else:
+            item = next(iter(
+                filter(lambda x: hasattr(x, 'title') and hasattr(values, 'title') and x.title == values.title, lst)),
+                None)
+            if item:
+                self.handle_duplicate_key(values.title)
+            else:
+                lst.append(values)
+        return values
+
+    def add_output(self, output):
+        if len(self.outputs) >= MAX_OUTPUTS:
+            raise ValueError('Maximum outputs %d reached' % MAX_OUTPUTS)
+        return self._update(self.outputs, output)
+
+    def add_parameter(self, parameter):
+        if len(self.parameters) >= MAX_PARAMETERS:
+            raise ValueError('Maximum parameters %d reached' % MAX_PARAMETERS)
+        return self._update(self.parameters, parameter)
+
+    def add_variable(self, variable):
+        if len(self.variables) >= MAX_VARIABLES:
+            raise ValueError('Maximum variables %d reached' % MAX_VARIABLES)
+        return self._update_list(self.variables, variable)
+
+    def add_resource(self, resource):
+        if len(self.resources) >= MAX_RESOURCES:
+            raise ValueError('Maximum number of resources %d reached'
+                             % MAX_RESOURCES)
+        return self._update_list(self.resources, resource)
+
+    def add_content_version(self, version=None):
+        if version:
+            self.contentVersion = version
+        else:
+            self.contentVersion = "1.0.0.0"
+
+    def to_dict(self):
+        t = {}
+        if self.description:
+            t['description'] = self.description
+
+        if self.outputs:
+            t['outputs'] = self.outputs
+        if self.parameters:
+            t['parameters'] = self.parameters
+        if self.contentVersion:
+            t['contentVersion'] = self.contentVersion
+
+        t['resources'] = self.resources
+        t['$schema'] = "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json"
+
+        return encode_to_dict(t)
+
+    def to_json(self, indent=4, sort_keys=True, separators=(',', ': ')):
+        return json.dumps(self.to_dict(), indent=indent,
+                          sort_keys=sort_keys, separators=separators)
+
+    def to_yaml(self, long_form=False):
+        return cfn_flip.to_yaml(self.to_json(), long_form)
+
+
+class ARMObject(AWSObject):
+    dictname = 'properties'
+
+    def __init__(self, title, template=None, validation=True, **kwargs):
+        AWSObject.__init__(self, title, template, validation, **kwargs)
+
+        if 'Type' in self.resource:
+            self.resource['type'] = self.resource['Type']
+            del self.resource['Type']
+
+        if hasattr(self, 'location') and self.location and 'location' not in self.resource:
+            self.resource['location'] = "[resourceGroup().location]"
+
+        if title:
+            self.resource['name'] = self.title
+
+        if hasattr(self, 'apiVersion'):
+            self.resource['apiVersion'] = self.apiVersion
+
+        # move root props from properties to resources dict to be in root of object when serialized
+        super(ARMObject, self)._validate_props()
+        for rootProp in list(filter(lambda x: issubclass(type(x[1]), ARMRootProperty), self.properties.items())):
+            k, v = rootProp
+            self.resource[k] = v
+            del self.properties[k]
+            del self.props[k]
+
+    def to_dict(self):
+        if 'name' in self.resource:
+            self.resource['name'] = self.title
+        if 'tags' in self.properties:
+            self.resource['tags'] = self.properties['tags']
+            del self.properties['tags']
+        if 'dependsOn' in self.properties:
+            self.resource['dependsOn'] = self.properties['dependsOn']
+            del self.properties['dependsOn']
+        return AWSObject.to_dict(self)
+
+    def ref(self):
+        return "[resourceId('{0}/','{1}')]".format(self.resource['type'], self.title)
+
+    Ref = ref
+
+    def get_att(self, value):
+        raise NotImplementedError()
+
+    def validate_title(self):
+        if not valid_names_azure.match(self.title):
+            raise ValueError('Name "%s" is not valid' % self.title)
+
+    # fluent api
+    def with_depends_on(self, dependsOn):
+        if 'dependsOn' not in self.resource:
+            self.resource['dependsOn'] = []
+        if isinstance(dependsOn, list):
+            for d in dependsOn:
+                self._add_dependency(d)
+        else:
+            self._add_dependency(dependsOn)
+        return self
+
+    def _add_dependency(self, dependency):
+        if isinstance(dependency, ARMObject):
+            self.resource['dependsOn'].append(dependency.Ref())
+        elif isinstance(dependency, str):
+            self.resource['dependsOn'].append(dependency)
+        else:
+            raise ValueError('Unsupported type')
+
+
+class ARMProperty(AWSProperty):
+    pass
+
+
+class ARMRootProperty(ARMProperty):
+    pass
+
+
+class ARMParameter(Parameter):
+    STRING_PROPERTIES = ['maxLength', 'minLength']
+    NUMBER_PROPERTIES = ['maxValue', 'minValue']
+    SUPPORTED_TYPES = ['string', 'secureString', 'int', 'bool', 'object', 'secureObject', 'array']
+
+    props = {
+        'type': (str, True),
+        'defaultValue': ((str, int, float), False),
+        'allowedValues': (list, False),
+        'maxLength': (validators.positive_integer, False),
+        'minLength': (validators.positive_integer, False),
+        'maxValue': (validators.integer, False),
+        'minValue': (validators.integer, False),
+        'description': (str, False)
+    }
+
+    def to_dict(self):
+        if 'description' in self.properties:
+            description = self.properties['description']
+            self.properties['metadata'] = {'description': description}
+            del self.properties['description']
+
+        return Parameter.to_dict(self)
+
+    def ref(self):
+        return "[parameters('{}')]".format(self.title)
+
+    Ref = ref
+
+    def validate(self):
+        def check_type(t, v):
+            try:
+                t(v)
+                return True
+            except ValueError:
+                return False
+
+        # Validate allowed types
+        if self.properties['type'] not in self.SUPPORTED_TYPES:
+            raise ValueError("{} is not a supported parameter type. Supported types: {}".format(
+                             self.properties['type'], self.SUPPORTED_TYPES))
+
+        # Validate the Default parameter value
+        default = self.properties.get('defaultValue')
+        if default:
+            error_str = ("Parameter default type mismatch: expecting "
+                         "type %s got %s with value %r")
+            # Get the Type specified and see whether the default type
+            # matches (in the case of a String Type) or can be coerced
+            # into one of the number formats.
+            param_type = self.properties.get('type')
+            if (param_type == 'string' or param_type == 'secureString') and not isinstance(default, str):
+                raise ValueError(error_str %
+                                 ('string', type(default), default))
+            elif param_type == 'int' and not isinstance(default, int):
+                raise ValueError(error_str %
+                                 (param_type, type(default), default))
+            elif param_type == 'bool' and not isinstance(default, bool):
+                raise ValueError(error_str %
+                                 (param_type, type(default), default))
+            elif param_type == 'array':
+                if not isinstance(default, str):
+                    raise ValueError(error_str %
+                                     (param_type, type(default), default))
+                allowed = [str, int]
+                dlist = default.split(",")
+                for d in dlist:
+                    # Verify the split array are all in allowed
+                    if not any([check_type(x, d) for x in allowed]):
+                        raise ValueError(error_str %
+                                         (param_type, type(d), dlist))
+
+        if self.properties['type'] != 'string':
+            for p in self.STRING_PROPERTIES:
+                if p in self.properties:
+                    raise ValueError("%s can only be used with parameters of "
+                                     "the String type." % p)
+        if self.properties['type'] != 'int':
+            for p in self.NUMBER_PROPERTIES:
+                if p in self.properties:
+                    raise ValueError("%s can only be used with parameters of "
+                                     "the Number type." % p)

--- a/troposphere/azure/compute.py
+++ b/troposphere/azure/compute.py
@@ -1,0 +1,161 @@
+from . import ARMObject, ARMRootProperty, ARMProperty
+
+
+class Plan(ARMRootProperty):
+    props = {
+        'name': (str, False),
+        'publisher': (str, False),
+        'product': (str, False),
+        'promotionCode': (str, False)
+    }
+
+
+class HardwareProfile(ARMProperty):
+    # todo add validations
+    props = {
+        'vmSize': (str, False)
+    }
+
+
+class ImageReference(ARMProperty):
+    def __init__(self, title=None, version='latest', **kwargs):
+        kwargs['version'] = version
+        ARMProperty.__init__(self, title, **kwargs)
+
+    # todo add validations
+    props = {
+        'publisher': (str, False),
+        'offer': (str, False),
+        'sku': (str, False),
+        'version': (str, False)
+    }
+
+
+class VirtualHardDisk(ARMProperty):
+    props = {
+        'uri': (str, False)
+    }
+
+
+class ManagedDiskParameters(ARMProperty):
+    props = {
+        'id': (str, False),
+        'storageAccountType': (str, False)  # todo add validation - Standard_LRS or Premium_LRS
+    }
+
+
+class OsDisk(ARMProperty):
+    props = {
+        'osTpe': (str, False),  # todo add validations: Linux/Windows
+        # 'encryptionSettings': (object, False),  # todo add support for encryptionSettings
+        'name': (str, False),
+        'vhd': (VirtualHardDisk, False),
+        'image': (VirtualHardDisk, False),
+        # 'caching': (str, False),  # todo add support
+        'createOption': (str, True),  # todo add validations
+        'diskSizeGB': (int, False),  # todo add validations on max size
+        'managedDisk': (ManagedDiskParameters, False)
+    }
+
+
+class StorageProfile(ARMProperty):
+    props = {
+        'imageReference': (ImageReference, False),
+        'osDisk': (OsDisk, False)
+        # 'dataDisks':  # todo add support
+    }
+
+
+class WindowsConfiguration(ARMProperty):
+    props = {
+        'provisionVMAgent': (bool, False),
+        'enableAutomaticUpdates': (bool, False),
+        'timeZone': (str, False),
+        # 'additionalUnattendContent': (str, False),  # todo add support
+        # 'winRM': (str, False)  # todo add support
+    }
+
+
+class SshPublicKey(ARMProperty):
+    props = {
+        'path': (str, False),
+        'keyData': (str, False)
+    }
+
+
+class SshConfiguration(ARMProperty):
+    props = {
+        'publicKeys': ((list, SshPublicKey), False)
+    }
+
+
+class LinuxConfiguration(ARMProperty):
+    props = {
+        'disablePasswordAuthentication': (bool, False),
+        'ssh': (SshConfiguration, False)
+    }
+
+
+class OSProfile(ARMProperty):
+    # todo add valiation: https://docs.microsoft.com/en-us/azure/templates/microsoft.compute/virtualmachines#OSProfile
+    props = {
+        'computerName': (str, False),
+        'adminUsername': (str, False),
+        'adminPassword': (str, False),
+        'customData': (str, False),
+        'windowsConfiguration': (WindowsConfiguration, False),
+        'linuxConfiguration': (LinuxConfiguration, False)
+        # 'secrets': (, False)  # todo add support
+    }
+
+
+class NetworkInterfaceReferenceProperties(ARMProperty):
+    props = {
+        'primary': (bool, False)
+    }
+
+
+class NetworkInterfaceReference(ARMProperty):
+    props = {
+        'id': (str, False),
+        'properties': (NetworkInterfaceReferenceProperties, False)
+    }
+
+
+class NetworkProfile(ARMProperty):
+    props = {
+        'networkInterfaces': ((list, NetworkInterfaceReference), False)
+    }
+
+
+class BootDiagnostics(ARMProperty):
+    props = {
+        'enabled': (bool, False),
+        'storageUri': (str, False)
+    }
+
+
+class DiagnosticsProfile(ARMProperty):
+    props = {
+        'bootDiagnostics': (BootDiagnostics, False)
+    }
+
+
+class VirtualMachine(ARMObject):
+    resource_type = 'Microsoft.Compute/virtualMachines'
+    apiVersion = "2017-12-01"
+    location = True
+
+    def __init__(self, title, template=None, validation=True, **kwargs):
+        ARMObject.__init__(self, title, template, validation, **kwargs)
+
+    props = {
+        'hardwareProfile': (HardwareProfile, False),
+        'storageProfile': (StorageProfile, False),
+        'osProfile': (OSProfile, False),
+        'networkProfile': (NetworkProfile, False),
+        'diagnosticsProfile': (DiagnosticsProfile, False),
+        # 'availabilitySet': (),  # todo add support
+        # 'licenseType': ()  # todo add support
+        'plan': (Plan, False),
+    }

--- a/troposphere/azure/network.py
+++ b/troposphere/azure/network.py
@@ -1,0 +1,132 @@
+from . import ARMObject, ARMProperty
+
+
+class AddressSpace(ARMProperty):
+    props = {
+        'addressPrefixes': (list, False)
+    }
+
+
+class Subnet(ARMObject):
+    props = {
+        'addressPrefix': (str, False)
+    }
+
+
+class VirtualNetwork(ARMObject):
+    resource_type = 'Microsoft.Network/virtualNetworks'
+    apiVersion = "2017-10-01"
+    location = True
+
+    props = {
+        'addressSpace': (AddressSpace, False),
+        'subnets': ((Subnet, list), False),
+        'tags': (dict, False)
+    }
+
+    def subnet_ref(self, subnet_name):
+        return "[resourceId('Microsoft.Network/virtualNetworks/subnets', '{0}', '{1}')]"\
+            .format(self.title,
+                    self.get_subnet(subnet_name).title)
+
+    def get_subnet(self, subnet_name):
+        return next(iter(filter(lambda x: x.title == subnet_name, self.properties['subnets'])))
+
+    SubnetRef = subnet_ref
+
+
+class SecurityRule(ARMObject):
+    props = {
+        'description': (str, False),  # todo add validation on length
+        'protocol': (str, True),  # todo add valiadtion on valid values: 'Tcp', 'Udp', and '*'
+        'sourcePortRange': (str, False),  # todo add validation for all 'range' props
+        'destinationPortRange': (str, False),
+        'sourceAddressPrefix': (str, False),
+        'sourceAddressPrefixes': ((list, str), False),
+        # 'sourceApplicationSecurityGroups': (str, False),  # todo implement
+        'destinationAddressPrefix': (str, False),
+        'destinationAddressPrefixes': ((list, str), False),
+        # 'destinationApplicationSecurityGroups': (str, False),  # todo implement
+        'sourcePortRanges': (str, False),
+        'destinationPortRanges': (str, False),
+        'access': (str, True),  # todo add validation on values: 'Allow' and 'Deny'
+        'priority': (int, False),
+        'direction': (str, True)  # todo add validation on values: 'Inbound' and 'Outbound'
+    }
+
+
+class SubResource(ARMProperty):
+    props = {
+        'id': (str, False),
+    }
+
+
+class PublicIPAddressDnsSettings(ARMProperty):
+    props = {
+        'domainNameLabel': (str, False),
+        'fqdn': (str, False),
+        'reverseFqdn': (str, False)
+    }
+
+
+class PublicIPAddress(ARMObject):
+    resource_type = 'Microsoft.Network/publicIPAddresses'
+    apiVersion = "2017-10-01"
+    location = True
+
+    props = {
+        'publicIPAllocationMethod': (str, False),  # todo add validation on values: 'Static' and 'Dynamic'
+        'publicIPAddressVersion': (str, False),  # todo add validation on values: 'IPv4' and 'IPv6'. Default is 'IPv4'
+        'dnsSettings': (PublicIPAddressDnsSettings, False),
+        'tags': (dict, False),
+    }
+
+
+class NetworkInterfaceIPConfiguration(ARMObject):
+    props = {
+        # 'applicationGatewayBackendAddressPools': () - not implemented
+        # 'loadBalancerBackendAddressPools': () - not implemented
+        # 'loadBalancerInboundNatRules': () - not implemented
+        'privateIPAddress': (str, False),
+        'privateIPAllocationMethod': (str, False),  # todo add validation on values: 'Static' and 'Dynamic'
+        'privateIPAddressVersion': (str, False),  # todo add validation on values: 'IPv4' and 'IPv6'. Default is 'IPv4'
+        'subnet': (SubResource, False),
+        'primary': (bool, False),
+        'publicIPAddress': (SubResource, False),
+        # 'applicationSecurityGroups': () - not implemented
+    }
+
+
+class NetworkInterfaceDnsSettings(ARMProperty):
+    props = {
+        'dnsServers': ((list, str), False),
+        'appliedDnsServers': ((list, str), False),
+        'internalDnsNameLabel': (str, False),
+        'internalFqdn': (str, False),
+        'internalDomainNameSuffix': (str, False),
+    }
+
+
+class NetworkSecurityGroup(ARMObject):
+    resource_type = 'Microsoft.Network/networkSecurityGroups'
+    apiVersion = "2017-10-01"
+    location = True
+
+    props = {
+        'securityRules': ((list, SecurityRule), False),
+        'tags': (dict, False)
+    }
+
+
+class NetworkInterface(ARMObject):
+    resource_type = 'Microsoft.Network/networkInterfaces'
+    apiVersion = "2017-10-01"
+    location = True
+
+    props = {
+        'virtualMachine': (SubResource, False),
+        'networkSecurityGroup': ((SubResource, NetworkSecurityGroup), False),
+        'ipConfigurations': ((list, NetworkInterfaceIPConfiguration), False),
+        'dnsSettings': (NetworkInterfaceDnsSettings, False),
+        'tags': (dict, False)
+    }

--- a/troposphere/azure/storage.py
+++ b/troposphere/azure/storage.py
@@ -1,0 +1,64 @@
+from . import ARMObject, ARMRootProperty, ARMProperty
+
+
+class Sku(ARMRootProperty):
+    props = {
+        'name': (str, True)  # todo - add validation: Gets or sets the sku name.
+        # todo - Required for account creation; optional for update
+        # todo - values: Standard_LRS, Standard_GRS, Standard_RAGRS, Standard_ZRS, Premium_LRS
+    }
+
+
+class VirtualNetworkRule(ARMProperty):
+    props = {
+        'id': (str, True)
+    }
+
+
+class IPRule(ARMProperty):
+    props = {
+        'value': (str, True)  # Specifies the IP or IP range in CIDR format. Only IPV4 address is allowed.
+    }
+
+
+class NetworkRuleSet(ARMProperty):
+    props = {
+        # 'bypass': (str, False)
+        'virtualNetworkRules': ((list, VirtualNetworkRule), False),
+        'ipRules': ((list, IPRule), False),
+        'defaultAction': (str, True)  # Allow/Deny
+    }
+
+
+# todo add title validaton: 3-24 chars lengths, numbers and lower case letters
+class StorageAccount(ARMObject):
+    resource_type = 'Microsoft.Storage/storageAccounts'
+    apiVersion = "2017-10-01"
+    location = True
+
+    props = {
+        'sku': (Sku, True),  # Required
+        'kind': (str, True),  # Required. Indicates the type of storage account. - Storage, StorageV2, BlobStorage
+        # 'customDomain':
+        # 'encryption':
+        'networkAcls': (NetworkRuleSet, False),
+        'supportsHttpsTrafficOnly': (bool, False),
+        'accessTier': (str, False),
+        'tags': (dict, False)
+    }
+
+    def __init__(self, title, template=None, validation=None, **kwargs):
+        ARMObject.__init__(self, title, template, validation, **kwargs)
+
+        StorageAccount
+        super(StorageAccount, self)._validate_props()
+        self.resource['kind'] = self.properties['kind']
+        del self.properties['kind']
+        del self.props['kind']
+
+    def to_dict(self):
+        # move sku to root
+        if 'sku' in self.properties:
+            self.resource['sku'] = self.properties['sku']
+            del self.properties['sku']
+        return ARMObject.to_dict(self)


### PR DESCRIPTION
- I extended the base objects in troposphere to support Azure ARM templates and modeled the basic compute, networking and storage objects. It is possible to generate fully functional ARM templates with the code in this PR.
- Added unit tests
- In the next PRs I plan to add support for more Azure objects like VM scale sets, ACS, etc. And add more validations to existing objects.