### PR TITLE
Add Launch Template capability to Spot Fleets

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -757,7 +757,7 @@ class LaunchSpecifications(AWSProperty):
     }
 
 
-class SpotFleetLaunchTemplateSpecification(AWSProperty):
+class FleetLaunchTemplateSpecification(AWSProperty):
     props = {
         'LaunchTemplateId': (basestring, False),
         'LaunchTemplateName': (basestring, False),
@@ -784,7 +784,7 @@ class LaunchTemplateOverrides(AWSProperty):
 
 class LaunchTemplateConfig(AWSProperty):
     props = {
-        'LaunchTemplateSpecification': (SpotFleetLaunchTemplateSpecification,
+        'LaunchTemplateSpecification': (FleetLaunchTemplateSpecification,
                                         True),
         'Overrides': ([LaunchTemplateOverrides], False)
     }

--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -758,12 +758,18 @@ class LaunchSpecifications(AWSProperty):
 
 
 class SpotFleetLaunchTemplateSpecification(AWSProperty):
-    # Only difference vs. LaunchTemplateSpecification is that Version is optional here
     props = {
         'LaunchTemplateId': (basestring, False),
         'LaunchTemplateName': (basestring, False),
-        'Version': (basestring, False),
+        'Version': (basestring, True),
     }
+
+    def validate(self):
+        template_identifiers = [
+            'LaunchTemplateId',
+            'LaunchTemplateName'
+        ]
+        exactly_one(self.__class__.__name__, self.properties, template_identifiers)
 
 
 class LaunchTemplateOverrides(AWSProperty):
@@ -776,10 +782,9 @@ class LaunchTemplateOverrides(AWSProperty):
     }
 
 
-class LaunchTemplateConfigs(AWSProperty):
-    # Not sure why LaunchTemplateSpecification is not required
+class LaunchTemplateConfig(AWSProperty):
     props = {
-        'LaunchTemplateSpecification': (SpotFleetLaunchTemplateSpecification, False),
+        'LaunchTemplateSpecification': (SpotFleetLaunchTemplateSpecification, True),
         'Overrides': ([LaunchTemplateOverrides], False)
     }
 
@@ -791,8 +796,8 @@ class SpotFleetRequestConfigData(AWSProperty):
         'IamFleetRole': (basestring, True),
         'InstanceInterruptionBehavior': (basestring, False),
         'ReplaceUnhealthyInstances': (boolean, False),
-        'LaunchSpecifications': ([LaunchSpecifications], True),
-        'LaunchTemplateConfigs': ([LaunchTemplateConfigs], False),
+        'LaunchSpecifications': ([LaunchSpecifications], False),
+        'LaunchTemplateConfigs': ([LaunchTemplateConfig], False),
         'SpotPrice': (basestring, False),
         'TargetCapacity': (positive_integer, True),
         'TerminateInstancesWithExpiration': (boolean, False),
@@ -800,6 +805,13 @@ class SpotFleetRequestConfigData(AWSProperty):
         'ValidFrom': (basestring, False),
         'ValidUntil': (basestring, False),
     }
+
+    def validate(self):
+        launch_props = [
+            'LaunchSpecifications',
+            'LaunchTemplateConfigs'
+        ]
+        exactly_one(self.__class__.__name__, self.properties, launch_props)
 
 
 class SpotFleet(AWSObject):

--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -757,13 +757,42 @@ class LaunchSpecifications(AWSProperty):
     }
 
 
+class SpotFleetLaunchTemplateSpecification(AWSProperty):
+    # Only difference vs. LaunchTemplateSpecification is that Version is optional here
+    props = {
+        'LaunchTemplateId': (basestring, False),
+        'LaunchTemplateName': (basestring, False),
+        'Version': (basestring, False),
+    }
+
+
+class LaunchTemplateOverrides(AWSProperty):
+    props = {
+        'AvailabilityZone': (basestring, False),
+        'InstanceType': (basestring, False),
+        'SpotPrice': (basestring, False),
+        'SubnetId': (basestring, False),
+        'WeightedCapacity': (basestring, False)
+    }
+
+
+class LaunchTemplateConfigs(AWSProperty):
+    # Not sure why LaunchTemplateSpecification is not required
+    props = {
+        'LaunchTemplateSpecification': (SpotFleetLaunchTemplateSpecification, False),
+        'Overrides': ([LaunchTemplateOverrides], False)
+    }
+
+
 class SpotFleetRequestConfigData(AWSProperty):
     props = {
         'AllocationStrategy': (basestring, False),
         'ExcessCapacityTerminationPolicy': (basestring, False),
         'IamFleetRole': (basestring, True),
+        'InstanceInterruptionBehavior': (basestring, False),
         'ReplaceUnhealthyInstances': (boolean, False),
         'LaunchSpecifications': ([LaunchSpecifications], True),
+        'LaunchTemplateConfigs': ([LaunchTemplateConfigs], False),
         'SpotPrice': (basestring, False),
         'TargetCapacity': (positive_integer, True),
         'TerminateInstancesWithExpiration': (boolean, False),

--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -765,11 +765,11 @@ class SpotFleetLaunchTemplateSpecification(AWSProperty):
     }
 
     def validate(self):
-        template_identifiers = [
+        conds = [
             'LaunchTemplateId',
             'LaunchTemplateName'
         ]
-        exactly_one(self.__class__.__name__, self.properties, template_identifiers)
+        exactly_one(self.__class__.__name__, self.properties, conds)
 
 
 class LaunchTemplateOverrides(AWSProperty):
@@ -784,7 +784,8 @@ class LaunchTemplateOverrides(AWSProperty):
 
 class LaunchTemplateConfig(AWSProperty):
     props = {
-        'LaunchTemplateSpecification': (SpotFleetLaunchTemplateSpecification, True),
+        'LaunchTemplateSpecification': (SpotFleetLaunchTemplateSpecification,
+                                        True),
         'Overrides': ([LaunchTemplateOverrides], False)
     }
 


### PR DESCRIPTION
EC2 Spot Fleets can now launch instances from Launch Templates, not just inline Launch Specifications. This adds that functionality to Troposphere.

I ran into a number of cases where the CF documentation didn't make sense, or when tested, didn't agree with CF's behavior -- I've submitted pull requests to their documentation in those cases, and I've written this PR to agree with CF's behavior, rather than the documentation. I'll point those instances out in the PR comments.