### PR TITLE
Fixed validator for task_type for SSM MaintenanceWindowTask

### DIFF
--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -266,7 +266,7 @@ def notification_event(events):
 
 
 def task_type(task):
-    valid_tasks = ['RUN_COMMAND', 'AUTOMATION', 'LAMBDA', 'STEP_FUNCTION']
+    valid_tasks = ['RUN_COMMAND', 'AUTOMATION', 'LAMBDA', 'STEP_FUNCTIONS']
     if task not in valid_tasks:
         raise ValueError(
             'TaskType must be one of: "%s"' % (


### PR DESCRIPTION
[Cloudformation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtask.html#cfn-ssm-maintenancewindowtask-tasktype) says that "STEP_FUNCTION" is a valid task type. Troposphere's validators.py currently follows this. 

However, Cloudformation and the SSM console say that the correct string is "STEP_FUNCTIONS":
![image](https://user-images.githubusercontent.com/39393004/41699296-8f97e866-7566-11e8-8f33-ed3ba1da737d.png)
