### PR TITLE
Add support for multi-region action in CodePipeline

### DIFF
--- a/troposphere/codepipeline.py
+++ b/troposphere/codepipeline.py
@@ -131,7 +131,7 @@ class Pipeline(AWSObject):
     resource_type = "AWS::CodePipeline::Pipeline"
 
     props = {
-        'ArtifactStore': (ArtifactStore, True),
+        'ArtifactStore': (ArtifactStore, False),
         'ArtifactStores': ([ArtifactStoreMap], False),
         'DisableInboundStageTransitions':
             ([DisableInboundStageTransitions], False),

--- a/troposphere/codepipeline.py
+++ b/troposphere/codepipeline.py
@@ -85,6 +85,13 @@ class ArtifactStore(AWSProperty):
     }
 
 
+class ArtifactStoreMap(AWSProperty):
+    props = {
+        'ArtifactStore': (ArtifactStore, True),
+        'Region': (basestring, True)
+    }
+
+
 class Actions(AWSProperty):
     props = {
         'ActionTypeId': (ActionTypeId, True),
@@ -92,6 +99,7 @@ class Actions(AWSProperty):
         'InputArtifacts': ([InputArtifacts], False),
         'Name': (basestring, True),
         'OutputArtifacts': ([OutputArtifacts], False),
+        'Region': (basestring, False),
         'RoleArn': (basestring, False),
         'RunOrder': (integer, False)
     }
@@ -124,6 +132,7 @@ class Pipeline(AWSObject):
 
     props = {
         'ArtifactStore': (ArtifactStore, True),
+        'ArtifactStores': ([ArtifactStoreMap], False),
         'DisableInboundStageTransitions':
             ([DisableInboundStageTransitions], False),
         'Name': (basestring, False),


### PR DESCRIPTION
AWS announced support for cross-region actions in CodePipeline. This PR adds the necessary functionality to Troposphere to enable cross-region actions.

Relevant AWS Docs and Announcements:

https://aws.amazon.com/about-aws/whats-new/2018/11/aws-codepipeline-now-supports-cross-region-actions/
https://docs.aws.amazon.com/codepipeline/latest/userguide/actions-create-cross-region.html