### PR TITLE
Add SchedulingStrategy as a prop to ecs.Service

### DIFF
--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -39,6 +39,30 @@ class TestECS(unittest.TestCase):
 
         ecs_service.to_dict()
 
+    def test_allow_scheduling_strategy(self):
+        task_definition = ecs.TaskDefinition(
+            "mytaskdef",
+            ContainerDefinitions=[
+                ecs.ContainerDefinition(
+                    Image="myimage",
+                    Memory="300",
+                    Name="mycontainer",
+                )
+            ],
+            Volumes=[
+                ecs.Volume(Name="my-vol"),
+            ],
+        )
+        ecs_service = ecs.Service(
+            'Service',
+            Cluster='cluster',
+            DesiredCount=2,
+            TaskDefinition=Ref(task_definition),
+            SchedulingStrategy=ecs.SCHEDULING_STRATEGY_DAEMON
+        )
+
+        ecs_service.to_dict()
+
     def test_fargate_launch_type(self):
         task_definition = ecs.TaskDefinition(
             "mytaskdef",

--- a/troposphere/ecs.py
+++ b/troposphere/ecs.py
@@ -5,6 +5,9 @@ from .validators import boolean, integer, network_port, positive_integer
 LAUNCH_TYPE_EC2 = 'EC2'
 LAUNCH_TYPE_FARGATE = 'FARGATE'
 
+SCHEDULING_STRATEGY_REPLICA = 'REPLICA'
+SCHEDULING_STRATEGY_DAEMON = 'DAEMON'
+
 
 class Cluster(AWSObject):
     resource_type = "AWS::ECS::Cluster"
@@ -104,6 +107,7 @@ class Service(AWSObject):
         'PlacementConstraints': ([PlacementConstraint], False),
         'PlacementStrategies': ([PlacementStrategy], False),
         'PlatformVersion': (basestring, False),
+        'SchedulingStrategy': (basestring, False),
         'ServiceName': (basestring, False),
         'ServiceRegistries': ([ServiceRegistry], False),
         'TaskDefinition': (basestring, True),


### PR DESCRIPTION
This adds support for the newly released `SchedulingStrategy` option in ecs.Service. See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-service.html#cfn-ecs-service-schedulingstrategy for more information on this parameter.