### PR TITLE
add "ServiceRegistries" attribute in AWS::ECS::Service

### DIFF
--- a/troposphere/ecs.py
+++ b/troposphere/ecs.py
@@ -99,6 +99,7 @@ class Service(AWSObject):
         'PlatformVersion': (basestring, False),
         'ServiceName': (basestring, False),
         'TaskDefinition': (basestring, True),
+        'ServiceRegistries': ([dict], False),
     }
 
 


### PR DESCRIPTION
this attribute is for Service Discovery setting which is currently working for cloudformation
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-discovery.html