### PR TITLE
Small fix in validators.py, integer_list_item_checker should cast to int before checking list contains value

### DIFF
--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -45,6 +45,7 @@ def integer_range(minimum_val, maximum_val):
 def integer_list_item(allowed_values):
     def integer_list_item_checker(x):
         i = positive_integer(x)
+        i = int(x)
         if i in allowed_values:
             return x
         raise ValueError('Integer must be one of following: %s' %


### PR DESCRIPTION
Current code seems to assume positive_integer(x) converts to int, while it doesn't.
This problem generates 'Integer must be one of following...' error when the value is in the list because it tries to find a string in an array of ints. 

Other methods such as integer_range do cast correctly, integer_list_item should work the same.

Ran into this issue when creating a LogGroup object with RetentionInDays set to u'7' which should be valid.