### PR TITLE
Additional codebuild source types

### DIFF
--- a/troposphere/codebuild.py
+++ b/troposphere/codebuild.py
@@ -125,10 +125,12 @@ class Source(AWSProperty):
 
     def validate(self):
         valid_types = [
+            'BITBUCKET',
             'CODECOMMIT',
             'CODEPIPELINE',
             'GITHUB',
             'GITHUB_ENTERPRISE',
+            'NO_SOURCE',
             'S3',
         ]
 

--- a/troposphere/codebuild.py
+++ b/troposphere/codebuild.py
@@ -136,6 +136,7 @@ class Source(AWSProperty):
 
         location_agnostic_types = [
             'CODEPIPELINE',
+            'NO_SOURCE',
         ]
 
         source_type = self.properties.get('Type')


### PR DESCRIPTION
The `NO_SOURCE` type should not require a location specification.