### PR TITLE
Tags support for SQS queues

### DIFF
--- a/troposphere/sqs.py
+++ b/troposphere/sqs.py
@@ -3,7 +3,7 @@
 #
 # See LICENSE file for full license.
 
-from . import AWSHelperFn, AWSObject, AWSProperty
+from . import AWSHelperFn, AWSObject, AWSProperty, Tags
 from .validators import integer
 try:
     from awacs.aws import Policy
@@ -33,6 +33,7 @@ class Queue(AWSObject):
         'QueueName': (basestring, False),
         'ReceiveMessageWaitTimeSeconds': (integer, False),
         'RedrivePolicy': (RedrivePolicy, False),
+        'Tags': (Tags, False),
         'VisibilityTimeout': (integer, False),
     }
 


### PR DESCRIPTION
SQS queues now support tags (cf. https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-queues.html#cfn-sqs-queue-tags)