### PR TITLE
improve double validation and fix some property datatypes

### DIFF
--- a/troposphere/apigateway.py
+++ b/troposphere/apigateway.py
@@ -1,6 +1,6 @@
 from . import AWSObject, AWSProperty
 from .validators import (
-    boolean, floatingpoint, integer_range, json_checker, positive_integer
+    boolean, double, integer_range, json_checker, positive_integer
 )
 
 
@@ -86,7 +86,7 @@ class CanarySetting(AWSProperty):
 
     props = {
         "DeploymentId": (basestring, False),
-        "PercentTraffic": ([floatingpoint], False),
+        "PercentTraffic": ([double], False),
         "StageVariableOverrides": (dict, False),
         "UseStageCache": (boolean, False),
     }
@@ -110,7 +110,7 @@ class ClientCertificate(AWSObject):
 class DeploymentCanarySettings(AWSProperty):
 
     props = {
-        "PercentTraffic": ([floatingpoint], False),
+        "PercentTraffic": ([double], False),
         "StageVariableOverrides": (dict, False),
         "UseStageCache": (boolean, False),
     }

--- a/troposphere/applicationautoscaling.py
+++ b/troposphere/applicationautoscaling.py
@@ -1,5 +1,5 @@
 from . import AWSObject, AWSProperty
-from .validators import boolean, floatingpoint, integer, positive_integer
+from .validators import boolean, double, integer, positive_integer
 
 
 class ScalableTargetAction(AWSProperty):
@@ -84,7 +84,7 @@ class TargetTrackingScalingPolicyConfiguration(AWSProperty):
             (PredefinedMetricSpecification, False),
         'ScaleInCooldown': (positive_integer, False),
         'ScaleOutCooldown': (positive_integer, False),
-        'TargetValue': (floatingpoint, True),
+        'TargetValue': (double, True),
     }
 
 

--- a/troposphere/cloudwatch.py
+++ b/troposphere/cloudwatch.py
@@ -4,7 +4,8 @@
 # See LICENSE file for full license.
 
 from . import AWSObject, AWSProperty
-from .validators import boolean, double, exactly_one, json_checker, positive_integer
+from .validators import (boolean, double, exactly_one, json_checker,
+                         positive_integer)
 
 
 class MetricDimension(AWSProperty):

--- a/troposphere/cloudwatch.py
+++ b/troposphere/cloudwatch.py
@@ -4,7 +4,7 @@
 # See LICENSE file for full license.
 
 from . import AWSObject, AWSProperty
-from .validators import boolean, exactly_one, json_checker, positive_integer
+from .validators import boolean, double, exactly_one, json_checker, positive_integer
 
 
 class MetricDimension(AWSProperty):
@@ -33,7 +33,7 @@ class Alarm(AWSObject):
         'OKActions': ([basestring], False),
         'Period': (positive_integer, True),
         'Statistic': (basestring, False),
-        'Threshold': (basestring, True),
+        'Threshold': (double, True),
         'TreatMissingData': (basestring, False),
         'Unit': (basestring, False),
     }

--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -5,7 +5,7 @@
 
 from . import AWSHelperFn, AWSObject, AWSProperty, Tags
 from .validators import (
-    boolean, exactly_one, integer, integer_range, floatingpoint,
+    boolean, exactly_one, integer, integer_range, double,
     network_port, positive_integer, vpn_pre_shared_key, vpn_tunnel_inside_cidr,
     vpc_endpoint_type
 )
@@ -765,7 +765,7 @@ class LaunchTemplateOverrides(AWSProperty):
         'InstanceType': (basestring, False),
         'SpotPrice': (basestring, False),
         'SubnetId': (basestring, False),
-        'WeightedCapacity': (floatingpoint, False)
+        'WeightedCapacity': (double, False)
     }
 
 

--- a/troposphere/emr.py
+++ b/troposphere/emr.py
@@ -5,7 +5,7 @@
 
 from . import AWSObject, AWSProperty, AWSHelperFn, Tags
 from .validators import (
-    boolean, integer, positive_integer, floatingpoint, defer
+    boolean, integer, positive_integer, double, defer
 )
 
 
@@ -197,7 +197,7 @@ class SimpleScalingPolicyConfiguration(AWSProperty):
             if adjustment_type == CHANGE_IN_CAPACITY:
                 integer(scaling_adjustment)
             elif adjustment_type == PERCENT_CHANGE_IN_CAPACITY:
-                floatingpoint(scaling_adjustment)
+                double(scaling_adjustment)
                 f = float(scaling_adjustment)
                 if f < 0.0 or f > 1.0:
                     raise ValueError(

--- a/troposphere/glue.py
+++ b/troposphere/glue.py
@@ -4,7 +4,7 @@
 # See LICENSE file for full license.
 
 from . import AWSObject, AWSProperty
-from .validators import boolean, floatingpoint, integer_range, positive_integer
+from .validators import boolean, double, integer_range, positive_integer
 
 
 class GrokClassifier(AWSProperty):
@@ -194,7 +194,7 @@ class ConnectionsList(AWSProperty):
 
 class ExecutionProperty(AWSProperty):
     props = {
-        'MaxConcurrentRuns': (floatingpoint, False),
+        'MaxConcurrentRuns': (positive_integer, False),
     }
 
 
@@ -209,14 +209,14 @@ class Job(AWSObject):
     resource_type = "AWS::Glue::Job"
 
     props = {
-        'AllocatedCapacity': (floatingpoint, False),
+        'AllocatedCapacity': (double, False),
         'Command': (JobCommand, True),
         'Connections': (ConnectionsList, False),
         'DefaultArguments': (dict, False),
         'Description': (basestring, False),
         'ExecutionProperty': (ExecutionProperty, False),
         'LogUri': (basestring, False),
-        'MaxRetries': (floatingpoint, False),
+        'MaxRetries': (double, False),
         'Name': (basestring, False),
         'Role': (basestring, True),
     }

--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -53,11 +53,11 @@ def integer_list_item(allowed_values):
     return integer_list_item_checker
 
 
-def floatingpoint(x):
+def double(x):
     try:
         float(x)
     except (ValueError, TypeError):
-        raise ValueError("%r is not a valid float" % x)
+        raise ValueError("%r is not a valid double" % x)
     else:
         return x
 


### PR DESCRIPTION
fixes #812 + improves validator consistency with AWS naming

 - replace `floatingpoint` validator with more valid `double` validator - this is also the naming used in AWS CloudFormation
 - update CloudWatch Alarm Threshold datatype to double (according to [documentation](https://docs.aws.amazon.com/de_de/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-threshold))
 - update Glue ExecutionProperty MaxConcurrentRuns datatype to positive_integer (according to [documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-job-executionproperty.html#cfn-glue-job-executionproperty-maxconcurrentruns))