### PR TITLE
Add CentOS to SSM supported OS

### DIFF
--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -290,7 +290,7 @@ def compliance_level(level):
 
 def operating_system(os):
     valid_os = ['WINDOWS', 'AMAZON_LINUX', 'UBUNTU', 'REDHAT_ENTERPRISE_LINUX',
-                'SUSE']
+                'SUSE', 'CENTOS']
     if os not in valid_os:
         raise ValueError(
             'OperatingSystem must be one of: "%s"' % (


### PR DESCRIPTION
Centos is now supported by AWS SSM.