### PR TITLE
Add equality methods to Template

### DIFF
--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -66,5 +66,49 @@ class TestValidate(unittest.TestCase):
             template.add_mapping("mapping", {"n": "v"})
 
 
+class TestEquality(unittest.TestCase):
+    def test_eq(self):
+        metadata = 'foo'
+        description = 'bar'
+        resource = Bucket('Baz')
+        output = Output('qux', Value='qux')
+
+        t1 = Template(Description=description, Metadata=metadata)
+        t1.add_resource(resource)
+        t1.add_output(output)
+
+        t2 = Template(Description=description, Metadata=metadata)
+        t2.add_resource(resource)
+        t2.add_output(output)
+
+        self.assertEqual(t1, t2)
+
+    def test_ne(self):
+        t1 = Template(Description='foo1', Metadata='bar1')
+        t1.add_resource(Bucket('Baz1'))
+        t1.add_output(Output('qux1', Value='qux1'))
+
+        t2 = Template(Description='foo2', Metadata='bar2')
+        t2.add_resource(Bucket('Baz2'))
+        t2.add_output(Output('qux2', Value='qux2'))
+
+        self.assertNotEqual(t1, t2)
+
+    def test_hash(self):
+        metadata = 'foo'
+        description = 'bar'
+        resource = Bucket('Baz')
+        output = Output('qux', Value='qux')
+
+        t1 = Template(Description=description, Metadata=metadata)
+        t1.add_resource(resource)
+        t1.add_output(output)
+
+        t2 = Template(Description=description, Metadata=metadata)
+        t2.add_resource(resource)
+        t2.add_output(output)
+
+        self.assertEqual(len(set([t1, t2])), 1)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -110,5 +110,6 @@ class TestEquality(unittest.TestCase):
 
         self.assertEqual(len(set([t1, t2])), 1)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -652,6 +652,18 @@ class Template(object):
         return cfn_flip.to_yaml(self.to_json(), clean_up=clean_up,
                                 long_form=long_form)
 
+    def __eq__(self, other):
+        if isinstance(other, Template):
+            return (self.to_json() == other.to_json())
+        else:
+            return false
+
+    def __ne__(self, other):
+        return (not self.__eq__(other))
+
+    def __hash__(self):
+        return hash(self.to_json())
+
 
 class Export(AWSHelperFn):
     def __init__(self, name):

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -656,7 +656,7 @@ class Template(object):
         if isinstance(other, Template):
             return (self.to_json() == other.to_json())
         else:
-            return false
+            return False
 
     def __ne__(self, other):
         return (not self.__eq__(other))


### PR DESCRIPTION
This change adds support for `__eq__()`, `__ne__()`, and `__hash__()` to `Template` objects. `to_json()` is used to test for equivalency and to generate the hash.

The following will be available to `Templates`:

- equality testing
```
>>> t1 = Template(Description='foo')
>>> t2 = Template(Description='foo')
>>> t1 == t2
True
```

- inequality testing
```
>>> t1 = Template(Description='foo')
>>> t2 = Template(Description='bar')
>>> t1 == t2
False
```

- usage in sets
```
>>> t1 = Template(Description='foo')
>>> t2 = Template(Description='foo')
>>> len(set([t1, t2]))
1
>>> t1 = Template(Description='foo')
>>> t2 = Template(Description='bar')
>>> len(set([t1, t2]))
2
```
