### PR TITLE
Instance ImageId is no longer required, specifically if using Launch …

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -233,7 +233,7 @@ class Instance(AWSObject):
         'ElasticGpuSpecifications': ([ElasticGpuSpecification], False),
         'HostId': (basestring, False),
         'IamInstanceProfile': (basestring, False),
-        'ImageId': (basestring, True),
+        'ImageId': (basestring, False),
         'InstanceInitiatedShutdownBehavior': (basestring, False),
         'InstanceType': (basestring, False),
         'Ipv6AddressCount': (integer, False),


### PR DESCRIPTION
…Templates