### PR TITLE
adding UseOnlineResharding policy, per 09/20/2018 update

### DIFF
--- a/troposphere/policies.py
+++ b/troposphere/policies.py
@@ -40,6 +40,7 @@ class UpdatePolicy(AWSAttribute):
         'AutoScalingScheduledAction': (AutoScalingScheduledAction, False),
         'AutoScalingReplacingUpdate': (AutoScalingReplacingUpdate, False),
         'CodeDeployLambdaAliasUpdate': (CodeDeployLambdaAliasUpdate, False),
+        'UseOnlineResharding': (boolean, False),
     }
 
 


### PR DESCRIPTION
Sept 20th update added a new UpdatePolicy attribute for Elasticache replication groups. https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/ReleaseHistory.html