### PR TITLE
Update for new S3 destination option in flow logs

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -90,8 +90,10 @@ class FlowLog(AWSObject):
     resource_type = "AWS::EC2::FlowLog"
 
     props = {
-        'DeliverLogsPermissionArn': (basestring, True),
-        'LogGroupName': (basestring, True),
+        'DeliverLogsPermissionArn': (basestring, False),
+        'LogDestination': (basestring, False),
+        'LogDestinationType': (basestring, False),
+        'LogGroupName': (basestring, False),
         'ResourceId': (basestring, True),
         'ResourceType': (basestring, True),
         'TrafficType': (basestring, True),


### PR DESCRIPTION
Adds support for sending logs to S3 in addition to the existing Cloudwatch Logs option