### PR TITLE
Add support for DeploymentPreference to AWS::Serverless::Function

### DIFF
--- a/examples/Serverless_Deployment_Preference.py
+++ b/examples/Serverless_Deployment_Preference.py
@@ -1,0 +1,28 @@
+# Converted from s3_processor located at:
+# https://github.com/awslabs/serverless-application-model/blob/dbc54b5d0cd31bf5cebd16d765b74aee9eb34641/examples/2016-10-31/s3_processor/template.yaml
+
+from troposphere import Template
+from troposphere.serverless import Function, DeploymentPreference
+
+t = Template()
+
+t.add_description(
+    "A function that uses the configured traffic shifting type for a canary deployment.")
+
+t.add_transform('AWS::Serverless-2016-10-31')
+
+t.add_resource(
+    Function(
+        "Function",
+        Handler='index.handler',
+        Runtime='nodejs6.10',
+        CodeUri='s3://<bucket>/function.zip',
+        AutoPublishAlias="live",
+        DeploymentPreference=DeploymentPreference(
+            Enabled=True,
+            Type="Canary10Percent5Minutes"
+        )
+    )
+)
+
+print(t.to_json())

--- a/examples/Serverless_Deployment_Preference.py
+++ b/examples/Serverless_Deployment_Preference.py
@@ -7,7 +7,8 @@ from troposphere.serverless import Function, DeploymentPreference
 t = Template()
 
 t.add_description(
-    "A function that uses the configured traffic shifting type for a canary deployment.")
+    "A function that uses the configured traffic shifting type "
+    "for a canary deployment.")
 
 t.add_transform('AWS::Serverless-2016-10-31')
 

--- a/tests/examples_output/Serverless_Deployment_Preference.template
+++ b/tests/examples_output/Serverless_Deployment_Preference.template
@@ -1,0 +1,19 @@
+{
+    "Description": "A function that uses the configured traffic shifting type for a canary deployment.",
+    "Resources": {
+        "Function": {
+            "Properties": {
+                "AutoPublishAlias": "live",
+                "CodeUri": "s3://<bucket>/function.zip",
+                "DeploymentPreference": {
+                    "Enabled": true,
+                    "Type": "Canary10Percent5Minutes"
+                },
+                "Handler": "index.handler",
+                "Runtime": "nodejs6.10"
+            },
+            "Type": "AWS::Serverless::Function"
+        }
+    },
+    "Transform": "AWS::Serverless-2016-10-31"
+}

--- a/tests/test_serverless.py
+++ b/tests/test_serverless.py
@@ -2,7 +2,7 @@ import unittest
 from troposphere import Tags, Template
 from troposphere.s3 import Filter, Rules, S3Key
 from troposphere.serverless import (
-    Api, DeadLetterQueue, Function, FunctionForPackaging,
+    Api, DeadLetterQueue, DeploymentPreference, Function, FunctionForPackaging,
     S3Event, S3Location, SimpleTable,
 )
 
@@ -70,6 +70,21 @@ class TestServerless(unittest.TestCase):
             Runtime="nodejs",
             CodeUri="s3://bucket/handler.zip",
             AutoPublishAlias="alias"
+        )
+        t = Template()
+        t.add_resource(serverless_func)
+        t.to_json()
+
+    def test_optional_deployment_preference(self):
+        serverless_func = Function(
+            "SomeHandler",
+            Handler="index.handler",
+            Runtime="nodejs",
+            CodeUri="s3://bucket/handler.zip",
+            AutoPublishAlias="alias",
+            DeploymentPreference=DeploymentPreference(
+                Type="AllAtOnce"
+            )
         )
         t = Template()
         t.add_resource(serverless_func)

--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -47,6 +47,23 @@ class S3Location(AWSProperty):
     }
 
 
+class Hooks(AWSProperty):
+    props = {
+        "PreTraffic": (basestring, False),
+        "PostTraffic": (basestring, False)
+
+    }
+
+
+class DeploymentPreference(AWSProperty):
+    props = {
+        "Type": (basestring, True),
+        "Alarms": (list, False),
+        "Hooks": (Hooks, False),
+        "Enabled": (bool, False)
+    }
+
+
 class Function(AWSObject):
     resource_type = "AWS::Serverless::Function"
 
@@ -67,7 +84,8 @@ class Function(AWSObject):
         'Tracing': (basestring, False),
         'KmsKeyArn': (basestring, False),
         'DeadLetterQueue': (DeadLetterQueue, False),
-        'AutoPublishAlias': (basestring, False)
+        'AutoPublishAlias': (basestring, False),
+        'DeploymentPreference': (DeploymentPreference, False)
     }
 
 


### PR DESCRIPTION
This PR adds support for the DeploymentPreference option in SAM based templates. 

For more details, see [documentation](https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#deploymentpreference-object)