### PR TITLE
closes #735 Add cloud-config.yaml UserData to basic EC2 example

### DIFF
--- a/examples/EC2InstanceSample.py
+++ b/examples/EC2InstanceSample.py
@@ -1,9 +1,23 @@
 # Converted from EC2InstanceSample.template located at:
 # http://aws.amazon.com/cloudformation/aws-cloudformation-templates/
+from io import open
+import os
 
 from troposphere import Base64, FindInMap, GetAtt
 from troposphere import Parameter, Output, Ref, Template
 import troposphere.ec2 as ec2
+
+
+def get_user_data(hostname, domain):
+    """ Open local YAML config template and substitute hostname & domain """
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    config_path = os.path.join(dir_path, 'cloud-config.yaml')
+    with open(config_path, encoding='utf-8') as f:
+        data = f.read()
+        data = data.replace('${InstanceHostname}', hostname)
+        data = data.replace('${PublicDomainName}', domain)
+
+    return data
 
 
 template = Template()
@@ -31,7 +45,7 @@ ec2_instance = template.add_resource(ec2.Instance(
     InstanceType="t1.micro",
     KeyName=Ref(keyname_param),
     SecurityGroups=["default"],
-    UserData=Base64("80")
+    UserData=Base64(get_user_data('hostname', 'hostname.example.com')),
 ))
 
 template.add_output([

--- a/examples/cloud-config.yaml
+++ b/examples/cloud-config.yaml
@@ -1,0 +1,26 @@
+#cloud-config
+hostname: ${InstanceHostname}
+fqdn: ${InstanceHostname}.${PublicDomainName}
+manage_etc_hosts: true
+package_update: true
+package_upgrade: true
+packages:
+  - build-essential
+  - curl
+  - git
+runcmd:
+  - |
+    echo "-----BEGIN RSA PRIVATE KEY-----
+    AAAAAAAAAAAAAAAAAAAAAAAAAA
+    -----END RSA PRIVATE KEY-----
+    " > /home/ubuntu/.ssh/id_rsa
+  - chmod 600 /home/ubuntu/.ssh/id_rsa
+  - chown ubuntu:ubuntu /home/ubuntu/.ssh/id_rsa
+  - ssh -oStrictHostKeyChecking=no -T git@github.com
+ssh_authorized_keys:
+  - ssh-rsa AAAA==
+  - ssh-rsa AAAA==
+power_state:
+  timeout: 120
+  message: Rebooting to ensure hostname has stuck correctly and apply any kernel updates
+  mode: reboot

--- a/tests/examples_output/EC2InstanceSample.template
+++ b/tests/examples_output/EC2InstanceSample.template
@@ -103,7 +103,7 @@
                     "default"
                 ],
                 "UserData": {
-                    "Fn::Base64": "80"
+                    "Fn::Base64": "#cloud-config\nhostname: hostname\nfqdn: hostname.hostname.example.com\nmanage_etc_hosts: true\npackage_update: true\npackage_upgrade: true\npackages:\n  - build-essential\n  - curl\n  - git\nruncmd:\n  - |\n    echo \"-----BEGIN RSA PRIVATE KEY-----\n    AAAAAAAAAAAAAAAAAAAAAAAAAA\n    -----END RSA PRIVATE KEY-----\n    \" > /home/ubuntu/.ssh/id_rsa\n  - chmod 600 /home/ubuntu/.ssh/id_rsa\n  - chown ubuntu:ubuntu /home/ubuntu/.ssh/id_rsa\n  - ssh -oStrictHostKeyChecking=no -T git@github.com\nssh_authorized_keys:\n  - ssh-rsa AAAA==\n  - ssh-rsa AAAA==\npower_state:\n  timeout: 120\n  message: Rebooting to ensure hostname has stuck correctly and apply any kernel updates\n  mode: reboot\n"
                 }
             },
             "Type": "AWS::EC2::Instance"

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -28,7 +28,7 @@ class TestExamples(unittest.TestCase):
             sys.stdout = stdout
             with open(self.filename) as f:
                 code = compile(f.read(), self.filename, 'exec')
-                exec(code, {'__name__': '__main__'})
+                exec(code, {'__name__': '__main__', '__file__': self.filename})
         finally:
             sys.stdout = saved
         # rewind fake stdout so we can read it


### PR DESCRIPTION
* Assumes cloud-config.yaml is in same dir as script
* Example substitutes hostname and FQDN
* yaml file also uses cf-style template strings for dual usage
* Modify Test runner to pass __file__ global to exec