### PR TITLE
Add 'Name' property for AWS::Serverless::Api

### DIFF
--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -88,6 +88,7 @@ class Api(AWSObject):
 
     props = {
         'StageName': (basestring, True),
+        'Name': (basestring, False),
         'DefinitionBody': (dict, False),
         'DefinitionUri': (basestring, False),
         'CacheClusterEnabled': (bool, False),


### PR DESCRIPTION
Add the missing 'Name' property for AWS::Serverless::Api resource type. (See the document [here](https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessapi))