### PR TITLE
Use dict for RestApi Parameters

### DIFF
--- a/troposphere/apigateway.py
+++ b/troposphere/apigateway.py
@@ -300,7 +300,7 @@ class RestApi(AWSObject):
         "FailOnWarnings": (basestring, False),
         "MinimumCompressionSize": (positive_integer, False),
         "Name": (basestring, False),
-        "Parameters": ([basestring], False),
+        "Parameters": (dict, False),
         "Policy": (dict, False),
     }
 


### PR DESCRIPTION
By supplying value that the previous "[basestring]" accepted, aws would always respond:
"Value of property Parameters must be an object".
The documentation here https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html
shows the proper form to be:
"Parameters" : { String:String, ... },

This change allows such values to be set.