### PR TITLE
Set line length for Python files in EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,5 +7,8 @@ charset = utf-8
 indent_style = space
 indent_size = 4
 
+[*.py]
+max_line_length = 79
+
 [Makefile]
 indent_style = tab


### PR DESCRIPTION
As the code style convention is validated using `pycodestyle` with the default settings, I added the corresponding parameter to EditorConfig file to enforce the line length to 79.