### PR TITLE
VPCPeeringConnection PeerRegion

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -679,6 +679,7 @@ class VPCPeeringConnection(AWSObject):
         'PeerVpcId': (basestring, True),
         'VpcId': (basestring, True),
         'Tags': ((Tags, list), False),
+        'PeerRegion': (basestring, False),
         'PeerOwnerId': (basestring, False),
         'PeerRoleArn': (basestring, False),
     }


### PR DESCRIPTION
- Add PeerRegion propery to VPCPeeringConnection resource

To address following issue:
https://github.com/cloudtools/troposphere/issues/1122