### PR TITLE
Add return value to template.add_condition()

### DIFF
--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -576,6 +576,7 @@ class Template(object):
 
     def add_condition(self, name, condition):
         self.conditions[name] = condition
+        return name
 
     def handle_duplicate_key(self, key):
         raise ValueError('duplicate key "%s" detected' % key)


### PR DESCRIPTION
By returning the `name` from the add_condition() call, it becomes easier
to re-use a created condition later on, without repeating yourself:

> condition_name = "aCondition"
> template.add_condition(condition_name, Equals(Ref(param), ''))
> template.add_resource(Something("res", Condition=condition_name))

Would become:

> condition_name = template.add_condition("aCondition", Equals(Ref(param), ''))
> template.add_resource(Something("res", Condition=condition_name))


Since add_condition() currently does not return anything, it is highly unlikely this will break anything.