### PR TITLE
Add support for Windows containers in CodeBuild

### DIFF
--- a/tests/test_codebuild.py
+++ b/tests/test_codebuild.py
@@ -1,0 +1,21 @@
+import unittest
+
+from troposphere import codebuild
+
+
+class TestCodeBuild(unittest.TestCase):
+    def test_linux_environment(self):
+        environment = codebuild.Environment(
+            ComputeType='BUILD_GENERAL1_SMALL',
+            Image='aws/codebuild/ubuntu-base:14.04',
+            Type='LINUX_CONTAINER'
+        )
+        environment.to_dict()
+
+    def test_windows_environment(self):
+        environment = codebuild.Environment(
+            ComputeType='BUILD_GENERAL1_LARGE',
+            Image='aws/codebuild/windows-base:1.0',
+            Type='WINDOWS_CONTAINER'
+        )
+        environment.to_dict()

--- a/troposphere/codebuild.py
+++ b/troposphere/codebuild.py
@@ -85,6 +85,7 @@ class Environment(AWSProperty):
     def validate(self):
         valid_types = [
             'LINUX_CONTAINER',
+            'WINDOWS_CONTAINER',
         ]
         env_type = self.properties.get('Type')
         if env_type not in valid_types:


### PR DESCRIPTION
This adds `WINDOWS_CONTAINER` to the valid list of environment types for a CodeBuild `Environment`.

See [here](https://docs.aws.amazon.com/codebuild/latest/userguide/create-project.html#create-project-cli) for docs.