### PR TITLE
Fix #1174 TemplateGenerator fail to parse template Fn::Sub with variable

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -406,19 +406,45 @@ class TestCidr(unittest.TestCase):
 
 class TestSub(unittest.TestCase):
 
-    def test_sub_with_vars(self):
+    def test_sub_without_vars(self):
         s = 'foo ${AWS::Region}'
         raw = Sub(s)
         actual = raw.to_dict()
         expected = {'Fn::Sub': 'foo ${AWS::Region}'}
         self.assertEqual(expected, actual)
 
-    def test_sub_without_vars(self):
+    def test_sub_with_vars_unpakaged(self):
         s = 'foo ${AWS::Region} ${sub1} ${sub2}'
         values = {'sub1': 'uno', 'sub2': 'dos'}
         raw = Sub(s, **values)
         actual = raw.to_dict()
         expected = {'Fn::Sub': ['foo ${AWS::Region} ${sub1} ${sub2}', values]}
+        self.assertEqual(expected, actual)
+
+    def test_sub_with_vars_not_unpakaged(self):
+        s = 'foo ${AWS::Region} ${sub1} ${sub2}'
+        values = {'sub1': 'uno', 'sub2': 'dos'}
+        raw = Sub(s, values)
+        actual = raw.to_dict()
+        expected = {'Fn::Sub': ['foo ${AWS::Region} ${sub1} ${sub2}', values]}
+        self.assertEqual(expected, actual)
+
+    def test_sub_with_vars_mix(self):
+        s = 'foo ${AWS::Region} ${sub1} ${sub2} ${sub3}'
+        values = {'sub1': 'uno', 'sub2': 'dos'}
+        raw = Sub(s, values, sub3='tres')
+        actual = raw.to_dict()
+        expected_values = {'sub1': 'uno', 'sub2': 'dos', 'sub3': 'tres'}
+        expected = {
+            'Fn::Sub': [
+                'foo ${AWS::Region} ${sub1} ${sub2} ${sub3}',
+                {
+                    'sub1': 'uno',
+                    'sub2': 'dos',
+                    'sub3': 'tres'
+                }
+            ]
+        }
         self.assertEqual(expected, actual)
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -434,7 +434,6 @@ class TestSub(unittest.TestCase):
         values = {'sub1': 'uno', 'sub2': 'dos'}
         raw = Sub(s, values, sub3='tres')
         actual = raw.to_dict()
-        expected_values = {'sub1': 'uno', 'sub2': 'dos', 'sub3': 'tres'}
         expected = {
             'Fn::Sub': [
                 'foo ${AWS::Region} ${sub1} ${sub2} ${sub3}',

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -473,7 +473,10 @@ class Split(AWSHelperFn):
 
 
 class Sub(AWSHelperFn):
-    def __init__(self, input_str, **values):
+    def __init__(self, input_str, dict_values=None, **values):
+        # merge dict
+        if dict_values:
+            values.update(dict_values)
         self.data = {'Fn::Sub': [input_str, values] if values else input_str}
 
 


### PR DESCRIPTION
Fix #1174 
 
TemplateGenerator was unable to load a template who contains a Fn::Sub with variables

Sample:
```json
{
  "AWSTemplateFormatVersion": "2010-09-09",
  "Resources": {
    "MySNS":{
      "Type" : "AWS::SNS::Topic",
      "Properties" : {
        "DisplayName" : "Display Name",
        "TopicName" : {
          "Fn::Sub": [ "MySNS-Test-${ABC}",
            {
              "ABC": "abc"
            }
          ]
        }
      }
    }
  }
}
``` 

The issue come from the definition of function `Sub`

As define here:
https://github.com/cloudtools/troposphere/blob/91dc3b5f8916b96ead45783c58d24ce7305c1701/troposphere/__init__.py#L474-L478

When the function is call **from the TemplateGenerator**, it will always have one or two arguments, never more, and if the second argument are present, it will be a **dict** (and it's dict are not unpackaged)

exemple:
```
Sub('MySNS-Test-${ABC}-${DEF}', { 'ABC': 'abc', 'DEF': 'def' })
```

When the function is call from the unit-tests, the second argument are **unpackaged**

https://github.com/cloudtools/troposphere/blob/91dc3b5f8916b96ead45783c58d24ce7305c1701/tests/test_basic.py#L406-L423

This is equivalent of:
```
Sub('MySNS-Test-${ABC}-${DEF}', ABC='abc', DEF='def')
```

So, how should we fix it ?

If we change Sub to
```python
def __init__(self, input_str, *values): 
```
the template generator will work fine, but we will have a **broking change**!

We can also supporte both of them with more code:
```python
class Sub(AWSHelperFn):
    def __init__(self, input_str, dict_values=None, **values):
        # merge dict
        if dict_values:
            values.update(dict_values)
        self.data = {'Fn::Sub': [input_str, values] if values else input_str}
```
 
Any suggest ? Any comment ?