### PR TITLE
Schedule expression validation

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -220,59 +220,63 @@ class TestValidators(unittest.TestCase):
                 event_schedule_expression(s)
 
         for s in [
-            'cron(* * * * * *)', 'cron(*   *   *   *   *   *)',
+            'cron(* * ? * * *)', 'cron(*   *   ?   *   *   *)',
             # Minutes
-            'cron(0 * * * * *)', 'cron(1 * * * * *)', 'cron(59 * * * * *)',
-            'cron(, * * * * *)', 'cron(- * * * * *)', 'cron(/ * * * * *)',
+            'cron(0 * ? * * *)', 'cron(1 * ? * * *)', 'cron(59 * ? * * *)',
+            'cron(, * ? * * *)', 'cron(- * ? * * *)', 'cron(/ * ? * * *)',
             # Hours
-            'cron(* 0 * * * *)', 'cron(* 1 * * * *)', 'cron(* 23 * * * *)',
-            'cron(* , * * * *)', 'cron(* - * * * *)', 'cron(* / * * * *)',
+            'cron(* 0 ? * * *)', 'cron(* 1 ? * * *)', 'cron(* 23 ? * * *)',
+            'cron(* , ? * * *)', 'cron(* - ? * * *)', 'cron(* / ? * * *)',
             # Day-of-month
-            'cron(* * 1 * * *)', 'cron(* * 31 * * *)',
-            'cron(* * , * * *)', 'cron(* * - * * *)', 'cron(* * / * * *)',
-            'cron(* * ? * * *)', 'cron(* * / * * *)', 'cron(* * L * * *)',
-            'cron(* * W * * *)',
+            'cron(* * 1 * ? *)', 'cron(* * 31 * ? *)',
+            'cron(* * , * ? *)', 'cron(* * - * ? *)', 'cron(* * / * ? *)',
+            'cron(* * ? * * *)', 'cron(* * / * ? *)', 'cron(* * L * ? *)',
+            'cron(* * W * ? *)',
             # Month
-            'cron(* * * 1 * *)', 'cron(* * * 12 * *)',
-            'cron(* * * JAN * *)', 'cron(* * * FEB * *)',
-            'cron(* * * MAR * *)', 'cron(* * * APR * *)',
-            'cron(* * * MAY * *)', 'cron(* * * JUN * *)',
-            'cron(* * * JUL * *)', 'cron(* * * AUG * *)',
-            'cron(* * * SEP * *)', 'cron(* * * OCT * *)',
-            'cron(* * * NOV * *)', 'cron(* * * DEC * *)',
-            'cron(* * * , * *)', 'cron(* * * - * *)', 'cron(* * * / * *)',
+            'cron(* * ? 1 * *)', 'cron(* * ? 12 * *)',
+            'cron(* * ? JAN * *)', 'cron(* * ? FEB * *)',
+            'cron(* * ? MAR * *)', 'cron(* * ? APR * *)',
+            'cron(* * ? MAY * *)', 'cron(* * ? JUN * *)',
+            'cron(* * ? JUL * *)', 'cron(* * ? AUG * *)',
+            'cron(* * ? SEP * *)', 'cron(* * ? OCT * *)',
+            'cron(* * ? NOV * *)', 'cron(* * ? DEC * *)',
+            'cron(* * ? , * *)', 'cron(* * ? - * *)', 'cron(* * ? / * *)',
             # Day-of-week
-            'cron(* * * * 1 *)', 'cron(* * * * 7 *)', 'cron(* * * * SUN *)',
-            'cron(* * * * MON *)', 'cron(* * * * TUE *)',
-            'cron(* * * * WED *)', 'cron(* * * * THU *)',
-            'cron(* * * * FRI *)', 'cron(* * * * SAT *)',
-            'cron(* * * * , *)', 'cron(* * * * - *)', 'cron(* * * * ? *)',
-            'cron(* * * * L *)', 'cron(* * * * # *)',
+            'cron(* * ? * 1 *)', 'cron(* * ? * 7 *)', 'cron(* * ? * SUN *)',
+            'cron(* * ? * MON *)', 'cron(* * ? * TUE *)',
+            'cron(* * ? * WED *)', 'cron(* * ? * THU *)',
+            'cron(* * ? * FRI *)', 'cron(* * ? * SAT *)',
+            'cron(* * ? * , *)', 'cron(* * ? * - *)', 'cron(* * * * ? *)',
+            'cron(* * ? * L *)', 'cron(* * ? * # *)',
             # Year
-            'cron(* * * * * 1970)', 'cron(* * * * * 2000)',
-            'cron(* * * * * 2020)', 'cron(* * * * * 2199)',
-            'cron(* * * * * ,)', 'cron(* * * * * -)', 'cron(* * * * * /)',
+            'cron(* * ? * * 1970)', 'cron(* * ? * * 2000)',
+            'cron(* * ? * * 2020)', 'cron(* * ? * * 2199)',
+            'cron(* * ? * * ,)', 'cron(* * ? * * -)', 'cron(* * ? * * /)',
+            #  Limit: Day-of-month / Day-of-week
+            'cron(* * 1 * ? *)', 'cron(* * ? * 1 *)',
+            'cron(* * * * ? *)', 'cron(* * ? * * *)',
         ]:
             event_schedule_expression(s)
         for s in [
             'cron(*)', 'cron(* )',
             # Minutes
-            'cron(60 * * * * *)', 'cron(a * * * * *)',
+            'cron(60 * ? * * *)', 'cron(a * ? * * *)',
             # Hours
-            'cron(* 24 * * * *)', 'cron(* a * * * *)',
+            'cron(* 24 ? * * *)', 'cron(* a ? * * *)',
             # Day-of-month
-            'cron(* * 0 * * *)', 'cron(* * 32 * * *)', 'cron(* * a * * *)',
+            'cron(* * 0 * ? *)', 'cron(* * 32 * ? *)', 'cron(* * a * ? *)',
             # Month
-            'cron(* * * 0 * *)', 'cron(* * * 13 * *)', 'cron(* * * ZZZ * *)',
+            'cron(* * ? 0 * *)', 'cron(* * ? 13 * *)', 'cron(* * ? ZZZ * *)',
             # Day-of-week
-            'cron(* * * * 0 *)', 'cron(* * * * 8 *)', 'cron(* * * * a *)',
-            'cron(* * * * ZZZ *)'
+            'cron(* * ? * 0 *)', 'cron(* * ? * 8 *)', 'cron(* * ? * a *)',
+            'cron(* * ? * ZZZ *)'
             # Year
-            'cron(* * * * * 1969)', 'cron(* * * * * 2200)',
-            'cron(* * * * * a)', 'cron(* * * * * aaaa)',
+            'cron(* * ? * * 1969)', 'cron(* * ? * * 2200)',
+            'cron(* * ? * * a)', 'cron(* * ? * * aaaa)',
+            #  Limit: Day-of-month / Day-of-week
+            'cron(* * 1 * 1 *)', 'cron(* * * * * *)'
         ]:
             with self.assertRaises(ValueError):
-                print(s)
                 event_schedule_expression(s)
 
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -9,6 +9,7 @@ from troposphere.validators import iam_group_name, iam_user_name, elb_name
 from troposphere.validators import mutually_exclusive, notification_type
 from troposphere.validators import notification_event, task_type
 from troposphere.validators import compliance_level, operating_system
+from troposphere.validators import event_schedule_expression
 
 
 class TestValidators(unittest.TestCase):
@@ -207,6 +208,72 @@ class TestValidators(unittest.TestCase):
         for s in ['', 'foo', 'a', 'l@mbda', 'STEPFUNCTION']:
             with self.assertRaises(ValueError):
                 task_type(s)
+
+    def test_event_schedule_expression(self):
+        for s in ['rate(1 minute)', 'rate(1 hour)', 'rate(1 day)',
+                  'rate(99 minutes)', 'rate(99 hours)', 'rate(99 days)',
+                  'rate(1     day)', 'rate(99     days)']:
+            event_schedule_expression(s)
+        for s in ['', 'rate 1 min', 'rate(1 minutes)', 'rate(1 hours)',
+                  'rate(1 days)', 'rate(1day)']:
+            with self.assertRaises(ValueError):
+                event_schedule_expression(s)
+
+        for s in [
+            'cron(* * * * * *)', 'cron(*   *   *   *   *   *)',
+            # Minutes
+            'cron(0 * * * * *)', 'cron(1 * * * * *)', 'cron(59 * * * * *)',
+            'cron(, * * * * *)', 'cron(- * * * * *)', 'cron(/ * * * * *)',
+            # Hours
+            'cron(* 0 * * * *)', 'cron(* 1 * * * *)', 'cron(* 23 * * * *)',
+            'cron(* , * * * *)', 'cron(* - * * * *)', 'cron(* / * * * *)',
+            # Day-of-month
+            'cron(* * 1 * * *)', 'cron(* * 31 * * *)',
+            'cron(* * , * * *)', 'cron(* * - * * *)', 'cron(* * / * * *)',
+            'cron(* * ? * * *)', 'cron(* * / * * *)', 'cron(* * L * * *)',
+            'cron(* * W * * *)',
+            # Month
+            'cron(* * * 1 * *)', 'cron(* * * 12 * *)',
+            'cron(* * * JAN * *)', 'cron(* * * FEB * *)',
+            'cron(* * * MAR * *)', 'cron(* * * APR * *)',
+            'cron(* * * MAY * *)', 'cron(* * * JUN * *)',
+            'cron(* * * JUL * *)', 'cron(* * * AUG * *)',
+            'cron(* * * SEP * *)', 'cron(* * * OCT * *)',
+            'cron(* * * NOV * *)', 'cron(* * * DEC * *)',
+            'cron(* * * , * *)', 'cron(* * * - * *)', 'cron(* * * / * *)',
+            # Day-of-week
+            'cron(* * * * 1 *)', 'cron(* * * * 7 *)', 'cron(* * * * SUN *)',
+            'cron(* * * * MON *)', 'cron(* * * * TUE *)',
+            'cron(* * * * WED *)', 'cron(* * * * THU *)',
+            'cron(* * * * FRI *)', 'cron(* * * * SAT *)',
+            'cron(* * * * , *)', 'cron(* * * * - *)', 'cron(* * * * ? *)',
+            'cron(* * * * L *)', 'cron(* * * * # *)',
+            # Year
+            'cron(* * * * * 1970)', 'cron(* * * * * 2000)',
+            'cron(* * * * * 2020)', 'cron(* * * * * 2199)',
+            'cron(* * * * * ,)', 'cron(* * * * * -)', 'cron(* * * * * /)',
+        ]:
+            event_schedule_expression(s)
+        for s in [
+            'cron(*)', 'cron(* )',
+            # Minutes
+            'cron(60 * * * * *)', 'cron(a * * * * *)',
+            # Hours
+            'cron(* 24 * * * *)', 'cron(* a * * * *)',
+            # Day-of-month
+            'cron(* * 0 * * *)', 'cron(* * 32 * * *)', 'cron(* * a * * *)',
+            # Month
+            'cron(* * * 0 * *)', 'cron(* * * 13 * *)', 'cron(* * * ZZZ * *)',
+            # Day-of-week
+            'cron(* * * * 0 *)', 'cron(* * * * 8 *)', 'cron(* * * * a *)',
+            'cron(* * * * ZZZ *)'
+            # Year
+            'cron(* * * * * 1969)', 'cron(* * * * * 2200)',
+            'cron(* * * * * a)', 'cron(* * * * * aaaa)',
+        ]:
+            with self.assertRaises(ValueError):
+                print(s)
+                event_schedule_expression(s)
 
 
 if __name__ == '__main__':

--- a/troposphere/events.py
+++ b/troposphere/events.py
@@ -4,6 +4,7 @@
 # See LICENSE file for full license.
 
 from . import AWSObject, AWSProperty
+from .validators import event_schedule_expression
 
 
 class EcsParameters(AWSProperty):
@@ -61,7 +62,7 @@ class Rule(AWSObject):
         'Description': (basestring, False),
         'EventPattern': (dict, False),
         'Name': (basestring, False),
-        'ScheduleExpression': (basestring, False),
+        'ScheduleExpression': (event_schedule_expression, False),
         'State': (basestring, False),
         'Targets': ([Target], False),
     }

--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -375,7 +375,6 @@ def event_schedule_expression(expression):
             % expression
         )
 
-    # r"[^\s]+\s+"
     rule_DoW_DoM = compile(
         r"^(rate\(.*|cron\("
         r"[^\s]+\s+"                        # Minutes

--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -374,4 +374,34 @@ def event_schedule_expression(expression):
             'The following is not a valid expression: "%s"'
             % expression
         )
+
+    # r"[^\s]+\s+"
+    rule_DoW_DoM = compile(
+        r"^(rate\(.*|cron\("
+        r"[^\s]+\s+"                        # Minutes
+        r"[^\s]+\s+"                     # Hours
+        r"(\?) +"             # Day-of-month
+        r"[^\s]+\s+"                            # Month
+        r"(\*|[,\-/L#]|[1-7]|SUN|MON|TUE|WED|THU|FRI|SAT) +"   # Day-of-month
+        r"[^\s]+"
+        r"\)|"
+        r"cron\("
+        r"[^\s]+\s+"                        # Minutes
+        r"[^\s]+\s+"                     # Hours
+        r"(\*|[,\-/LW]|[1-9]|[1-2][0-9]|3[0-1]) +"             # Day-of-month
+        r"[^\s]+\s+"                            # Month
+        r"(\?) +"   # Day-of-month
+        r"[^\s]+"
+        r"\))$"
+    )
+
+    if not rule_DoW_DoM.match(expression):
+        raise ValueError(
+            'You can\'t specify the Day-of-month and Day-of-week fields '
+            'in the same cron expression. If you specify a value (or a *) '
+            'in one of the fields, you must use a ? (question mark) in '
+            ' the other. : "%s"'
+            % expression
+        )
+
     return(expression)

--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -350,3 +350,28 @@ def vpc_endpoint_type(endpoint_type):
             )
         )
     return(endpoint_type)
+
+
+def event_schedule_expression(expression):
+    rate_re = compile(
+        r"^rate\((1 +(minute|hour|day)|"
+        r"(?:[2-9]|\d\d\d*) +(minutes|hours|days))\)$"
+    )
+    cron_re = compile(
+        r"^cron\("
+        r"(\*|[,\-/]|[0-9]|[1-5][0-9]) +"                        # Minutes
+        r"(\*|[,\-/]|[0-9]|1[0-9]|2[0-3]) +"                     # Hours
+        r"(\*|[,\-/\?LW]|[1-9]|[1-2][0-9]|3[0-1]) +"             # Day-of-month
+        r"(\*|[,\-/]|[1-9]|11|12|" +                             # Month
+        r"JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC) +"
+        r"(\*|[,\-/\?L#]|[1-7]|SUN|MON|TUE|WED|THU|FRI|SAT) +"   # Day-of-month
+        r"(\*|[,\-/]|19[7-9][0-9]|2[0-1][0-9][0-9])"
+        r"\)$"
+    )
+
+    if not (rate_re.match(expression) or cron_re.match(expression)):
+        raise ValueError(
+            'The following is not a valid expression: "%s"'
+            % expression
+        )
+    return(expression)


### PR DESCRIPTION
This is the enhancement described in the "help wanted" ticket #1052

The behaviour of the validator has been tested agains the values that should be expected.

I'm not entirely sure of the style but this validation will save many users time debugging the cron/rate expressions when using troposphere.