### PR TITLE
Add UsernameAttributes to Cognito

### DIFF
--- a/troposphere/cognito.py
+++ b/troposphere/cognito.py
@@ -191,6 +191,7 @@ class UserPool(AWSObject):
         'SmsAuthenticationMessage': (basestring, False),
         'SmsConfiguration': (SmsConfiguration, False),
         'SmsVerificationMessage': (basestring, False),
+        'UsernameAttributes': ([basestring], False),
         'UserPoolTags': (dict, False),
     }
 


### PR DESCRIPTION
I was trying to setup a Cognito User Pool and noticed that the UserPool object was missing the `UsernameAttributes` field.

From the docs:

> Specifies whether email addresses or phone numbers can be specified as usernames when a user signs up. Possible values: phone_number or email.
> Required: No
> Type: List of String values

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpool.html#cfn-cognito-userpool-usernameattributes