### PR TITLE
Fix AutoScalingRole in EMR: Fixes #984

### DIFF
--- a/examples/EMR_Cluster.py
+++ b/examples/EMR_Cluster.py
@@ -202,7 +202,7 @@ cluster = template.add_resource(emr.Cluster(
     ],
     JobFlowRole=Ref(emr_instance_profile),
     ServiceRole=Ref(emr_service_role),
-    AutoScalingRole=Ref(emr_autoscaling_role),
+    AutoScalingRole=emr_autoscaling_role,
     Instances=emr.JobFlowInstancesConfig(
         Ec2KeyName=Ref(keyname),
         Ec2SubnetId=Ref(subnet),

--- a/tests/examples_output/EMR_Cluster.template
+++ b/tests/examples_output/EMR_Cluster.template
@@ -87,9 +87,7 @@
                         "Name": "Spark"
                     }
                 ],
-                "AutoScalingRole": {
-                    "Ref": "EMR_AutoScaling_DefaultRole"
-                },
+                "AutoScalingRole": "EMR_AutoScaling_DefaultRole",
                 "BootstrapActions": [
                     {
                         "Name": "Dummy bootstrap action",


### PR DESCRIPTION
changed to
python emr.py | grep EMR_AutoScaling_DefaultRole
                "AutoScalingRole": "EMR_AutoScaling_DefaultRole",

from

python emr.py | grep EMR_AutoScaling_DefaultRole
                    "Ref": "EMR_AutoScaling_DefaultRole"