### PR TITLE
Add on-demand billing for DynamoDB tables

### DIFF
--- a/examples/DynamoDB_Tables_OnDemand.py
+++ b/examples/DynamoDB_Tables_OnDemand.py
@@ -1,0 +1,229 @@
+#!/usr/bin/python
+
+from troposphere import (
+    Template,
+    If,
+    NoValue,
+    Equals,
+    Ref,
+    Output,
+    Parameter
+)
+from troposphere.dynamodb import (
+    KeySchema,
+    AttributeDefinition,
+    Projection,
+    ProvisionedThroughput,
+    Table,
+    GlobalSecondaryIndex
+)
+
+template = Template()
+
+template.add_description("Create two dynamodb tables with "
+                         "conditional on-demand billing. One "
+                         "with global secondary index and one without")
+
+
+on_demand = template.add_parameter(Parameter(
+    "BillOnDemand",
+    Type="String",
+    Default="true",
+    AllowedPattern="(false|true)"
+))
+
+readunits = template.add_parameter(Parameter(
+    "ReadCapacityUnits",
+    Description="Provisioned read throughput",
+    Type="Number",
+    Default="5",
+    MinValue="5",
+    MaxValue="10000",
+    ConstraintDescription="should be between 5 and 10000"
+))
+
+writeunits = template.add_parameter(Parameter(
+    "WriteCapacityUnits",
+    Description="Provisioned write throughput",
+    Type="Number",
+    Default="10",
+    MinValue="5",
+    MaxValue="10000",
+    ConstraintDescription="should be between 5 and 10000"
+))
+
+template.add_condition("OnDemand", Equals(Ref(on_demand), "true"))
+
+hashkeyname = template.add_parameter(Parameter(
+    "HashKeyElementName",
+    Description="HashType PrimaryKey Name",
+    Type="String",
+    AllowedPattern="[a-zA-Z0-9]*",
+    MinLength="1",
+    MaxLength="2048",
+    ConstraintDescription="must contain only alphanumberic characters"
+))
+
+hashkeytype = template.add_parameter(Parameter(
+    "HashKeyElementType",
+    Description="HashType PrimaryKey Type",
+    Type="String",
+    Default="S",
+    AllowedPattern="[S|N]",
+    MinLength="1",
+    MaxLength="1",
+    ConstraintDescription="must be either S or N"
+))
+
+# N.B. If you remove the provisioning section this works for
+# LocalSecondaryIndexes aswell.
+
+tableIndexName = template.add_parameter(Parameter(
+    "TableIndexName",
+    Description="Table: Primary Key Field",
+    Type="String",
+    Default="id",
+    AllowedPattern="[a-zA-Z0-9]*",
+    MinLength="1",
+    MaxLength="2048",
+    ConstraintDescription="must contain only alphanumberic characters"
+))
+
+tableIndexDataType = template.add_parameter(Parameter(
+    "TableIndexDataType",
+    Description=" Table: Primary Key Data Type",
+    Type="String",
+    Default="S",
+    AllowedPattern="[S|N|B]",
+    MinLength="1",
+    MaxLength="1",
+    ConstraintDescription="S for string data, N for numeric data, or B for "
+                          "binary data"
+))
+
+secondaryIndexHashName = template.add_parameter(Parameter(
+    "SecondaryIndexHashName",
+    Description="Secondary Index: Primary Key Field",
+    Type="String",
+    Default="tokenType",
+    AllowedPattern="[a-zA-Z0-9]*",
+    MinLength="1",
+    MaxLength="2048",
+    ConstraintDescription="must contain only alphanumberic characters"
+))
+
+secondaryIndexHashDataType = template.add_parameter(Parameter(
+    "SecondaryIndexHashDataType",
+    Description="Secondary Index: Primary Key Data Type",
+    Type="String",
+    Default="S",
+    AllowedPattern="[S|N|B]",
+    MinLength="1",
+    MaxLength="1",
+    ConstraintDescription="S for string data, N for numeric data, or B for "
+                          "binary data"
+))
+
+secondaryIndexRangeName = template.add_parameter(Parameter(
+    "refreshSecondaryIndexRangeName",
+    Description="Secondary Index: Range Key Field",
+    Type="String",
+    Default="tokenUpdatedTime",
+    AllowedPattern="[a-zA-Z0-9]*",
+    MinLength="1",
+    MaxLength="2048",
+    ConstraintDescription="must contain only alphanumberic characters"
+))
+
+secondaryIndexRangeDataType = template.add_parameter(Parameter(
+    "SecondaryIndexRangeDataType",
+    Description="Secondary Index: Range Key Data Type",
+    Type="String",
+    Default="S",
+    AllowedPattern="[S|N|B]",
+    MinLength="1",
+    MaxLength="1",
+    ConstraintDescription="S for string data, N for numeric data, or B for "
+                          "binary data"
+))
+
+myDynamoDB = template.add_resource(Table(
+    "myDynamoDBTable",
+    AttributeDefinitions=[
+        AttributeDefinition(
+            AttributeName=Ref(hashkeyname),
+            AttributeType=Ref(hashkeytype)
+        ),
+    ],
+    BillingMode=If("OnDemand", "PAY_PER_REQUEST", "PROVISIONED"),
+    ProvisionedThroughput=If("OnDemand", NoValue, ProvisionedThroughput(
+        ReadCapacityUnits=Ref(readunits),
+        WriteCapacityUnits=Ref(writeunits)
+    )),
+    KeySchema=[
+        KeySchema(
+            AttributeName=Ref(hashkeyname),
+            KeyType="HASH"
+        )
+    ]
+))
+
+GSITable = template.add_resource(Table(
+    "GSITable",
+    AttributeDefinitions=[
+        AttributeDefinition(
+            AttributeName=Ref(tableIndexName),
+            AttributeType=Ref(tableIndexDataType)
+        ),
+        AttributeDefinition(
+            AttributeName=Ref(secondaryIndexHashName),
+            AttributeType=Ref(secondaryIndexHashDataType)
+        ),
+        AttributeDefinition(
+            AttributeName=Ref(secondaryIndexRangeName),
+            AttributeType=Ref(secondaryIndexRangeDataType)
+        )
+    ],
+    BillingMode=If("OnDemand", "PAY_PER_REQUEST", "PROVISIONED"),
+    KeySchema=[
+        KeySchema(
+            AttributeName=Ref(tableIndexName),
+            KeyType="HASH"
+        )
+    ],
+    ProvisionedThroughput=If("OnDemand", NoValue, ProvisionedThroughput(
+                             ReadCapacityUnits=Ref(readunits),
+                             WriteCapacityUnits=Ref(writeunits)
+                             )),
+    GlobalSecondaryIndexes=[
+        GlobalSecondaryIndex(
+            IndexName="SecondaryIndex",
+            KeySchema=[
+                KeySchema(
+                    AttributeName=Ref(secondaryIndexHashName),
+                    KeyType="HASH"
+                ),
+                KeySchema(
+                    AttributeName=Ref(secondaryIndexRangeName),
+                    KeyType="RANGE"
+                )
+            ],
+            Projection=Projection(ProjectionType="ALL"),
+            ProvisionedThroughput=If("OnDemand", NoValue,
+                                     ProvisionedThroughput(
+                                         ReadCapacityUnits=Ref(readunits),
+                                         WriteCapacityUnits=Ref(writeunits)
+                                     )
+                                     )
+        )
+    ]
+))
+
+template.add_output(Output(
+    "GSITable",
+    Value=Ref(GSITable),
+    Description="Table with a Global Secondary Index",
+))
+
+
+print(template.to_json())

--- a/tests/examples_output/DynamoDB_Tables_OnDemand.template
+++ b/tests/examples_output/DynamoDB_Tables_OnDemand.template
@@ -1,0 +1,263 @@
+{
+    "Conditions": {
+        "OnDemand": {
+            "Fn::Equals": [
+                {
+                    "Ref": "BillOnDemand"
+                },
+                "true"
+            ]
+        }
+    },
+    "Description": "Create two dynamodb tables with conditional on-demand billing. One with global secondary index and one without",
+    "Outputs": {
+        "GSITable": {
+            "Description": "Table with a Global Secondary Index",
+            "Value": {
+                "Ref": "GSITable"
+            }
+        }
+    },
+    "Parameters": {
+        "BillOnDemand": {
+            "AllowedPattern": "(false|true)",
+            "Default": "true",
+            "Type": "String"
+        },
+        "HashKeyElementName": {
+            "AllowedPattern": "[a-zA-Z0-9]*",
+            "ConstraintDescription": "must contain only alphanumberic characters",
+            "Description": "HashType PrimaryKey Name",
+            "MaxLength": "2048",
+            "MinLength": "1",
+            "Type": "String"
+        },
+        "HashKeyElementType": {
+            "AllowedPattern": "[S|N]",
+            "ConstraintDescription": "must be either S or N",
+            "Default": "S",
+            "Description": "HashType PrimaryKey Type",
+            "MaxLength": "1",
+            "MinLength": "1",
+            "Type": "String"
+        },
+        "ReadCapacityUnits": {
+            "ConstraintDescription": "should be between 5 and 10000",
+            "Default": "5",
+            "Description": "Provisioned read throughput",
+            "MaxValue": "10000",
+            "MinValue": "5",
+            "Type": "Number"
+        },
+        "SecondaryIndexHashDataType": {
+            "AllowedPattern": "[S|N|B]",
+            "ConstraintDescription": "S for string data, N for numeric data, or B for binary data",
+            "Default": "S",
+            "Description": "Secondary Index: Primary Key Data Type",
+            "MaxLength": "1",
+            "MinLength": "1",
+            "Type": "String"
+        },
+        "SecondaryIndexHashName": {
+            "AllowedPattern": "[a-zA-Z0-9]*",
+            "ConstraintDescription": "must contain only alphanumberic characters",
+            "Default": "tokenType",
+            "Description": "Secondary Index: Primary Key Field",
+            "MaxLength": "2048",
+            "MinLength": "1",
+            "Type": "String"
+        },
+        "SecondaryIndexRangeDataType": {
+            "AllowedPattern": "[S|N|B]",
+            "ConstraintDescription": "S for string data, N for numeric data, or B for binary data",
+            "Default": "S",
+            "Description": "Secondary Index: Range Key Data Type",
+            "MaxLength": "1",
+            "MinLength": "1",
+            "Type": "String"
+        },
+        "TableIndexDataType": {
+            "AllowedPattern": "[S|N|B]",
+            "ConstraintDescription": "S for string data, N for numeric data, or B for binary data",
+            "Default": "S",
+            "Description": " Table: Primary Key Data Type",
+            "MaxLength": "1",
+            "MinLength": "1",
+            "Type": "String"
+        },
+        "TableIndexName": {
+            "AllowedPattern": "[a-zA-Z0-9]*",
+            "ConstraintDescription": "must contain only alphanumberic characters",
+            "Default": "id",
+            "Description": "Table: Primary Key Field",
+            "MaxLength": "2048",
+            "MinLength": "1",
+            "Type": "String"
+        },
+        "WriteCapacityUnits": {
+            "ConstraintDescription": "should be between 5 and 10000",
+            "Default": "10",
+            "Description": "Provisioned write throughput",
+            "MaxValue": "10000",
+            "MinValue": "5",
+            "Type": "Number"
+        },
+        "refreshSecondaryIndexRangeName": {
+            "AllowedPattern": "[a-zA-Z0-9]*",
+            "ConstraintDescription": "must contain only alphanumberic characters",
+            "Default": "tokenUpdatedTime",
+            "Description": "Secondary Index: Range Key Field",
+            "MaxLength": "2048",
+            "MinLength": "1",
+            "Type": "String"
+        }
+    },
+    "Resources": {
+        "GSITable": {
+            "Properties": {
+                "AttributeDefinitions": [
+                    {
+                        "AttributeName": {
+                            "Ref": "TableIndexName"
+                        },
+                        "AttributeType": {
+                            "Ref": "TableIndexDataType"
+                        }
+                    },
+                    {
+                        "AttributeName": {
+                            "Ref": "SecondaryIndexHashName"
+                        },
+                        "AttributeType": {
+                            "Ref": "SecondaryIndexHashDataType"
+                        }
+                    },
+                    {
+                        "AttributeName": {
+                            "Ref": "refreshSecondaryIndexRangeName"
+                        },
+                        "AttributeType": {
+                            "Ref": "SecondaryIndexRangeDataType"
+                        }
+                    }
+                ],
+                "BillingMode": {
+                    "Fn::If": [
+                        "OnDemand",
+                        "PAY_PER_REQUEST",
+                        "PROVISIONED"
+                    ]
+                },
+                "GlobalSecondaryIndexes": [
+                    {
+                        "IndexName": "SecondaryIndex",
+                        "KeySchema": [
+                            {
+                                "AttributeName": {
+                                    "Ref": "SecondaryIndexHashName"
+                                },
+                                "KeyType": "HASH"
+                            },
+                            {
+                                "AttributeName": {
+                                    "Ref": "refreshSecondaryIndexRangeName"
+                                },
+                                "KeyType": "RANGE"
+                            }
+                        ],
+                        "Projection": {
+                            "ProjectionType": "ALL"
+                        },
+                        "ProvisionedThroughput": {
+                            "Fn::If": [
+                                "OnDemand",
+                                {
+                                    "Ref": "AWS::NoValue"
+                                },
+                                {
+                                    "ReadCapacityUnits": {
+                                        "Ref": "ReadCapacityUnits"
+                                    },
+                                    "WriteCapacityUnits": {
+                                        "Ref": "WriteCapacityUnits"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "KeySchema": [
+                    {
+                        "AttributeName": {
+                            "Ref": "TableIndexName"
+                        },
+                        "KeyType": "HASH"
+                    }
+                ],
+                "ProvisionedThroughput": {
+                    "Fn::If": [
+                        "OnDemand",
+                        {
+                            "Ref": "AWS::NoValue"
+                        },
+                        {
+                            "ReadCapacityUnits": {
+                                "Ref": "ReadCapacityUnits"
+                            },
+                            "WriteCapacityUnits": {
+                                "Ref": "WriteCapacityUnits"
+                            }
+                        }
+                    ]
+                }
+            },
+            "Type": "AWS::DynamoDB::Table"
+        },
+        "myDynamoDBTable": {
+            "Properties": {
+                "AttributeDefinitions": [
+                    {
+                        "AttributeName": {
+                            "Ref": "HashKeyElementName"
+                        },
+                        "AttributeType": {
+                            "Ref": "HashKeyElementType"
+                        }
+                    }
+                ],
+                "BillingMode": {
+                    "Fn::If": [
+                        "OnDemand",
+                        "PAY_PER_REQUEST",
+                        "PROVISIONED"
+                    ]
+                },
+                "KeySchema": [
+                    {
+                        "AttributeName": {
+                            "Ref": "HashKeyElementName"
+                        },
+                        "KeyType": "HASH"
+                    }
+                ],
+                "ProvisionedThroughput": {
+                    "Fn::If": [
+                        "OnDemand",
+                        {
+                            "Ref": "AWS::NoValue"
+                        },
+                        {
+                            "ReadCapacityUnits": {
+                                "Ref": "ReadCapacityUnits"
+                            },
+                            "WriteCapacityUnits": {
+                                "Ref": "WriteCapacityUnits"
+                            }
+                        }
+                    ]
+                }
+            },
+            "Type": "AWS::DynamoDB::Table"
+        }
+    }
+}

--- a/troposphere/template_generator.py
+++ b/troposphere/template_generator.py
@@ -271,6 +271,8 @@ class TemplateGenerator(Template):
             if isinstance(args, Ref):
                 # use the returned ref instead of creating a new object
                 return args
+            if isinstance(args, AWSHelperFn):
+                return self._convert_definition(kwargs)
             assert isinstance(args, Mapping)
             return cls(title=ref, **args)
 


### PR DESCRIPTION
I saw that #1239 is also open for the same feature and that there were a couple suggestions made for adding more validation.

I would appreciate feedback on whether my validation logic can be improved since I couldn't find any other set of properties resembling DynamoDB's billing logic now. I looked at the ELBv2 code and was surprised that it doesn't do more deep validation to model the numerous conditionally required properties / mutually exclusive properties.

Although the `ProvisionedThroughput` AWSProperty has become optional unless the billing mode is `PAY_PER_REQUEST` this does not seem to be consistent when using Global Secondary Indexes because that still requires `ProvisionedThroughput` settings. You can confirm this currently in the console because you can't specify on-demand for the GSI. In a possibly related behavior, updates to the GSI `ProvisionedThroughput` property seem to be getting ignored and failing internally in CloudFormation with a 400 status `One or more parameter values were invalid: List of GlobalSecondaryIndexUpdates is empty`. All I really checked was that CloudFormation validates and creates the stack correctly.

In a slightly unrelated fix, I had a great deal of trouble getting a new use case accepted by the tests and added a fix. A complex object returned by a Conditional didn't validate in Troposphere but is definitely accepted by CloudFormation (the example template deploys nicely). Consequently, I added some extra logic to the template generator code to be a little more lenient. Should I split this PR into a separate bug fix? In self-interest, I'd prefer to keep this PR together but I'll do whatever is desired by maintainers.

Edit: referenced wrong PR