### PR TITLE
[codebuild] source_type - use value comparison instead of identity

### DIFF
--- a/tests/test_codebuild.py
+++ b/tests/test_codebuild.py
@@ -19,3 +19,9 @@ class TestCodeBuild(unittest.TestCase):
             Type='WINDOWS_CONTAINER'
         )
         environment.to_dict()
+
+    def test_source_codepipeline(self):
+        source = codebuild.Source(
+            Type='CODEPIPELINE'
+        )
+        source.to_dict()

--- a/troposphere/codebuild.py
+++ b/troposphere/codebuild.py
@@ -129,6 +129,10 @@ class Source(AWSProperty):
             'S3',
         ]
 
+        location_agnostic_types = [
+            'CODEPIPELINE',
+        ]
+
         source_type = self.properties.get('Type')
 
         # Don't do additional checks if source_type can't
@@ -141,7 +145,8 @@ class Source(AWSProperty):
                              ','.join(valid_types))
 
         location = self.properties.get('Location')
-        if source_type is not 'CODEPIPELINE' and not location:
+
+        if source_type not in location_agnostic_types and not location:
             raise ValueError(
                 'Source Location: must be defined when type is %s' %
                 source_type


### PR DESCRIPTION
Eventually I see error for `CODECOMMIT` source type:

```
ValueError: Source Location: must be defined when type is CODEPIPELINE
```

That was caused by identity check (`is`) of `source_type` string variable.

```python
>>> source_type = 'CODECOMMIT'
>>> source_type is not 'CODEPIPELINE'
True   # <== What?

>>> id(source_type), id('CODEPIPELINE')
(4430947472, 4432006256)
```

Cheers!