### PR TITLE
Allow Ref's to test equality against their data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 sudo: false
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -6,6 +6,7 @@ from troposphere import depends_on_helper
 from troposphere.ec2 import Instance, Route, SecurityGroupRule
 from troposphere.s3 import Bucket
 from troposphere.elasticloadbalancing import HealthCheck
+from troposphere import cloudformation
 from troposphere.validators import positive_integer
 
 
@@ -327,13 +328,17 @@ class TestRef(unittest.TestCase):
         s = "AWS::NoValue"
         r = Ref(s)
 
+        wch = cloudformation.WaitConditionHandle("TestResource")
+
         self.assertEqual(s, r)
         self.assertEqual(s, NoValue)
         self.assertEqual(r, NoValue)
+        self.assertEqual(wch.Ref(), "TestResource")
 
         self.assertNotEqual(r, "AWS::Region")
         self.assertNotEqual(r, Region)
         self.assertNotEqual(r, Ref)
+        self.assertNotEqual(wch.Ref(), "NonexistantResource")
 
 
 class TestName(unittest.TestCase):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,6 +1,7 @@
 import unittest
 from troposphere import AWSObject, AWSProperty, Output, Parameter
 from troposphere import Cidr, If, Join, Ref, Split, Sub, Template
+from troposphere import NoValue, Region
 from troposphere import depends_on_helper
 from troposphere.ec2 import Instance, Route, SecurityGroupRule
 from troposphere.s3 import Bucket
@@ -321,6 +322,18 @@ class TestRef(unittest.TestCase):
         t = Ref(param)
         ref = t.to_dict()
         self.assertEqual(ref['Ref'], 'param')
+
+    def test_ref_eq(self):
+        s = "AWS::NoValue"
+        r = Ref(s)
+
+        self.assertEqual(s, r)
+        self.assertEqual(s, NoValue)
+        self.assertEqual(r, NoValue)
+
+        self.assertNotEqual(r, "AWS::Region")
+        self.assertNotEqual(r, Region)
+        self.assertNotEqual(r, Ref)
 
 
 class TestName(unittest.TestCase):

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -481,6 +481,11 @@ class Ref(AWSHelperFn):
     def __init__(self, data):
         self.data = {'Ref': self.getdata(data)}
 
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.data == other.data
+        return self.data.values()[0] == other
+
 
 # Pseudo Parameter Ref's
 AccountId = Ref(AWS_ACCOUNT_ID)


### PR DESCRIPTION
This is largely used by the Pseudo Parameters, so that these three
properties are all the same:

```
from troposphere import NoValue, Ref

s = "AWS::NoValue"
r = Ref(s)

s == r
s == NoValue
r == NoValue
```

This is in preparation for another PR to fix the validators for
`mutually_exlusive` and `exactly_one` - which should both allow
multiple values provided the values are set to `AWS::NoValue`