### PR TITLE
Add basestring to allowed types for Code property of Function class

### DIFF
--- a/troposphere/awslambda.py
+++ b/troposphere/awslambda.py
@@ -90,6 +90,9 @@ class Code(AWSProperty):
             )
 
 
+codetypes = Code, basestring
+
+
 class VPCConfig(AWSProperty):
 
     props = {
@@ -135,7 +138,7 @@ class Function(AWSObject):
     resource_type = "AWS::Lambda::Function"
 
     props = {
-        'Code': (Code, True),
+        'Code': (codetypes, True),
         'Description': (basestring, False),
         'DeadLetterConfig': (DeadLetterConfig, False),
         'Environment': (Environment, False),


### PR DESCRIPTION
In order to use the "aws package" command, we need to be able to provide a file/folder path to the Function resource as a simple string value.