### PR TITLE
Fix CPUCredits casing and create LaunchTemplateCreditSpecification class

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -147,7 +147,7 @@ class Placement(AWSProperty):
 
 class CreditSpecification(AWSProperty):
     props = {
-        'CpuCredits': (basestring, False),
+        'CPUCredits': (basestring, False),
     }
 
 
@@ -820,10 +820,16 @@ class InstanceMarketOptions(AWSProperty):
     }
 
 
+class LaunchTemplateCreditSpecification(AWSProperty):
+    props = {
+        'CpuCredits': (basestring, False),
+    }
+
+
 class LaunchTemplateData(AWSProperty):
     props = {
         'BlockDeviceMappings': ([BlockDeviceMapping], False),
-        'CreditSpecification': (CreditSpecification, False),
+        'CreditSpecification': (LaunchTemplateCreditSpecification, False),
         'DisableApiTermination': (boolean, False),
         'EbsOptimized': (boolean, False),
         'ElasticGpuSpecifications': ([ElasticGpuSpecification], False),


### PR DESCRIPTION
Change corrects the casing for the `CreditSpecification` class's `CPUCredits` object as documented at https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-creditspecification.html

Change also implements a `LaunchTemplateCreditSpecification` class with the correct case for that object.

Fixes #1099 