### PR TITLE
Fix CodeDeploy EC2TagSet definition

### DIFF
--- a/examples/CodeDeploy.py
+++ b/examples/CodeDeploy.py
@@ -1,8 +1,15 @@
 from troposphere import Template
-from troposphere.codedeploy import AutoRollbackConfiguration, \
-    DeploymentStyle, DeploymentGroup, ElbInfoList, LoadBalancerInfo, \
-    OnPremisesInstanceTagFilters
-
+from troposphere.codedeploy import (
+    AutoRollbackConfiguration,
+    DeploymentGroup,
+    DeploymentStyle,
+    Ec2TagFilters,
+    Ec2TagSet,
+    Ec2TagSetListObject,
+    ElbInfoList,
+    LoadBalancerInfo,
+    OnPremisesInstanceTagFilters,
+)
 
 template = Template()
 template.add_version('2010-09-09')
@@ -34,6 +41,39 @@ deployment_group = DeploymentGroup(
     ServiceRoleArn='arn:aws:iam::0123456789:role/codedeploy-role'
 )
 template.add_resource(deployment_group)
+
+# EC2 instances
+deployment_group_ec2 = DeploymentGroup(
+    "DemoDeploymentGroupEC2Instances",
+    DeploymentGroupName='DemoApplicationEc2Instances',
+    ApplicationName='DemoApplicationEc2Instances',
+    AutoRollbackConfiguration=auto_rollback_configuration,
+    DeploymentStyle=DeploymentStyle(
+        DeploymentOption='WITHOUT_TRAFFIC_CONTROL'
+    ),
+    ServiceRoleArn='arn:aws:iam::0123456789:role/codedeploy-role',
+    Ec2TagSet=Ec2TagSet(
+        Ec2TagSetList=[
+            Ec2TagSetListObject(
+                Ec2TagGroup=[
+                    Ec2TagFilters(
+                        Key="CodeDeploy",
+                        Type="KEY_AND_VALUE",
+                        Value="activated"
+                    ),
+                    Ec2TagFilters(
+                        Key="Environment",
+                        Type="KEY_AND_VALUE",
+                        Value="dev"
+                    ),
+                ]
+            )
+        ]
+    )
+)
+
+template.add_resource(deployment_group_ec2)
+
 
 # On premises
 deployment_group_on_premises = DeploymentGroup(

--- a/tests/examples_output/CodeDeploy.template
+++ b/tests/examples_output/CodeDeploy.template
@@ -24,6 +24,41 @@
             },
             "Type": "AWS::CodeDeploy::DeploymentGroup"
         },
+        "DemoDeploymentGroupEC2Instances": {
+            "Properties": {
+                "ApplicationName": "DemoApplicationEc2Instances",
+                "AutoRollbackConfiguration": {
+                    "Enabled": true,
+                    "Events": [
+                        "DEPLOYMENT_FAILURE"
+                    ]
+                },
+                "DeploymentGroupName": "DemoApplicationEc2Instances",
+                "DeploymentStyle": {
+                    "DeploymentOption": "WITHOUT_TRAFFIC_CONTROL"
+                },
+                "Ec2TagSet": {
+                    "Ec2TagSetList": [
+                        {
+                            "Ec2TagGroup": [
+                                {
+                                    "Key": "CodeDeploy",
+                                    "Type": "KEY_AND_VALUE",
+                                    "Value": "activated"
+                                },
+                                {
+                                    "Key": "Environment",
+                                    "Type": "KEY_AND_VALUE",
+                                    "Value": "dev"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "ServiceRoleArn": "arn:aws:iam::0123456789:role/codedeploy-role"
+            },
+            "Type": "AWS::CodeDeploy::DeploymentGroup"
+        },
         "DemoDeploymentGroupOnPremises": {
             "Properties": {
                 "ApplicationName": "DemoApplicationOnPremises",

--- a/troposphere/codedeploy.py
+++ b/troposphere/codedeploy.py
@@ -7,7 +7,6 @@ from . import AWSObject, AWSProperty
 from .validators import boolean, exactly_one, mutually_exclusive,\
     positive_integer
 
-
 KEY_ONLY = "KEY_ONLY"
 VALUE_ONLY = "VALUE_ONLY"
 KEY_AND_VALUE = "KEY_AND_VALUE"
@@ -179,15 +178,9 @@ class Ec2TagSetListObject(AWSProperty):
     }
 
 
-class Ec2TagSetList(AWSProperty):
-    props = {
-        'Ec2TagSetList': ([Ec2TagSetListObject], False)
-    }
-
-
 class Ec2TagSet(AWSProperty):
     props = {
-        'Ec2TagSet': (Ec2TagSetList, False)
+        'Ec2TagSetList': ([Ec2TagSetListObject], False)
     }
 
 


### PR DESCRIPTION
Redefine Ec2TagSet class using `Ec2TagSetList` as a property instead of `Ec2TagSet` as the current definition leads to a failure when creating the stack with status `Encountered unsupported property Ec2TagSet`.