### PR TITLE
Fix EC2Fleet class definition to match functional correctness of Clou…

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -1066,7 +1066,7 @@ class EC2Fleet(AWSObject):
     resource_type = "AWS::EC2::EC2Fleet"
     props = {
         'ExcessCapacityTerminationPolicy': (basestring, False),
-        'LaunchTemplateConfigs': (FleetLaunchTemplateConfigRequest, True),
+        'LaunchTemplateConfigs': ([FleetLaunchTemplateConfigRequest], True),
         'OnDemandOptions': (OnDemandOptionsRequest, False),
         'ReplaceUnhealthyInstances': (boolean, False),
         'SpotOptions': (SpotOptionsRequest, False),
@@ -1075,6 +1075,6 @@ class EC2Fleet(AWSObject):
                                         False),
         'TerminateInstancesWithExpiration': (boolean, False),
         'Type': (basestring, False),
-        'ValidFrom': (integer, False),
-        'ValidUntil': (integer, False),
+        'ValidFrom': (str, False),
+        'ValidUntil': (str, False),
     }


### PR DESCRIPTION
The LaunchTemplateConfigs property of AWS::EC2::EC2Fleet is required to be a list of FleetLaunchConfigRequest objects
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html

While the CloudFormation documentation currently states that ValidFrom and ValidUntil type is `Integer`, the details property description states:
```
date and time of the request, in UTC format (for example, YYYY-MM-DDTHH:MM:SSZ)
```
Troposphere incorrectly diverges from the CloudFormation documentation in the preceeding case.

CloudFormation actually requires `ValidUntil` and `ValidFrom` to be an ISO 8601 formatted string, similar to the corresponding properties in AWS::EC2::SpotFleet property `SpotFleetRequestConfigData`
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-spotfleet-spotfleetrequestconfigdata.html

Troposphere currently follows the CloudFormation documentation in this case, which is actually incorrect.