### PR TITLE
Fix nested 'Name' sections in Output import

### DIFF
--- a/troposphere/template_generator.py
+++ b/troposphere/template_generator.py
@@ -25,7 +25,7 @@ from troposphere import (
     Output, Parameter,  # AWSDeclarations
     AWSObject,  # covers resources
     AWSHelperFn, GenericHelperFn,  # covers ref, fn::, etc
-    Tags, autoscaling, cloudformation)
+    Tags, autoscaling, cloudformation, Export)
 from troposphere.policies import UpdatePolicy, CreationPolicy
 
 
@@ -228,6 +228,9 @@ class TemplateGenerator(Template):
 
                 if issubclass(cls, autoscaling.Metadata):
                     return self._generate_autoscaling_metadata(cls, args)
+
+                if issubclass(cls, Export):
+                    return cls(args['Name'])
 
                 args = self._convert_definition(args)
                 if isinstance(args, Ref) and issubclass(cls, Ref):


### PR DESCRIPTION
TemplateGenerator seems to generate nested 'Name' sections to Exports in Output section as mentioned in issue #977, this PR should fix the nesting