### PR TITLE
Setup to_dict for Tags AWSHelper

### DIFF
--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -1,5 +1,5 @@
 import unittest
-from troposphere import Template, Ref
+from troposphere import Template, Ref, Tags
 from troposphere import ecs
 from troposphere import iam
 
@@ -73,6 +73,13 @@ class TestDict(unittest.TestCase):
         self.d["Environment"][0] = "BadValue"
         with self.assertRaises(ValueError):
             ecs.ContainerDefinition.from_dict("mycontainer", self.d)
+
+    def test_tags_from_dict(self):
+        d = {"key1": "value1", "key2": "value2"}
+        expected = [{"Key": k, "Value": v} for k, v in d.items()]
+        tags = Tags.from_dict(**d)
+
+        self.assertEquals(sorted(expected), sorted(tags.tags))
 
 
 if __name__ == '__main__':

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -548,6 +548,10 @@ class Tags(AWSHelperFn):
     def to_dict(self):
         return [encode_to_dict(tag) for tag in self.tags]
 
+    @classmethod
+    def from_dict(cls, title=None, **kwargs):
+        return cls(**kwargs)
+
 
 class Template(object):
     props = {


### PR DESCRIPTION
Ran into an issue in stacker where resources with `Tags` couldn't be
built as `TroposphereType`s because Tags are a subclass of AWSHelperFn.