### PR TITLE
Add get_or_add parameter method

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -236,6 +236,22 @@ class TestParameter(unittest.TestCase):
         with self.assertRaises(ValueError):
             t.to_json()
 
+    def test_get_or_add_adds(self):
+        t = Template()
+        p = Parameter("param", Type="String", Default="foo")
+        result = t.get_or_add_parameter(p)
+        self.assertEquals(t.parameters["param"], p)
+        self.assertEquals(result, p)
+
+    def test_add_or_get_returns_with_out_adding_duplicate(self):
+        t = Template()
+        p = Parameter("param", Type="String", Default="foo")
+        t.add_parameter(p)
+        result = t.get_or_add_parameter(p)
+        self.assertEquals(t.parameters["param"], p)
+        self.assertEquals(result, p)
+        self.assertEquals(len(t.parameters), 1)
+
     def test_property_default(self):
         p = Parameter("param", Type="String", Default="foo")
         p.validate()

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -611,6 +611,13 @@ class Template(object):
             raise ValueError('Maximum parameters %d reached' % MAX_PARAMETERS)
         return self._update(self.parameters, parameter)
 
+    def get_or_add_parameter(self, parameter):
+        if parameter.title in self.parameters:
+            return self.parameters[parameter.title]
+        else:
+            self.add_parameter(parameter)
+        return parameter
+
     def add_resource(self, resource):
         if len(self.resources) >= MAX_RESOURCES:
             raise ValueError('Maximum number of resources %d reached'


### PR DESCRIPTION
When writing reuable methods to add resources and parameters to a template to abstract a common pattern it is often the case that we want to get a parameter that we know may already be inside the template, depending on what the end user has already called.  This PR adds a method which will add a parameter if it's not already there and otherwise return it.