### PR TITLE
Added new aws properties in elbv2

### DIFF
--- a/troposphere/elasticloadbalancingv2.py
+++ b/troposphere/elasticloadbalancingv2.py
@@ -23,12 +23,60 @@ class Certificate(AWSProperty):
     }
 
 
+class AuthenticateCognitoConfig(AWSProperty):
+    props = {
+        'AuthenticationRequestExtraParams': (dict,False),
+        'OnUnauthenticatedRequest':(basestring,False),
+        'Scope':(basestring,False),
+        'SessionCookieName':(basestring,False),
+        'SessionTimeout':(integer, True),
+        'UserPoolArn':(basestring, True),
+        'UserPoolClientId':(basestring, True),
+        'UserPoolDomain':(basestring,True)
+    }
+
+class AuthenticateOidcConfig(AWSProperty):
+    props = {
+        'AuthenticationRequestExtraParams': (dict,False),
+        'AuthorizationEndpoint':(basestring,True),
+        'ClientId':(basestring,True),
+        'ClientSecret':(basestring,True),
+        'Issuer':(basestring,True),
+        'OnUnauthenticatedRequest':(basestring,False),
+        'Scope':(basestring,False),
+        'SessionCookieName':(basestring,False),
+        'SessionTimeout':(integer,False),
+        'TokenEndpoint':(basestring,True),
+        'UserInfoEndpoint':(basestring,True)
+    }
+
+class FixedResponseConfig(AWSProperty):
+    props = {
+        'ContentType':(basestring,False),
+        'MessageBody':(basestring,False),
+        'StatusCode':(basestring,True)
+    }
+
+class RedirectConfig(AWSProperty):
+    props = {
+        'Host':(basestring,False),
+        'Path':(basestring,False),
+        'Port':(integer,False),
+        'Protocol':(basestring,False),
+        'Query':(basestring,False),
+        'StatusCode':(basestring,True)
+    }
+
 class Action(AWSProperty):
     props = {
+        'AuthenticateCognitoConfig': (AuthenticateCognitoConfig, False),
+        'AuthenticateOidcConfig':(AuthenticateOidcConfig,False),
+        'FixedResponseConfig':(FixedResponseConfig,False),
+        'Order':(integer,False),
+        'RedirectConfig':(RedirectConfig,False),
         'TargetGroupArn': (basestring, True),
         'Type': (basestring, True)
     }
-
 
 class Condition(AWSProperty):
     props = {

--- a/troposphere/elasticloadbalancingv2.py
+++ b/troposphere/elasticloadbalancingv2.py
@@ -78,7 +78,7 @@ class Action(AWSProperty):
         'FixedResponseConfig': (FixedResponseConfig, False),
         'Order': (integer, False),
         'RedirectConfig': (RedirectConfig, False),
-        'TargetGroupArn': (basestring, True),
+        'TargetGroupArn': (basestring, False),
         'Type': (basestring, True)
     }
 

--- a/troposphere/elasticloadbalancingv2.py
+++ b/troposphere/elasticloadbalancingv2.py
@@ -38,7 +38,7 @@ class AuthenticateCognitoConfig(AWSProperty):
 
 class AuthenticateOidcConfig(AWSProperty):
     props = {
-        'AuthenticationRequestExtraParams': (dict,False),
+        'AuthenticationRequestExtraParams': (dict, False),
         'AuthorizationEndpoint': (basestring, True),
         'ClientId': (basestring, True),
         'ClientSecret': (basestring, True),

--- a/troposphere/elasticloadbalancingv2.py
+++ b/troposphere/elasticloadbalancingv2.py
@@ -25,58 +25,63 @@ class Certificate(AWSProperty):
 
 class AuthenticateCognitoConfig(AWSProperty):
     props = {
-        'AuthenticationRequestExtraParams': (dict,False),
-        'OnUnauthenticatedRequest':(basestring,False),
-        'Scope':(basestring,False),
-        'SessionCookieName':(basestring,False),
-        'SessionTimeout':(integer, True),
-        'UserPoolArn':(basestring, True),
-        'UserPoolClientId':(basestring, True),
-        'UserPoolDomain':(basestring,True)
+        'AuthenticationRequestExtraParams': (dict, False),
+        'OnUnauthenticatedRequest': (basestring, False),
+        'Scope': (basestring, False),
+        'SessionCookieName': (basestring, False),
+        'SessionTimeout': (integer, True),
+        'UserPoolArn': (basestring, True),
+        'UserPoolClientId': (basestring, True),
+        'UserPoolDomain': (basestring, True)
     }
+
 
 class AuthenticateOidcConfig(AWSProperty):
     props = {
         'AuthenticationRequestExtraParams': (dict,False),
-        'AuthorizationEndpoint':(basestring,True),
-        'ClientId':(basestring,True),
-        'ClientSecret':(basestring,True),
-        'Issuer':(basestring,True),
-        'OnUnauthenticatedRequest':(basestring,False),
-        'Scope':(basestring,False),
-        'SessionCookieName':(basestring,False),
-        'SessionTimeout':(integer,False),
-        'TokenEndpoint':(basestring,True),
-        'UserInfoEndpoint':(basestring,True)
+        'AuthorizationEndpoint': (basestring, True),
+        'ClientId': (basestring, True),
+        'ClientSecret': (basestring, True),
+        'Issuer': (basestring, True),
+        'OnUnauthenticatedRequest': (basestring, False),
+        'Scope': (basestring, False),
+        'SessionCookieName': (basestring, False),
+        'SessionTimeout': (integer, False),
+        'TokenEndpoint': (basestring, True),
+        'UserInfoEndpoint': (basestring, True)
     }
+
 
 class FixedResponseConfig(AWSProperty):
     props = {
-        'ContentType':(basestring,False),
-        'MessageBody':(basestring,False),
-        'StatusCode':(basestring,True)
+        'ContentType': (basestring, False),
+        'MessageBody': (basestring, False),
+        'StatusCode': (basestring, True)
     }
+
 
 class RedirectConfig(AWSProperty):
     props = {
-        'Host':(basestring,False),
-        'Path':(basestring,False),
-        'Port':(integer,False),
-        'Protocol':(basestring,False),
-        'Query':(basestring,False),
-        'StatusCode':(basestring,True)
+        'Host': (basestring, False),
+        'Path': (basestring, False),
+        'Port': (integer, False),
+        'Protocol': (basestring, False),
+        'Query': (basestring, False),
+        'StatusCode': (basestring, True)
     }
+
 
 class Action(AWSProperty):
     props = {
         'AuthenticateCognitoConfig': (AuthenticateCognitoConfig, False),
-        'AuthenticateOidcConfig':(AuthenticateOidcConfig,False),
-        'FixedResponseConfig':(FixedResponseConfig,False),
-        'Order':(integer,False),
-        'RedirectConfig':(RedirectConfig,False),
+        'AuthenticateOidcConfig': (AuthenticateOidcConfig, False),
+        'FixedResponseConfig': (FixedResponseConfig, False),
+        'Order': (integer, False),
+        'RedirectConfig': (RedirectConfig, False),
         'TargetGroupArn': (basestring, True),
         'Type': (basestring, True)
     }
+
 
 class Condition(AWSProperty):
     props = {


### PR DESCRIPTION
A series of new additions have been made by aws to elbv2 properties. These are the new listener actions available:
* AuthenticateCognitoConfig
* AuthenticateOidcConfig
* FixedResponseConfig
* RedirectConfig
* Order

These series of changes add support for these. For more information refer to their documentation here:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listenerrule-actions.html#cfn-elasticloadbalancingv2-listenerrule-action-authenticatecognitoconfig

One slight change I have made is that TargetGroupARN is required in their docs but I made it conditional because you can't include that when you use certain actions like the AuthenticateCognitoConfig.

I tried to keep this in the same format that I have been seeing in this repository.

I don't know if these have been added in the elb as well because I haven't looked due to the fact that I am not using it.