### PR TITLE
Fix AutoScalingRollingUpdate validation failure

### DIFF
--- a/tests/test_asg.py
+++ b/tests/test_asg.py
@@ -107,6 +107,37 @@ class TestAutoScalingGroup(unittest.TestCase):
         )
         self.assertTrue(group.validate())
 
+    def test_AutoScalingRollingUpdate_all_defaults(self):
+        group = AutoScalingGroup(
+            'mygroup',
+            AvailabilityZones=['eu-west-1a', 'eu-west-1b'],
+            LaunchConfigurationName="I'm a test",
+            MaxSize="1",
+            MinSize="1",
+            UpdatePolicy=UpdatePolicy(
+                AutoScalingRollingUpdate=AutoScalingRollingUpdate())
+        )
+        self.assertTrue(group.validate())
+
+    def test_AutoScalingRollingUpdate_validation(self):
+        update_policy = UpdatePolicy(
+            AutoScalingRollingUpdate=AutoScalingRollingUpdate(
+                MinInstancesInService="2",
+                MaxBatchSize='1'
+            )
+        )
+        group = AutoScalingGroup(
+            'mygroup',
+            AvailabilityZones=['eu-west-1a', 'eu-west-1b'],
+            LaunchConfigurationName="I'm a test",
+            MaxSize="2",
+            MinSize="1",
+            UpdatePolicy=update_policy
+        )
+
+        with self.assertRaises(ValueError):
+            self.assertTrue(group.validate())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/troposphere/autoscaling.py
+++ b/troposphere/autoscaling.py
@@ -167,16 +167,17 @@ class AutoScalingGroup(AWSObject):
                         update_policy.AutoScalingRollingUpdate, AWSHelperFn):
                     rolling_update = update_policy.AutoScalingRollingUpdate
 
+                    min_instances = rolling_update.properties.get(
+                        "MinInstancesInService", "0")
                     is_min_no_check = isinstance(
-                        rolling_update.MinInstancesInService,
-                        (FindInMap, Ref)
+                        min_instances, (FindInMap, Ref)
                     )
                     is_max_no_check = isinstance(self.MaxSize,
                                                  (If, FindInMap, Ref))
 
                     if not (is_min_no_check or is_max_no_check):
                         max_count = int(self.MaxSize)
-                        min_count = int(rolling_update.MinInstancesInService)
+                        min_count = int(min_instances)
 
                         if min_count >= max_count:
                             raise ValueError(


### PR DESCRIPTION
The validator for AutoScalingGroups assumed that if an AutoScalingRollingUpdate was specified, it would contain the MinInstancesInService attribute, which caused an AttributeError when that argument wasn't passed. However, MinInstancesInService is [optional](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html).

This fixes the assumption that MinInstancesInService is present by adding a default value, and adds tests for the existing intended behavior (to make sure I didn't break it) and to confirm the fix works.