### PR TITLE
Added HealthCheckCustomConfig to ServiceDiscovery Service

### DIFF
--- a/troposphere/servicediscovery.py
+++ b/troposphere/servicediscovery.py
@@ -43,6 +43,12 @@ class HealthCheckConfig(AWSProperty):
     }
 
 
+class HealthCheckCustomConfig(AWSProperty):
+    props = {
+        'FailureThreshold': (float, True)
+    }
+
+
 class DnsRecord(AWSProperty):
     props = {
         'TTL': (basestring, True),
@@ -64,5 +70,6 @@ class Service(AWSObject):
         'Description': (basestring, False),
         'DnsConfig': (DnsConfig, True),
         'HealthCheckConfig': (HealthCheckConfig, False),
+        'HealthCheckCustomConfig': (HealthCheckCustomConfig, False),
         'Name': (basestring, False),
     }


### PR DESCRIPTION
Documentation for this property is available here: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicediscovery-service.html
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-servicediscovery-service-healthcheckcustomconfig.html

It is needed to solve issues with CloudFormation and ServiceDiscovery in ECS, ref: https://forums.aws.amazon.com/thread.jspa?messageID=858305