### PR TITLE
Fix SES

### DIFF
--- a/troposphere/ses.py
+++ b/troposphere/ses.py
@@ -180,8 +180,8 @@ class EmailTemplate(AWSProperty):
         'TemplateName': (basestring, False),
         'TextPart': (basestring, False),
     }
- 
-    
+
+
 class Template(AWSObject):
     resource_type = "AWS::SES::Template"
 


### PR DESCRIPTION
Fixes the following problem:

Class Template exists twice in this file, this will overwrite the first Template class. Can you please rename Template to EmailTemplate

Inspecting Ses Module...

```
def print_classes():
    for name, obj in inspect.getmembers(ses):
        if inspect.isclass(obj):
            print(obj)

print_classes()

<class 'troposphere.AWSObject'>
<class 'troposphere.AWSProperty'>
<class 'troposphere.ses.Action'>
<class 'troposphere.ses.AddHeaderAction'>
<class 'troposphere.ses.BounceAction'>
<class 'troposphere.ses.CloudWatchDestination'>
<class 'troposphere.ses.ConfigurationSet'>
<class 'troposphere.ses.ConfigurationSetEventDestination'>
<class 'troposphere.ses.DimensionConfiguration'>
<class 'troposphere.ses.EventDestination'>
<class 'troposphere.ses.Filter'>
<class 'troposphere.ses.IpFilter'>
<class 'troposphere.ses.KinesisFirehoseDestination'>
<class 'troposphere.ses.LambdaAction'>
<class 'troposphere.ses.ReceiptFilter'>
<class 'troposphere.ses.ReceiptRule'>
<class 'troposphere.ses.ReceiptRuleSet'>
<class 'troposphere.ses.Rule'>
<class 'troposphere.ses.S3Action'>
<class 'troposphere.ses.SNSAction'>
<class 'troposphere.ses.StopAction'>
<class 'troposphere.ses.Template'>
<class 'troposphere.ses.WorkmailAction'>
{
    "Resources": {},
    "Transform": "AWS::Serverless-2016-10-31"
}

```
And when running the same script on only the Template class...

```
def print_classes():
    for name, obj in inspect.getmembers(ses.Template):
        if inspect.isclass(obj):
            print(obj)

print_classes()

<type 'type'>
{
    "Resources": {},
    "Transform": "AWS::Serverless-2016-10-31"
}
```