### PR TITLE
Return real booleans in the output

### DIFF
--- a/tests/examples_output/Autoscaling.template
+++ b/tests/examples_output/Autoscaling.template
@@ -129,13 +129,13 @@
             "Type": "AWS::AutoScaling::AutoScalingGroup",
             "UpdatePolicy": {
                 "AutoScalingReplacingUpdate": {
-                    "WillReplace": "true"
+                    "WillReplace": true
                 },
                 "AutoScalingRollingUpdate": {
                     "MaxBatchSize": "1",
                     "MinInstancesInService": "1",
                     "PauseTime": "PT5M",
-                    "WaitOnResourceSignals": "true"
+                    "WaitOnResourceSignals": true
                 }
             }
         },
@@ -181,8 +181,8 @@
                         "services": {
                             "sysvinit": {
                                 "rsyslog": {
-                                    "enabled": "true",
-                                    "ensureRunning": "true",
+                                    "enabled": true,
+                                    "ensureRunning": true,
                                     "files": [
                                         "/etc/rsyslog.d/20-somethin.conf"
                                     ]
@@ -243,7 +243,7 @@
                     "Enabled": true,
                     "Timeout": 120
                 },
-                "CrossZone": "true",
+                "CrossZone": true,
                 "HealthCheck": {
                     "HealthyThreshold": "5",
                     "Interval": "20",

--- a/tests/examples_output/AutoscalingHTTPRequests.template
+++ b/tests/examples_output/AutoscalingHTTPRequests.template
@@ -129,13 +129,13 @@
             "Type": "AWS::AutoScaling::AutoScalingGroup",
             "UpdatePolicy": {
                 "AutoScalingReplacingUpdate": {
-                    "WillReplace": "true"
+                    "WillReplace": true
                 },
                 "AutoScalingRollingUpdate": {
                     "MaxBatchSize": "1",
                     "MinInstancesInService": "1",
                     "PauseTime": "PT5M",
-                    "WaitOnResourceSignals": "true"
+                    "WaitOnResourceSignals": true
                 }
             }
         },
@@ -218,8 +218,8 @@
                         "services": {
                             "sysvinit": {
                                 "rsyslog": {
-                                    "enabled": "true",
-                                    "ensureRunning": "true",
+                                    "enabled": true,
+                                    "ensureRunning": true,
                                     "files": [
                                         "/etc/rsyslog.d/20-somethin.conf"
                                     ]
@@ -280,7 +280,7 @@
                     "Enabled": true,
                     "Timeout": 120
                 },
-                "CrossZone": "true",
+                "CrossZone": true,
                 "HealthCheck": {
                     "HealthyThreshold": "5",
                     "Interval": "20",

--- a/tests/examples_output/ClassExtensions.template
+++ b/tests/examples_output/ClassExtensions.template
@@ -4,7 +4,7 @@
             "Properties": {
                 "ImageId": "ami-xxxx",
                 "InstanceType": "t1.micro",
-                "Monitoring": "true",
+                "Monitoring": true,
                 "SecurityGroups": [
                     "frontend"
                 ]
@@ -15,7 +15,7 @@
             "Properties": {
                 "ImageId": "ami-xxxx",
                 "InstanceType": "m2.large",
-                "Monitoring": "true",
+                "Monitoring": true,
                 "SecurityGroups": [
                     "processing"
                 ]

--- a/tests/examples_output/CloudFront_S3.template
+++ b/tests/examples_output/CloudFront_S3.template
@@ -35,12 +35,12 @@
                 "DistributionConfig": {
                     "DefaultCacheBehavior": {
                         "ForwardedValues": {
-                            "QueryString": "false"
+                            "QueryString": false
                         },
                         "TargetOriginId": "Origin 1",
                         "ViewerProtocolPolicy": "allow-all"
                     },
-                    "Enabled": "true",
+                    "Enabled": true,
                     "HttpVersion": "http2",
                     "Origins": [
                         {

--- a/tests/examples_output/CloudTrail.template
+++ b/tests/examples_output/CloudTrail.template
@@ -115,7 +115,7 @@
                 "TopicPolicy"
             ],
             "Properties": {
-                "IsLogging": "true",
+                "IsLogging": true,
                 "S3BucketName": {
                     "Ref": "S3Bucket"
                 },

--- a/tests/examples_output/ECSCluster.template
+++ b/tests/examples_output/ECSCluster.template
@@ -89,8 +89,8 @@
                         },
                         "services": {
                             "cfn-hup": {
-                                "enabled": "true",
-                                "ensureRunning": "true",
+                                "enabled": true,
+                                "ensureRunning": true,
                                 "files": [
                                     "/etc/cfn/cfn-hup.conf",
                                     "/etc/cfn/hooks.d/cfn-auto-reloader.conf"
@@ -101,7 +101,7 @@
                 }
             },
             "Properties": {
-                "AssociatePublicIpAddress": "true",
+                "AssociatePublicIpAddress": true,
                 "IamInstanceProfile": {
                     "Ref": "EC2InstanceProfile"
                 },

--- a/tests/examples_output/ECSFargate.template
+++ b/tests/examples_output/ECSFargate.template
@@ -36,7 +36,7 @@
             "Properties": {
                 "ContainerDefinitions": [
                     {
-                        "Essential": "true",
+                        "Essential": true,
                         "Image": "nginx",
                         "Name": "nginx",
                         "PortMappings": [

--- a/tests/examples_output/ELBSample.template
+++ b/tests/examples_output/ELBSample.template
@@ -154,7 +154,7 @@
                     "Enabled": true,
                     "Timeout": 300
                 },
-                "CrossZone": "true",
+                "CrossZone": true,
                 "HealthCheck": {
                     "HealthyThreshold": "3",
                     "Interval": "30",

--- a/tests/examples_output/EMR_Cluster.template
+++ b/tests/examples_output/EMR_Cluster.template
@@ -199,7 +199,7 @@
                                     "VolumesPerInstance": "1"
                                 }
                             ],
-                            "EbsOptimized": "true"
+                            "EbsOptimized": true
                         },
                         "InstanceCount": "1",
                         "InstanceType": "m4.large",
@@ -280,7 +280,7 @@
                         "Value": "EMR Sample Cluster"
                     }
                 ],
-                "VisibleToAllUsers": "true"
+                "VisibleToAllUsers": true
             },
             "Type": "AWS::EMR::Cluster"
         },
@@ -299,8 +299,8 @@
                                 "EncryptionMode": "SSE-KMS"
                             }
                         },
-                        "EnableAtRestEncryption": "true",
-                        "EnableInTransitEncryption": "true",
+                        "EnableAtRestEncryption": true,
+                        "EnableInTransitEncryption": true,
                         "InTransitEncryptionConfiguration": {
                             "TLSCertificateConfiguration": {
                                 "CertificateProviderType": "PEM",

--- a/tests/examples_output/ElastiCacheRedis.template
+++ b/tests/examples_output/ElastiCacheRedis.template
@@ -527,16 +527,16 @@
                         "services": {
                             "sysvinit": {
                                 "cfn-hup": {
-                                    "enabled": "true",
-                                    "ensureRunning": "true",
+                                    "enabled": true,
+                                    "ensureRunning": true,
                                     "files": [
                                         "/etc/cfn/cfn-hup.conf",
                                         "/etc/cfn/hooks.d/cfn-auto-reloader.conf"
                                     ]
                                 },
                                 "httpd": {
-                                    "enabled": "true",
-                                    "ensureRunning": "true"
+                                    "enabled": true,
+                                    "ensureRunning": true
                                 }
                             }
                         }

--- a/tests/examples_output/ElasticsearchDomain.template
+++ b/tests/examples_output/ElasticsearchDomain.template
@@ -17,22 +17,22 @@
                     "Version": "2012-10-17"
                 },
                 "AdvancedOptions": {
-                    "rest.action.multi.allow_explicit_index": "true"
+                    "rest.action.multi.allow_explicit_index": true
                 },
                 "DomainName": "ExampleElasticsearchDomain",
                 "EBSOptions": {
-                    "EBSEnabled": "true",
+                    "EBSEnabled": true,
                     "Iops": 0,
                     "VolumeSize": 20,
                     "VolumeType": "gp2"
                 },
                 "ElasticsearchClusterConfig": {
                     "DedicatedMasterCount": 3,
-                    "DedicatedMasterEnabled": "true",
+                    "DedicatedMasterEnabled": true,
                     "DedicatedMasterType": "m3.medium.elasticsearch",
                     "InstanceCount": 2,
                     "InstanceType": "m3.medium.elasticsearch",
-                    "ZoneAwarenessEnabled": "true"
+                    "ZoneAwarenessEnabled": true
                 },
                 "SnapshotOptions": {
                     "AutomatedSnapshotStartHour": 0

--- a/tests/examples_output/Firehose_with_Redshift.template
+++ b/tests/examples_output/Firehose_with_Redshift.template
@@ -7,7 +7,7 @@
                 "DeliveryStreamName": "MyDeliveryStream",
                 "RedshiftDestinationConfiguration": {
                     "CloudWatchLoggingOptions": {
-                        "Enabled": "true",
+                        "Enabled": true,
                         "LogGroupName": "my-log-group",
                         "LogStreamName": "my-log-stream"
                     },
@@ -26,7 +26,7 @@
                             "SizeInMBs": 60
                         },
                         "CloudWatchLoggingOptions": {
-                            "Enabled": "true",
+                            "Enabled": true,
                             "LogGroupName": "my-other-log-group",
                             "LogStreamName": "my-other-log-stream"
                         },

--- a/tests/examples_output/IoTSample.template
+++ b/tests/examples_output/IoTSample.template
@@ -53,7 +53,7 @@
                             }
                         }
                     ],
-                    "RuleDisabled": "true",
+                    "RuleDisabled": true,
                     "Sql": "SELECT temp FROM SomeTopic WHERE temp > 60"
                 }
             },

--- a/tests/examples_output/NatGateway.template
+++ b/tests/examples_output/NatGateway.template
@@ -102,7 +102,7 @@
                 "CidrBlock": {
                     "Ref": "PrivateSubnetCidr"
                 },
-                "MapPublicIpOnLaunch": "false",
+                "MapPublicIpOnLaunch": false,
                 "VpcId": {
                     "Ref": "VPC"
                 }
@@ -145,7 +145,7 @@
                 "CidrBlock": {
                     "Ref": "PublicSubnetCidr"
                 },
-                "MapPublicIpOnLaunch": "true",
+                "MapPublicIpOnLaunch": true,
                 "VpcId": {
                     "Ref": "VPC"
                 }

--- a/tests/examples_output/OpenStack_AutoScaling.template
+++ b/tests/examples_output/OpenStack_AutoScaling.template
@@ -59,8 +59,8 @@
                         "services": {
                             "sysvinit": {
                                 "service1": {
-                                    "enabled": "true",
-                                    "ensureRunning": "true",
+                                    "enabled": true,
+                                    "ensureRunning": true,
                                     "files": [
                                         "/etc/service1/somefile.conf"
                                     ]

--- a/tests/examples_output/OpsWorksSnippet.template
+++ b/tests/examples_output/OpsWorksSnippet.template
@@ -41,16 +41,16 @@
                     "MysqlRootPassword": {
                         "Ref": "MysqlRootPassword"
                     },
-                    "MysqlRootPasswordUbiquitous": "true"
+                    "MysqlRootPasswordUbiquitous": true
                 },
-                "AutoAssignElasticIps": "false",
-                "AutoAssignPublicIps": "true",
+                "AutoAssignElasticIps": false,
+                "AutoAssignPublicIps": true,
                 "CustomRecipes": {
                     "Setup": [
                         "phpapp::dbsetup"
                     ]
                 },
-                "EnableAutoHealing": "true",
+                "EnableAutoHealing": true,
                 "Name": "MyMySQL",
                 "Shortname": "db-layer",
                 "StackId": {
@@ -165,14 +165,14 @@
         },
         "myLayer": {
             "Properties": {
-                "AutoAssignElasticIps": "false",
-                "AutoAssignPublicIps": "true",
+                "AutoAssignElasticIps": false,
+                "AutoAssignPublicIps": true,
                 "CustomRecipes": {
                     "Configure": [
                         "phpapp::appsetup"
                     ]
                 },
-                "EnableAutoHealing": "true",
+                "EnableAutoHealing": true,
                 "Name": "MyPHPApp",
                 "Shortname": "php-app",
                 "StackId": {
@@ -221,7 +221,7 @@
                         ]
                     ]
                 },
-                "UseCustomCookbooks": "true"
+                "UseCustomCookbooks": true
             },
             "Type": "AWS::OpsWorks::Stack"
         }

--- a/tests/examples_output/Redshift.template
+++ b/tests/examples_output/Redshift.template
@@ -116,7 +116,7 @@
                 "Parameters": [
                     {
                         "ParameterName": "enable_user_activity_logging",
-                        "ParameterValue": "true"
+                        "ParameterValue": true
                     }
                 ]
             },

--- a/tests/examples_output/RedshiftClusterInVpc.template
+++ b/tests/examples_output/RedshiftClusterInVpc.template
@@ -135,7 +135,7 @@
                 "Parameters": [
                     {
                         "ParameterName": "enable_user_activity_logging",
-                        "ParameterValue": "true"
+                        "ParameterValue": true
                     }
                 ]
             },

--- a/tests/examples_output/VPC_EC2_Instance_With_Multiple_Dynamic_IPAddresses.template
+++ b/tests/examples_output/VPC_EC2_Instance_With_Multiple_Dynamic_IPAddresses.template
@@ -197,7 +197,7 @@
                 "SecondaryPrivateIpAddressCount": {
                     "Ref": "SecondaryIPAddressCount"
                 },
-                "SourceDestCheck": "true",
+                "SourceDestCheck": true,
                 "SubnetId": {
                     "Ref": "SubnetId"
                 },

--- a/tests/examples_output/VPC_With_VPN_Connection.template
+++ b/tests/examples_output/VPC_With_VPN_Connection.template
@@ -88,7 +88,7 @@
         "InboundPrivateNetworkAclEntry": {
             "Properties": {
                 "CidrBlock": "0.0.0.0/0",
-                "Egress": "false",
+                "Egress": false,
                 "NetworkAclId": {
                     "Ref": "PrivateNetworkAcl"
                 },
@@ -105,7 +105,7 @@
         "OutBoundPrivateNetworkAclEntry": {
             "Properties": {
                 "CidrBlock": "0.0.0.0/0",
-                "Egress": "true",
+                "Egress": true,
                 "NetworkAclId": {
                     "Ref": "PrivateNetworkAcl"
                 },
@@ -221,8 +221,8 @@
                 "CidrBlock": {
                     "Ref": "VPCCIDR"
                 },
-                "EnableDnsHostnames": "true",
-                "EnableDnsSupport": "true",
+                "EnableDnsHostnames": true,
+                "EnableDnsSupport": true,
                 "Tags": [
                     {
                         "Key": "Application",
@@ -243,7 +243,7 @@
                 "CustomerGatewayId": {
                     "Ref": "CustomerGateway"
                 },
-                "StaticRoutesOnly": "true",
+                "StaticRoutesOnly": true,
                 "Type": "ipsec.1",
                 "VpnGatewayId": {
                     "Ref": "VPNGateway"

--- a/tests/examples_output/VPC_single_instance_in_subnet.template
+++ b/tests/examples_output/VPC_single_instance_in_subnet.template
@@ -270,7 +270,7 @@
         "InboundHTTPNetworkAclEntry": {
             "Properties": {
                 "CidrBlock": "0.0.0.0/0",
-                "Egress": "false",
+                "Egress": false,
                 "NetworkAclId": {
                     "Ref": "NetworkAcl"
                 },
@@ -287,7 +287,7 @@
         "InboundResponsePortsNetworkAclEntry": {
             "Properties": {
                 "CidrBlock": "0.0.0.0/0",
-                "Egress": "false",
+                "Egress": false,
                 "NetworkAclId": {
                     "Ref": "NetworkAcl"
                 },
@@ -304,7 +304,7 @@
         "InboundSSHNetworkAclEntry": {
             "Properties": {
                 "CidrBlock": "0.0.0.0/0",
-                "Egress": "false",
+                "Egress": false,
                 "NetworkAclId": {
                     "Ref": "NetworkAcl"
                 },
@@ -375,7 +375,7 @@
         "OutBoundHTTPNetworkAclEntry": {
             "Properties": {
                 "CidrBlock": "0.0.0.0/0",
-                "Egress": "true",
+                "Egress": true,
                 "NetworkAclId": {
                     "Ref": "NetworkAcl"
                 },
@@ -392,7 +392,7 @@
         "OutBoundHTTPSNetworkAclEntry": {
             "Properties": {
                 "CidrBlock": "0.0.0.0/0",
-                "Egress": "true",
+                "Egress": true,
                 "NetworkAclId": {
                     "Ref": "NetworkAcl"
                 },
@@ -409,7 +409,7 @@
         "OutBoundResponsePortsNetworkAclEntry": {
             "Properties": {
                 "CidrBlock": "0.0.0.0/0",
-                "Egress": "true",
+                "Egress": true,
                 "NetworkAclId": {
                     "Ref": "NetworkAcl"
                 },
@@ -585,16 +585,16 @@
                         "services": {
                             "sysvinit": {
                                 "cfn-hup": {
-                                    "enabled": "true",
-                                    "ensureRunning": "true",
+                                    "enabled": true,
+                                    "ensureRunning": true,
                                     "files": [
                                         "/etc/cfn/cfn-hup.conf",
                                         "/etc/cfn/hooks.d/cfn-auto-reloader.conf"
                                     ]
                                 },
                                 "httpd": {
-                                    "enabled": "true",
-                                    "ensureRunning": "true"
+                                    "enabled": true,
+                                    "ensureRunning": true
                                 }
                             }
                         }
@@ -627,8 +627,8 @@
                 },
                 "NetworkInterfaces": [
                     {
-                        "AssociatePublicIpAddress": "true",
-                        "DeleteOnTermination": "true",
+                        "AssociatePublicIpAddress": true,
+                        "DeleteOnTermination": true,
                         "DeviceIndex": "0",
                         "GroupSet": [
                             {

--- a/tests/examples_output/WAF_Common_Attacks_Sample.template
+++ b/tests/examples_output/WAF_Common_Attacks_Sample.template
@@ -38,7 +38,7 @@
                         "DataId": {
                             "Ref": "WAFManualIPBlockSet"
                         },
-                        "Negated": "false",
+                        "Negated": false,
                         "Type": "IPMatch"
                     }
                 ]
@@ -126,7 +126,7 @@
                         "DataId": {
                             "Ref": "SizeMatchSet"
                         },
-                        "Negated": "false",
+                        "Negated": false,
                         "Type": "SizeConstraint"
                     }
                 ]
@@ -236,7 +236,7 @@
                         "DataId": {
                             "Ref": "SqliMatchSet"
                         },
-                        "Negated": "false",
+                        "Negated": false,
                         "Type": "SqlInjectionMatch"
                     }
                 ]
@@ -326,7 +326,7 @@
                         "DataId": {
                             "Ref": "XssMatchSet"
                         },
-                        "Negated": "false",
+                        "Negated": false,
                         "Type": "XssMatch"
                     }
                 ]

--- a/tests/examples_output/WAF_Regional_Common_Attacks_Sample.template
+++ b/tests/examples_output/WAF_Regional_Common_Attacks_Sample.template
@@ -38,7 +38,7 @@
                         "DataId": {
                             "Ref": "WAFManualIPBlockSet"
                         },
-                        "Negated": "false",
+                        "Negated": false,
                         "Type": "IPMatch"
                     }
                 ]
@@ -126,7 +126,7 @@
                         "DataId": {
                             "Ref": "SizeMatchSet"
                         },
-                        "Negated": "false",
+                        "Negated": false,
                         "Type": "SizeConstraint"
                     }
                 ]
@@ -236,7 +236,7 @@
                         "DataId": {
                             "Ref": "SqliMatchSet"
                         },
-                        "Negated": "false",
+                        "Negated": false,
                         "Type": "SqlInjectionMatch"
                     }
                 ]
@@ -326,7 +326,7 @@
                         "DataId": {
                             "Ref": "XssMatchSet"
                         },
-                        "Negated": "false",
+                        "Negated": false,
                         "Type": "XssMatch"
                     }
                 ]

--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -9,9 +9,9 @@ from re import compile
 
 def boolean(x):
     if x in [True, 1, '1', 'true', 'True']:
-        return "true"
+        return True
     if x in [False, 0, '0', 'false', 'False']:
-        return "false"
+        return False
     raise ValueError
 
 


### PR DESCRIPTION
cfn-lint (https://github.com/awslabs/cfn-python-lint) was giving me an error on booleans (E3012 Property Resources/KmsKey/Properties/Enabled should be of type Boolean), because troposhere renders them to strings.

This makes them also booleans in JSON.

If we want to limit to number of templates that would have their output changed, we may want to do this only if the input was `True` or `False` and not on strings or `1`/`0`.
