### PR TITLE
Add DeleteAutomatedBackups to RDS DBInstance

### DIFF
--- a/troposphere/rds.py
+++ b/troposphere/rds.py
@@ -173,6 +173,7 @@ class DBInstance(AWSObject):
         'DBSecurityGroups': (list, False),
         'DBSnapshotIdentifier': (basestring, False),
         'DBSubnetGroupName': (basestring, False),
+        'DeleteAutomatedBackups': (boolean, False),
         'DeletionProtection': (boolean, False),
         'Domain': (basestring, False),
         'DomainIAMRoleName': (basestring, False),


### PR DESCRIPTION
This was part of the Nov. 19 update:

> Use the DeleteAutomatedBackups property to indicate whether automated backups should be deleted (true) or retained (false) when you delete a DB instance. The default is true.