### PR TITLE
Fixes LoadBalancersConfig structure

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -782,6 +782,12 @@ class ClassicLoadBalancer(AWSProperty):
     }
 
 
+class ClassicLoadBalancersConfig(AWSProperty):
+    props = {
+        'ClassicLoadBalancers': ([ClassicLoadBalancer], True)
+    }
+
+
 class TargetGroup(AWSProperty):
     props = {
         'Arn': (basestring, True)
@@ -790,7 +796,7 @@ class TargetGroup(AWSProperty):
 
 class LoadBalancersConfig(AWSProperty):
     props = {
-        'ClassicLoadBalancersConfig': ([ClassicLoadBalancer], False),
+        'ClassicLoadBalancersConfig': ([ClassicLoadBalancersConfig], False),
         'TargetGroupsConfig': (TargetGroup, False)
     }
 


### PR DESCRIPTION
### Files changed:

`ec2.py`

### Summary
Adds the missing structure to the classic load balancer config. 

Fixes #1206 