### PR TITLE
Updated appsync apikey expires to be an int: Fixes #1039

### DIFF
--- a/troposphere/appsync.py
+++ b/troposphere/appsync.py
@@ -4,7 +4,7 @@
 # See LICENSE file for full license.
 
 from . import AWSObject, AWSProperty
-from .validators import boolean
+from .validators import boolean, integer
 
 
 class ApiKey(AWSObject):
@@ -13,7 +13,7 @@ class ApiKey(AWSObject):
     props = {
         'ApiId': (basestring, True),
         'Description': (basestring, False),
-        'Expires': (float, False),
+        'Expires': (integer, False),
     }
 
 


### PR DESCRIPTION
Fixes issue https://github.com/cloudtools/troposphere/issues/1039

The expires prop on the appsync ApiKey class needs to be an int otherwise the decimal place causes cloudformation to throw a `Can not deserialize value of type java.lang.Long from String` error.