### PR TITLE
Add ThroughputMode and ProvisionedThroughputInMibps to EFS (#1124)

### DIFF
--- a/tests/test_efs.py
+++ b/tests/test_efs.py
@@ -1,0 +1,55 @@
+import unittest
+
+from troposphere import Template, efs
+
+
+class TestEfsTemplate(unittest.TestCase):
+    def test_bucket_template(self):
+        template = Template()
+        title = "Efs"
+        efs.FileSystem(title, template)
+        self.assertIn(title, template.resources)
+
+
+class TestEfs(unittest.TestCase):
+    def test_validData(self):
+        file_system = efs.FileSystem("Efs")
+        file_system.to_dict()
+
+    def test_validateThroughputMode(self):
+        with self.assertRaises(ValueError):
+            file_system = efs.FileSystem(
+                "Efs", ThroughputMode="UndefinedThroughputMode"
+            )
+            file_system.to_dict()
+
+        file_system = efs.FileSystem(
+            "Efs", ThroughputMode=efs.Bursting
+        )
+
+        result = file_system.to_dict()
+        self.assertEqual(result["Type"], "AWS::EFS::FileSystem")
+
+    def test_validateProvisionedThroughputInMibps(self):
+        with self.assertRaises(TypeError):
+            file_system = efs.FileSystem(
+                "Efs", ProvisionedThroughputInMibps="512"
+            )
+            file_system.to_dict()
+
+        with self.assertRaises(TypeError):
+            file_system = efs.FileSystem(
+                "Efs", ProvisionedThroughputInMibps=512
+            )
+            file_system.to_dict()
+
+        file_system = efs.FileSystem(
+            "Efs", ProvisionedThroughputInMibps=512.0
+        )
+
+        result = file_system.to_dict()
+        self.assertEqual(result["Type"], "AWS::EFS::FileSystem")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/troposphere/efs.py
+++ b/troposphere/efs.py
@@ -1,6 +1,26 @@
 from . import AWSObject, Tags
 from .validators import boolean
 
+Bursting = 'bursting'
+Provisioned = 'provisioned'
+
+
+def throughput_mode_validator(mode):
+    valid_modes = [Bursting, Provisioned]
+    if mode not in valid_modes:
+        raise ValueError(
+            'ThroughputMode must be one of: "%s"' % (', '.join(valid_modes))
+        )
+    return mode
+
+
+def provisioned_throughput_validator(throughput):
+    if throughput < 0.0:
+        raise ValueError(
+            'ProvisionedThroughputInMibps must be greater than or equal to 0.0'
+        )
+    return throughput
+
 
 class FileSystem(AWSObject):
     resource_type = "AWS::EFS::FileSystem"
@@ -10,6 +30,8 @@ class FileSystem(AWSObject):
         'FileSystemTags': (Tags, False),
         'KmsKeyId': (basestring, False),
         'PerformanceMode': (basestring, False),
+        'ProvisionedThroughputInMibps': (float, False),
+        'ThroughputMode': (throughput_mode_validator, False),
     }
 
 


### PR DESCRIPTION
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-efs-filesystem.html#cfn-elasticfilesystem-filesystem-provisionedthroughputinmibps