### PR TITLE
extend Action to support Redirect and FixedResponse for AWS::ElasticLoadBalancingV2::ListenerRule

### DIFF
--- a/tests/test_elasticloadbalancerv2.py
+++ b/tests/test_elasticloadbalancerv2.py
@@ -1,0 +1,60 @@
+import unittest
+
+from troposphere.elasticloadbalancingv2 import Action, RedirectActionConfig
+
+
+class TestListenerActions(unittest.TestCase):
+    def test_redirect_action(self):
+        Action(
+            Type='redirect',
+            RedirectConfig=RedirectActionConfig(
+                StatusCode='HTTP_301',
+                Protocol='HTTPS',
+                Host='api.troposphere.org',
+                Path='redirect/#{path}'
+            )
+        ).to_dict()
+
+    def test_forward_action(self):
+        Action(
+            Type='forward',
+            TargetGroupArn=''
+        ).to_dict()
+
+    def test_redirect_action_config_one_of(self):
+        with self.assertRaises(ValueError):
+            RedirectActionConfig(
+                StatusCode='HTTP_200'
+            ).to_dict()
+
+    def test_forward_action_requires_target_arn(self):
+        with self.assertRaises(ValueError):
+            Action(
+                Type='forward'
+            ).to_dict()
+
+    def test_redirect_action_requires_redirect_config(self):
+        with self.assertRaises(ValueError):
+            Action(
+                Type='redirect'
+            ).to_dict()
+
+    def test_target_arn_only_forward(self):
+        with self.assertRaises(ValueError):
+            Action(
+                Type='redirect',
+                TargetGroupArn=''
+            ).to_dict()
+
+    def test_redirect_config_only_with_redirect(self):
+        with self.assertRaises(ValueError):
+            Action(
+                Type='forward',
+                RedirectConfig=RedirectActionConfig(
+                    StatusCode='HTTP_301',
+                )
+            ).to_dict()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_elasticloadbalancerv2.py
+++ b/tests/test_elasticloadbalancerv2.py
@@ -1,17 +1,27 @@
 import unittest
 
-from troposphere.elasticloadbalancingv2 import Action, RedirectActionConfig
+from troposphere.elasticloadbalancingv2 import Action, RedirectConfig, FixedResponseConfig
 
 
 class TestListenerActions(unittest.TestCase):
     def test_redirect_action(self):
         Action(
             Type='redirect',
-            RedirectConfig=RedirectActionConfig(
+            RedirectConfig=RedirectConfig(
                 StatusCode='HTTP_301',
                 Protocol='HTTPS',
                 Host='api.troposphere.org',
                 Path='redirect/#{path}'
+            )
+        ).to_dict()
+
+    def test_fixed_response_action(self):
+        Action(
+            Type='fixed-response',
+            FixedResponseConfig=FixedResponseConfig(
+                ContentType='text/plain',
+                MessageBody='I am a fixed response',
+                StatusCode='200'
             )
         ).to_dict()
 
@@ -23,14 +33,26 @@ class TestListenerActions(unittest.TestCase):
 
     def test_redirect_action_config_one_of(self):
         with self.assertRaises(ValueError):
-            RedirectActionConfig(
+            RedirectConfig(
                 StatusCode='HTTP_200'
+            ).to_dict()
+
+    def test_fixed_response_config_one_of(self):
+        with self.assertRaises(ValueError):
+            FixedResponseConfig(
+                ContentType='application/octet-stream',
             ).to_dict()
 
     def test_forward_action_requires_target_arn(self):
         with self.assertRaises(ValueError):
             Action(
                 Type='forward'
+            ).to_dict()
+
+    def test_fixed_response_requires_fixed_response_config(self):
+        with self.assertRaises(ValueError):
+            Action(
+                Type='fixed-response'
             ).to_dict()
 
     def test_redirect_action_requires_redirect_config(self):
@@ -50,8 +72,17 @@ class TestListenerActions(unittest.TestCase):
         with self.assertRaises(ValueError):
             Action(
                 Type='forward',
-                RedirectConfig=RedirectActionConfig(
+                RedirectConfig=RedirectConfig(
                     StatusCode='HTTP_301',
+                )
+            ).to_dict()
+
+    def test_fixed_response_config_only_with_fixed_response(self):
+        with self.assertRaises(ValueError):
+            Action(
+                Type='forward',
+                FixedResponseConfig=FixedResponseConfig(
+                    ContentType='text/plain',
                 )
             ).to_dict()
 

--- a/tests/test_elasticloadbalancerv2.py
+++ b/tests/test_elasticloadbalancerv2.py
@@ -1,6 +1,7 @@
 import unittest
 
-from troposphere.elasticloadbalancingv2 import Action, RedirectConfig, FixedResponseConfig
+from troposphere.elasticloadbalancingv2 import Action, RedirectConfig, \
+    FixedResponseConfig
 
 
 class TestListenerActions(unittest.TestCase):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -9,6 +9,7 @@ from troposphere.validators import iam_group_name, iam_user_name, elb_name
 from troposphere.validators import mutually_exclusive, notification_type
 from troposphere.validators import notification_event, task_type
 from troposphere.validators import compliance_level, operating_system
+from troposphere.validators import one_of
 
 
 class TestValidators(unittest.TestCase):
@@ -147,6 +148,14 @@ class TestValidators(unittest.TestCase):
         for s in ['', 'a'*65, 'a%', 'a#', 'A a']:
             with self.assertRaises(ValueError):
                 iam_user_name(s)
+
+    def test_one_of(self):
+        conds = ['Bilbo', 'Frodo']
+        one_of('hobbits', {"first": "Bilbo"}, "first", conds)
+        one_of('hobbits', {"first": "Frodo"}, "first", conds)
+        with self.assertRaises(ValueError):
+            one_of('hobbits', {"first": "Gandalf"}, "first", conds)
+            one_of('hobbits', {"first": "Gandalf"}, "second", conds)
 
     def test_mutually_exclusive(self):
         conds = ['a', 'b', 'c']

--- a/troposphere/elasticloadbalancingv2.py
+++ b/troposphere/elasticloadbalancingv2.py
@@ -57,7 +57,7 @@ class Action(AWSProperty):
                ['forward', 'redirect'])
 
         def requires(action_type, prop):
-            if self.properties.get('Type') is action_type and \
+            if self.properties.get('Type') == action_type and \
                     prop not in self.properties:
                 raise ValueError(
                     'Type "%s" requires definition of "%s"' % (
@@ -66,7 +66,7 @@ class Action(AWSProperty):
                 )
 
             if prop in self.properties and \
-                    self.properties.get('Type') is not action_type:
+                    self.properties.get('Type') != action_type:
                 raise ValueError(
                     'Definition of "%s" allowed only with '
                     'type "%s", was: "%s"' % (

--- a/troposphere/elasticloadbalancingv2.py
+++ b/troposphere/elasticloadbalancingv2.py
@@ -6,7 +6,8 @@
 from . import AWSObject, AWSProperty, If, Tags
 from .validators import (
     elb_name, exactly_one, network_port,
-    tg_healthcheck_port, integer
+    tg_healthcheck_port, integer,
+    one_of
 )
 
 
@@ -23,11 +24,48 @@ class Certificate(AWSProperty):
     }
 
 
+class RedirectActionConfig(AWSProperty):
+    # https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_RedirectActionConfig.html
+    props = {
+        'Host': (basestring, False),
+        'Path': (basestring, False),
+        'Port': (basestring, False),
+        'Protocol': (basestring, False),
+        'Query': (basestring, False),
+        'StatusCode': (basestring, True),
+    }
+
+    def validate(self):
+        one_of(self.__class__.__name__, self.properties, 'StatusCode', ['HTTP_301', 'HTTP_302'])
+
+
 class Action(AWSProperty):
     props = {
-        'TargetGroupArn': (basestring, True),
-        'Type': (basestring, True)
+        'Type': (basestring, True),
+        'TargetGroupArn': (basestring, False),
+        'RedirectConfig': (RedirectActionConfig, False)
     }
+
+    def validate(self):
+        one_of(self.__class__.__name__, self.properties, 'Type', ['forward', 'redirect'])
+
+        def requires(action_type, prop):
+            if self.properties.get('Type') is action_type and prop not in self.properties:
+                raise ValueError(
+                    'Type "%s" requires definition of "%s"' % (
+                        action_type, prop
+                    )
+                )
+
+            if prop in self.properties and self.properties.get('Type') is not action_type:
+                raise ValueError(
+                    'Definition of "%s" allowed only with type "%s"' % (
+                        prop, action_type
+                    )
+                )
+
+        requires('forward', 'TargetGroupArn')
+        requires('redirect', 'RedirectConfig')
 
 
 class Condition(AWSProperty):

--- a/troposphere/elasticloadbalancingv2.py
+++ b/troposphere/elasticloadbalancingv2.py
@@ -25,7 +25,8 @@ class Certificate(AWSProperty):
 
 
 class RedirectActionConfig(AWSProperty):
-    # https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_RedirectActionConfig.html
+    # https://docs.aws.amazon.com
+    # /elasticloadbalancing/latest/APIReference/API_RedirectActionConfig.html
     props = {
         'Host': (basestring, False),
         'Path': (basestring, False),
@@ -36,7 +37,10 @@ class RedirectActionConfig(AWSProperty):
     }
 
     def validate(self):
-        one_of(self.__class__.__name__, self.properties, 'StatusCode', ['HTTP_301', 'HTTP_302'])
+        one_of(self.__class__.__name__,
+               self.properties,
+               'StatusCode',
+               ['HTTP_301', 'HTTP_302'])
 
 
 class Action(AWSProperty):
@@ -47,17 +51,22 @@ class Action(AWSProperty):
     }
 
     def validate(self):
-        one_of(self.__class__.__name__, self.properties, 'Type', ['forward', 'redirect'])
+        one_of(self.__class__.__name__,
+               self.properties,
+               'Type',
+               ['forward', 'redirect'])
 
         def requires(action_type, prop):
-            if self.properties.get('Type') is action_type and prop not in self.properties:
+            if self.properties.get('Type') is action_type and \
+                    prop not in self.properties:
                 raise ValueError(
                     'Type "%s" requires definition of "%s"' % (
                         action_type, prop
                     )
                 )
 
-            if prop in self.properties and self.properties.get('Type') is not action_type:
+            if prop in self.properties and \
+                    self.properties.get('Type') is not action_type:
                 raise ValueError(
                     'Definition of "%s" allowed only with type "%s"' % (
                         prop, action_type

--- a/troposphere/elasticloadbalancingv2.py
+++ b/troposphere/elasticloadbalancingv2.py
@@ -24,7 +24,7 @@ class Certificate(AWSProperty):
     }
 
 
-class RedirectActionConfig(AWSProperty):
+class RedirectConfig(AWSProperty):
     # https://docs.aws.amazon.com/
     # AWSCloudFormation/latest/UserGuide/
     # aws-properties-elasticloadbalancingv2-listener-redirectconfig.html
@@ -44,18 +44,34 @@ class RedirectActionConfig(AWSProperty):
                ['HTTP_301', 'HTTP_302'])
 
 
+class FixedResponseConfig(AWSProperty):
+    props = {
+        'ContentType': (basestring, False),
+        'MessageBody': (basestring, False),
+        'StatusCode': (basestring, False),
+    }
+
+    def validate(self):
+        one_of(self.__class__.__name__,
+               self.properties,
+               'ContentType',
+               ['text/plain', 'text/css', 'text/html',
+                'application/javascript', 'application/json'])
+
+
 class Action(AWSProperty):
     props = {
         'Type': (basestring, True),
         'TargetGroupArn': (basestring, False),
-        'RedirectConfig': (RedirectActionConfig, False)
+        'RedirectConfig': (RedirectConfig, False),
+        'FixedResponseConfig': (FixedResponseConfig, False)
     }
 
     def validate(self):
         one_of(self.__class__.__name__,
                self.properties,
                'Type',
-               ['forward', 'redirect'])
+               ['forward', 'redirect', 'fixed-response'])
 
         def requires(action_type, prop):
             if self.properties.get('Type') == action_type and \
@@ -77,6 +93,7 @@ class Action(AWSProperty):
 
         requires('forward', 'TargetGroupArn')
         requires('redirect', 'RedirectConfig')
+        requires('fixed-response', 'FixedResponseConfig')
 
 
 class Condition(AWSProperty):

--- a/troposphere/elasticloadbalancingv2.py
+++ b/troposphere/elasticloadbalancingv2.py
@@ -68,8 +68,9 @@ class Action(AWSProperty):
             if prop in self.properties and \
                     self.properties.get('Type') is not action_type:
                 raise ValueError(
-                    'Definition of "%s" allowed only with type "%s"' % (
-                        prop, action_type
+                    'Definition of "%s" allowed only with '
+                    'type "%s", was: "%s"' % (
+                        prop, action_type, self.properties.get('Type')
                     )
                 )
 

--- a/troposphere/elasticloadbalancingv2.py
+++ b/troposphere/elasticloadbalancingv2.py
@@ -25,8 +25,9 @@ class Certificate(AWSProperty):
 
 
 class RedirectActionConfig(AWSProperty):
-    # https://docs.aws.amazon.com
-    # /elasticloadbalancing/latest/APIReference/API_RedirectActionConfig.html
+    # https://docs.aws.amazon.com/
+    # AWSCloudFormation/latest/UserGuide/
+    # aws-properties-elasticloadbalancingv2-listener-redirectconfig.html
     props = {
         'Host': (basestring, False),
         'Path': (basestring, False),

--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -194,6 +194,15 @@ def iam_group_name(group_name):
     return group_name
 
 
+def one_of(class_name, properties, property, conditionals):
+    if properties.get(property) not in conditionals:
+        raise ValueError(
+            '%s.%s must be one of: "%s"' % (
+                class_name, property, ', '.join(conditionals)
+            )
+        )
+
+
 def mutually_exclusive(class_name, properties, conditionals):
     from . import NoValue
 


### PR DESCRIPTION
add possibility to define redirect type with RedirectConfig as
defined in docs: https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_Action.html

also add validation to allowed values and combinations of type and
required property

this PR also adds one_of validator to check against list of possible
values