### PR TITLE
Add LambdaPermission in Example CloudWatchEventsSample.py

### DIFF
--- a/examples/CloudWatchEventsSample.py
+++ b/examples/CloudWatchEventsSample.py
@@ -57,7 +57,7 @@ rule = t.add_resource(Rule(
 
 # Create Lambda Permission
 permission = t.add_resource(Permission(
-    'LambdaFunctionPermission',
+    'FoobarPermission',
     Action='lambda:invokeFunction',
     Principal='events.amazonaws.com',
     FunctionName=Ref(foobar_function),

--- a/examples/CloudWatchEventsSample.py
+++ b/examples/CloudWatchEventsSample.py
@@ -1,7 +1,7 @@
 from troposphere import Template
 from troposphere.events import Rule, Target
-from troposphere.awslambda import Function, Code
-from troposphere import GetAtt, Join
+from troposphere.awslambda import Function, Code, Permission
+from troposphere import GetAtt, Join, Ref
 
 
 t = Template()
@@ -53,6 +53,15 @@ rule = t.add_resource(Rule(
     Description="Foobar CloudWatch Event",
     State="ENABLED",
     Targets=[foobar_target]
+))
+
+# Create Lambda Permission
+permission = t.add_resource(Permission(
+    'LambdaFunctionPermission',
+    Action='lambda:invokeFunction',
+    Principal='events.amazonaws.com',
+    FunctionName=Ref(foobar_function),
+    SourceArn=GetAtt(rule, 'Arn')
 ))
 
 print(t.to_json())

--- a/tests/examples_output/CloudWatchEventsSample.template
+++ b/tests/examples_output/CloudWatchEventsSample.template
@@ -27,6 +27,22 @@
             },
             "Type": "AWS::Lambda::Function"
         },
+        "FoobarPermission": {
+            "Properties": {
+                "Action": "lambda:invokeFunction",
+                "FunctionName": {
+                    "Ref": "FoobarFunction"
+                },
+                "Principal": "events.amazonaws.com",
+                "SourceArn": {
+                    "Fn::GetAtt": [
+                        "FoobarRule",
+                        "Arn"
+                    ]
+                }
+            },
+            "Type": "AWS::Lambda::Permission"
+        },
         "FoobarRule": {
             "Properties": {
                 "Description": "Foobar CloudWatch Event",
@@ -57,22 +73,6 @@
                 ]
             },
             "Type": "AWS::Events::Rule"
-        },
-        "FoobarPermission": {
-            "Properties": {
-                "Action": "lambda:invokeFunction",
-                "FunctionName": {
-                    "Ref": "FoobarFunction"
-                },
-                "Principal": "events.amazonaws.com",
-                "SourceArn": {
-                    "Fn::GetAtt": [
-                        "FoobarRule",
-                        "Arn"
-                    ]
-                }
-            },
-            "Type": "AWS::Lambda::Permission"
         }
     }
 }

--- a/tests/examples_output/CloudWatchEventsSample.template
+++ b/tests/examples_output/CloudWatchEventsSample.template
@@ -57,6 +57,22 @@
                 ]
             },
             "Type": "AWS::Events::Rule"
+        },
+        "FoobarPermission": {
+            "Properties": {
+                "Action": "lambda:invokeFunction",
+                "FunctionName": {
+                    "Ref": "FoobarFunction"
+                },
+                "Principal": "events.amazonaws.com",
+                "SourceArn": {
+                    "Fn::GetAtt": [
+                        "FoobarRule",
+                        "Arn"
+                    ]
+                }
+            },
+            "Type": "AWS::Lambda::Permission"
         }
     }
 }


### PR DESCRIPTION
It's necessary Create Permission in CloudWatchEventsSample.py Example to Lambda to work.