### PR TITLE
Update the OnPremisesInstanceTagFilters parameter for AWS::CodeDeploy::DeploymentGroup

### DIFF
--- a/examples/CodeDeploy.py
+++ b/examples/CodeDeploy.py
@@ -1,6 +1,7 @@
 from troposphere import Template
 from troposphere.codedeploy import AutoRollbackConfiguration, \
-    DeploymentStyle, DeploymentGroup, ElbInfoList, LoadBalancerInfo
+    DeploymentStyle, DeploymentGroup, ElbInfoList, LoadBalancerInfo, \
+    OnPremisesInstanceTagFilters
 
 
 template = Template()
@@ -33,5 +34,23 @@ deployment_group = DeploymentGroup(
     ServiceRoleArn='arn:aws:iam::0123456789:role/codedeploy-role'
 )
 template.add_resource(deployment_group)
+
+# On premises
+deployment_group_on_premises = DeploymentGroup(
+    "DemoDeploymentGroupOnPremises",
+    DeploymentGroupName='DemoApplicationOnPremises',
+    ApplicationName='DemoApplicationOnPremises',
+    AutoRollbackConfiguration=auto_rollback_configuration,
+    DeploymentStyle=DeploymentStyle(
+        DeploymentOption='WITHOUT_TRAFFIC_CONTROL'
+    ),
+    ServiceRoleArn='arn:aws:iam::0123456789:role/codedeploy-role',
+    OnPremisesInstanceTagFilters=[OnPremisesInstanceTagFilters(
+        Key='Service',
+        Value='DemoApplicationOnPremises',
+        Type='KEY_AND_VALUE'
+    )]
+)
+template.add_resource(deployment_group_on_premises)
 
 print(template.to_json())

--- a/tests/examples_output/CodeDeploy.template
+++ b/tests/examples_output/CodeDeploy.template
@@ -23,6 +23,30 @@
                 "ServiceRoleArn": "arn:aws:iam::0123456789:role/codedeploy-role"
             },
             "Type": "AWS::CodeDeploy::DeploymentGroup"
+        },
+        "DemoDeploymentGroupOnPremises": {
+            "Properties": {
+                "ApplicationName": "DemoApplicationOnPremises",
+                "AutoRollbackConfiguration": {
+                    "Enabled": true,
+                    "Events": [
+                        "DEPLOYMENT_FAILURE"
+                    ]
+                },
+                "DeploymentGroupName": "DemoApplicationOnPremises",
+                "DeploymentStyle": {
+                    "DeploymentOption": "WITHOUT_TRAFFIC_CONTROL"
+                },
+                "OnPremisesInstanceTagFilters": [
+                    {
+                        "Key": "Service",
+                        "Type": "KEY_AND_VALUE",
+                        "Value": "DemoApplicationOnPremises"
+                    }
+                ],
+                "ServiceRoleArn": "arn:aws:iam::0123456789:role/codedeploy-role"
+            },
+            "Type": "AWS::CodeDeploy::DeploymentGroup"
         }
     }
 }

--- a/troposphere/codedeploy.py
+++ b/troposphere/codedeploy.py
@@ -178,7 +178,9 @@ class DeploymentGroup(AWSObject):
         'DeploymentStyle': (DeploymentStyle, False),
         'Ec2TagFilters': ([Ec2TagFilters], False),
         'LoadBalancerInfo': (LoadBalancerInfo, False),
-        'OnPremisesInstanceTagFilters': (OnPremisesInstanceTagFilters, False),
+        'OnPremisesInstanceTagFilters': (
+            [OnPremisesInstanceTagFilters], False
+        ),
         'ServiceRoleArn': (basestring, True),
         'TriggerConfigurations': ([TriggerConfig], False),
     }


### PR DESCRIPTION
CloudFormation expects the `OnPremisesInstanceTagFilters` parameter of the `AWS::CodeDeploy::DeploymentGroup` resource to be a list of objects and not a single object, [as seen in the documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codedeploy-deploymentgroup.html#cfn-codedeploy-deploymentgroup-onpremisesinstancetagfilters). This PR fixes that.

I would also like to change the `codedeploy.OnPremisesInstanceTagFilters` to `codedeploy.OnPremisesInstanceTagFilter` (singularis), but not sure how you usually go about doing things like that since it's breaking. If you think it's a good idea, let me know how you usually do it and I will fix it.