### PR TITLE
Allow multiple NoValue properties in mutually_exclusive

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,5 +1,5 @@
 import unittest
-from troposphere import Parameter, Ref
+from troposphere import Parameter, Ref, NoValue
 from troposphere.validators import boolean, integer, integer_range
 from troposphere.validators import positive_integer, network_port
 from troposphere.validators import tg_healthcheck_port
@@ -150,13 +150,25 @@ class TestValidators(unittest.TestCase):
 
     def test_mutually_exclusive(self):
         conds = ['a', 'b', 'c']
-        mutually_exclusive('a', ['a'], conds)
-        mutually_exclusive('b', ['b'], conds)
-        mutually_exclusive('c', ['c'], conds)
+        mutually_exclusive('a', {"a": "apple"}, conds)
+        mutually_exclusive('b', {"b": "banana"}, conds)
+        mutually_exclusive('c', {"c": "carrot"}, conds)
         with self.assertRaises(ValueError):
-            mutually_exclusive('ac', ['a', 'c'], conds)
+            mutually_exclusive('ac', {"a": "apple", "c": "carrot"}, conds)
         with self.assertRaises(ValueError):
-            mutually_exclusive('abc', ['a', 'b', 'c'], conds)
+            mutually_exclusive(
+                'abc', {"a": "apple", "b": "banana", "c": "carrot"}, conds
+            )
+
+    def test_mutually_exclusive_novalue(self):
+        conds = ['a', 'b', 'c']
+        properties = {
+            'a': Ref("AWS::NoValue"),
+            'b': NoValue,
+            'c': "AWS::Region",
+        }
+
+        mutually_exclusive("a", properties, conds)
 
     def test_compliance_level(self):
         for s in ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'INFORMATIONAL',

--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -6,6 +6,8 @@
 import json
 from re import compile
 
+from . import NoValue
+
 
 def boolean(x):
     if x in [True, 1, '1', 'true', 'True']:
@@ -197,7 +199,7 @@ def iam_group_name(group_name):
 def mutually_exclusive(class_name, properties, conditionals):
     found_list = []
     for c in conditionals:
-        if c in properties:
+        if c in properties and not properties[c] == NoValue:
             found_list.append(c)
     seen = set(found_list)
     specified_count = len(seen)


### PR DESCRIPTION
mutually_exclusive ignores the value of properties, only looking at
whether or not they are defined. This causes a bug where you cannot
have two mutually exclusive properties, even if the value of those
properties is AWS::NoValue, which is allowed by cloudformation.