### PR TITLE
Instance ImageId is no longer required, specifically if using Launch …

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -4,7 +4,8 @@ from troposphere import AWSObject, AWSProperty, Output, Parameter
 from troposphere import Cidr, If, Join, Ref, Split, Sub, Template
 from troposphere import NoValue, Region
 from troposphere import depends_on_helper
-from troposphere.ec2 import Instance, Route, SecurityGroupRule
+from troposphere.ec2 import Instance, LaunchTemplateData
+from troposphere.ec2 import Route, SecurityGroupRule
 from troposphere.s3 import Bucket
 from troposphere.elasticloadbalancing import HealthCheck
 from troposphere import cloudformation
@@ -20,7 +21,7 @@ class TestBasic(unittest.TestCase):
     def test_badrequired(self):
         with self.assertRaises(ValueError):
             t = Template()
-            t.add_resource(Instance('ec2instance'))
+            t.add_resource(LaunchTemplateData('launchtemplatedata'))
             t.to_json()
 
     def test_badtype(self):
@@ -28,7 +29,10 @@ class TestBasic(unittest.TestCase):
             Instance('ec2instance', image_id=0.11)
 
     def test_goodrequired(self):
-        Instance('ec2instance', ImageId="ami-xxxx", InstanceType="m1.small")
+        LaunchTemplateData(
+            'launchtemplatedata', ImageId='ami-xxxx',
+            InstanceType='m1.small'
+        )
 
     def test_extraattribute(self):
 
@@ -39,12 +43,6 @@ class TestBasic(unittest.TestCase):
 
         instance = ExtendedInstance('ec2instance', attribute='value')
         self.assertEqual(instance.attribute, 'value')
-
-    def test_required_title_error(self):
-        with self.assertRaisesRegexp(ValueError, "title:"):
-            t = Template()
-            t.add_resource(Instance('ec2instance'))
-            t.to_json()
 
     def test_depends_on_helper_with_resource(self):
         resource_name = "Bucket1"

--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -233,7 +233,7 @@ class Instance(AWSObject):
         'ElasticGpuSpecifications': ([ElasticGpuSpecification], False),
         'HostId': (basestring, False),
         'IamInstanceProfile': (basestring, False),
-        'ImageId': (basestring, True),
+        'ImageId': (basestring, False),
         'InstanceInitiatedShutdownBehavior': (basestring, False),
         'InstanceType': (basestring, False),
         'Ipv6AddressCount': (integer, False),


### PR DESCRIPTION
…Templates; updated tests
After this commit, the following code (this commit makes it so that ImageId is no longer a required field to create Instances, as Launch Templates can specify the ImageId instead now)

```
import sys
from troposphere import Template
import troposphere.ec2 as ec2

stack = 'dunder-mifflin'
avail_zone = 'us-east-1b'


def alphanum(str):
    return ''.join(ch for ch in stack if ch.isalnum())


t = Template()

ltd = ec2.LaunchTemplateData(
    alphanum(stack) + 'ltd',
    InstanceType='r4.2xlarge',
    ImageId='ami-0ff8a91507f77f867')

lt = ec2.LaunchTemplate(
    alphanum(stack) + 'lt', LaunchTemplateData=ltd, LaunchTemplateName=stack)
t.add_resource(lt)

lts = ec2.LaunchTemplateSpecification(
    alphanum(stack) + 'lts', LaunchTemplateName=stack, Version='1')

inst = ec2.Instance(
    alphanum(stack) + 'inst',
    LaunchTemplate=lts,
    SubnetId='subnet-1293cfcd',
    DependsOn=alphanum(stack) + 'lt')
t.add_resource(inst)

print(t.to_json())
```

creates the following resource JSON that gets the instance up successfully via CloudFormation:

```
{
    "Resources": {
        "dundermifflininst": {
            "DependsOn": "dundermifflinlt",
            "Properties": {
                "LaunchTemplate": {
                    "LaunchTemplateName": "dunder-mifflin",
                    "Version": "1"
                },
                "SubnetId": "subnet-1293cfcd"
            },
            "Type": "AWS::EC2::Instance"
        },
        "dundermifflinlt": {
            "Properties": {
                "LaunchTemplateData": {
                    "ImageId": "ami-0ff8a91507f77f867",
                    "InstanceType": "r4.2xlarge"
                },
                "LaunchTemplateName": "dunder-mifflin"
            },
            "Type": "AWS::EC2::LaunchTemplate"
        }
    }
}
```

I tested and included this code in case you want to consider it or something similar for any new examples.