### PR TITLE
cloudfront - remove unsupported property

### DIFF
--- a/examples/CloudFront_StreamingDistribution_S3.py
+++ b/examples/CloudFront_StreamingDistribution_S3.py
@@ -31,7 +31,7 @@ myDistribution = t.add_resource(StreamingDistribution(
     StreamingDistributionConfig=StreamingDistributionConfig(
         Comment="Streaming distribution",
         Enabled=True,
-        S3Origin=S3Origin(DomainName=Ref(s3dnsname)),
+        S3Origin=S3Origin(),
         TrustedSigners=TrustedSigners(
             Enabled=False,
         ),

--- a/troposphere/cloudfront.py
+++ b/troposphere/cloudfront.py
@@ -73,7 +73,6 @@ class DefaultCacheBehavior(AWSProperty):
 
 class S3Origin(AWSProperty):
     props = {
-        'DomainName': (basestring, True),
         'OriginAccessIdentity': (basestring, False),
     }
 


### PR DESCRIPTION
This property (DomainName) is not supported for S3Origin in CloudFormation https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-s3originconfig.html
neither in boto3 api https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudfront.html#CloudFront.Client.create_distribution
```
'S3OriginConfig': {
                        'OriginAccessIdentity': 'string'
                    },
```

The stack is rolled back with error 
```
Property validation failure: [Encountered unsupported properties in {/DistributionConfig/Origins/0/S3OriginConfig}: [DomainName]]
```
