### PR TITLE
Fix validator for SSM MaintenanceWindowTask TaskType

### DIFF
--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -266,7 +266,7 @@ def notification_event(events):
 
 
 def task_type(task):
-    valid_tasks = ['RUN_COMMAND', 'AUTOMATION', 'LAMBDA', 'STEP_FUNCTION']
+    valid_tasks = ['RUN_COMMAND', 'AUTOMATION', 'LAMBDA', 'STEP_FUNCTIONS']
     if task not in valid_tasks:
         raise ValueError(
             'TaskType must be one of: "%s"' % (


### PR DESCRIPTION
It appears the documentation (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtask.html#cfn-ssm-maintenancewindowtask-tasktype) is not correct, and that SSM actually requires the string STEP_FUNCTIONS.

e.g.
![image](https://user-images.githubusercontent.com/39393004/41697907-93ec2628-755e-11e8-8928-06c7e8803ab8.png)
