### PR TITLE
Fix to_yaml long_form parameter

### DIFF
--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -646,7 +646,7 @@ class Template(object):
                           sort_keys=sort_keys, separators=separators)
 
     def to_yaml(self, long_form=False):
-        return cfn_flip.to_yaml(self.to_json(), long_form)
+        return cfn_flip.to_yaml(self.to_json(), long_form=long_form)
 
 
 class Export(AWSHelperFn):

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -645,8 +645,8 @@ class Template(object):
         return json.dumps(self.to_dict(), indent=indent,
                           sort_keys=sort_keys, separators=separators)
 
-    def to_yaml(self, long_form=False):
-        return cfn_flip.to_yaml(self.to_json(), long_form=long_form)
+    def to_yaml(self, clean_up=False, long_form=False):
+        return cfn_flip.to_yaml(self.to_json(), clean_up=clean_up, long_form=long_form)
 
 
 class Export(AWSHelperFn):

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -646,7 +646,8 @@ class Template(object):
                           sort_keys=sort_keys, separators=separators)
 
     def to_yaml(self, clean_up=False, long_form=False):
-        return cfn_flip.to_yaml(self.to_json(), clean_up=clean_up, long_form=long_form)
+        return cfn_flip.to_yaml(self.to_json(), clean_up=clean_up,
+                                long_form=long_form)
 
 
 class Export(AWSHelperFn):


### PR DESCRIPTION
Since the update to use cfn_flip 1.0.2, the `long_form` parameter of `to_yaml` was being incorrectly passed to the `clean_up` parameter of `cfn_flip.to_yaml`. This fixes that, and also add `clean_up` as an actual parameter.