### PR TITLE
Fix DockerVolumeConfiguration Labels and DriverOpts definition

### DIFF
--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -245,7 +245,9 @@ class TestECS(unittest.TestCase):
     def test_docker_volume_configuration(self):
         docker_volume_configuration = ecs.DockerVolumeConfiguration(
             Autoprovision=True,
-            Scope="task"
+            Scope="task",
+            Labels=dict(label="ok"),
+            DriverOpts=dict(option="ok")
         )
         task_definition = ecs.TaskDefinition(
             "mytaskdef",

--- a/troposphere/ecs.py
+++ b/troposphere/ecs.py
@@ -259,8 +259,8 @@ class DockerVolumeConfiguration(AWSProperty):
     props = {
         'Autoprovision': (boolean, False),
         'Driver': (basestring, False),
-        'DriverOpts': ([basestring], False),
-        'Labels': ([basestring], False),
+        'DriverOpts': (dict, False),
+        'Labels': (dict, False),
         'Scope': (scope_validator, False)
     }
 


### PR DESCRIPTION
AWS DockerVolumeConfiguration expects objects for Labels and DriverOpts.
The current definition leads to a failure when creating the stack : Value of property DriverOpts must be an object,  Value of property Labels must be an object