### PR TITLE
fix casing of CpuCredits

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -146,7 +146,7 @@ class Placement(AWSProperty):
 
 class CreditSpecification(AWSProperty):
     props = {
-        'CPUCredits': (basestring, False),
+        'CpuCredits': (basestring, False),
     }
 
 


### PR DESCRIPTION
This fixes the following error:
```
Property validation failure: [Encountered unsupported properties in {/LaunchTemplateData/CreditSpecification}: [CPUCredits]]
```