### PR TITLE
Changed policy to AmazonDynamoDBFullAccess for delete and put

### DIFF
--- a/examples/Serverless_Api_Backend.py
+++ b/examples/Serverless_Api_Backend.py
@@ -45,7 +45,7 @@ t.add_resource(
         Handler='index.put',
         Runtime='nodejs4.3',
         CodeUri='s3://<bucket>/api_backend.zip',
-        Policies='AmazonDynamoDBReadOnlyAccess',
+        Policies='AmazonDynamoDBFullAccess',
         Environment=Environment(
             Variables={
                 'TABLE_NAME': Ref(simple_table)
@@ -67,7 +67,7 @@ t.add_resource(
         Handler='index.delete',
         Runtime='nodejs4.3',
         CodeUri='s3://<bucket>/api_backend.zip',
-        Policies='AmazonDynamoDBReadOnlyAccess',
+        Policies='AmazonDynamoDBFullAccess',
         Environment=Environment(
             Variables={
                 'TABLE_NAME': Ref(simple_table)

--- a/tests/examples_output/Serverless_Api_Backend.template
+++ b/tests/examples_output/Serverless_Api_Backend.template
@@ -21,7 +21,7 @@
                     }
                 },
                 "Handler": "index.delete",
-                "Policies": "AmazonDynamoDBReadOnlyAccess",
+                "Policies": "AmazonDynamoDBFullAccess",
                 "Runtime": "nodejs4.3"
             },
             "Type": "AWS::Serverless::Function"
@@ -71,7 +71,7 @@
                     }
                 },
                 "Handler": "index.put",
-                "Policies": "AmazonDynamoDBReadOnlyAccess",
+                "Policies": "AmazonDynamoDBFullAccess",
                 "Runtime": "nodejs4.3"
             },
             "Type": "AWS::Serverless::Function"


### PR DESCRIPTION
AmazonDynamoDBFullAccess is required for put or delete, and is consistent with AWS Labs example