### PR TITLE
Adding CENTOS to validators.operating_system

### DIFF
--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -290,7 +290,7 @@ def compliance_level(level):
 
 def operating_system(os):
     valid_os = ['WINDOWS', 'AMAZON_LINUX', 'UBUNTU', 'REDHAT_ENTERPRISE_LINUX',
-                'SUSE']
+                'SUSE', 'CENTOS']
     if os not in valid_os:
         raise ValueError(
             'OperatingSystem must be one of: "%s"' % (


### PR DESCRIPTION
CENTOS is supported by SSM
http://boto3.readthedocs.io/en/latest/reference/services/ssm.html#SSM.Client.create_patch_baseline

response = client.create_patch_baseline(
    OperatingSystem='WINDOWS'|'AMAZON_LINUX'|'UBUNTU'|'REDHAT_ENTERPRISE_LINUX'|'SUSE'|'CENTOS',
    Name=....