### PR TITLE
Allow Refs to be hashable using their data

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -349,6 +349,22 @@ class TestRef(unittest.TestCase):
         self.assertNotEqual(r, Ref)
         self.assertNotEqual(wch.Ref(), "NonexistantResource")
 
+    def test_ref_hash(self):
+        s = hash("AWS::NoValue")
+        r = hash(Ref(s))
+
+        wch = cloudformation.WaitConditionHandle("TestResource")
+
+        self.assertEqual(s, r)
+        self.assertEqual(s, hash(NoValue))
+        self.assertEqual(r, hash(NoValue))
+        self.assertEqual(hash(wch.Ref()), hash("TestResource"))
+
+        self.assertNotEqual(r, hash("AWS::Region"))
+        self.assertNotEqual(r, hash(Region))
+        self.assertNotEqual(r, hash(Ref))
+        self.assertNotEqual(hash(wch.Ref()), hash("NonexistantResource"))
+
 
 class TestName(unittest.TestCase):
 

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -493,6 +493,9 @@ class Ref(AWSHelperFn):
             return self.data == other.data
         return self.data.values()[0] == other
 
+    def __hash__(self):
+        return hash(self.data.values()[0])
+
 
 # Pseudo Parameter Ref's
 AccountId = Ref(AWS_ACCOUNT_ID)


### PR DESCRIPTION
With the addition of the `__eq__` method (#1048), Refs are no longer hashable. This PR should revert to the previous behavior.