### PR TITLE
Allow empty To/From port ranges for SG's for certain IP protocols

### DIFF
--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -37,6 +37,22 @@ class TestEC2(unittest.TestCase):
 
         egress = ec2.SecurityGroupEgress(
             'egress',
+            IpProtocol="-1",
+            GroupId="id",
+            DestinationSecurityGroupId='id',
+        )
+        egress.to_dict()
+
+        egress = ec2.SecurityGroupEgress(
+            'egress',
+            IpProtocol="58",
+            GroupId="id",
+            DestinationSecurityGroupId='id',
+        )
+        egress.to_dict()
+
+        egress = ec2.SecurityGroupEgress(
+            'egress',
             ToPort='80',
             FromPort='80',
             IpProtocol="tcp",
@@ -44,9 +60,10 @@ class TestEC2(unittest.TestCase):
             CidrIp="0.0.0.0/0",
             DestinationPrefixListId='id',
         )
-
         with self.assertRaises(ValueError):
             egress.to_dict()
+
+        # Test mutually exclusive fields
         egress = ec2.SecurityGroupEgress(
             'egress',
             ToPort='80',
@@ -57,6 +74,26 @@ class TestEC2(unittest.TestCase):
             DestinationPrefixListId='id',
             DestinationSecurityGroupId='id',
         )
+        with self.assertRaises(ValueError):
+            egress.to_dict()
 
+        # Test no ToPort
+        egress = ec2.SecurityGroupEgress(
+            'egress',
+            FromPort='80',
+            IpProtocol="tcp",
+            GroupId="id",
+            CidrIp="0.0.0.0/0",
+        )
+        with self.assertRaises(ValueError):
+            egress.to_dict()
+
+        # Test no ToPort or FromPort
+        egress = ec2.SecurityGroupEgress(
+            'egress',
+            IpProtocol="tcp",
+            GroupId="id",
+            CidrIp="0.0.0.0/0",
+        )
         with self.assertRaises(ValueError):
             egress.to_dict()

--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -427,8 +427,12 @@ class RouteTable(AWSObject):
 
 
 def check_ports(props):
-    # Specify "all protocols" and ICMPv6
-    ports_optional = ["-1", "58"]
+    # IpProtocol is a required field but not all values allowed require
+    # ToPort and FromPort. The ones that don't need these ports are:
+    ports_optional = [
+        "-1",  # all protocols
+        "58",  # ICMPv6
+    ]
     proto = props['IpProtocol']
 
     if proto not in ports_optional:

--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -426,6 +426,17 @@ class RouteTable(AWSObject):
     }
 
 
+def check_ports(props):
+    # Specify "all protocols" and ICMPv6
+    ports_optional = ["-1", "58"]
+    proto = props['IpProtocol']
+
+    if proto not in ports_optional:
+        if not ('ToPort' in props and 'FromPort' in props):
+            raise ValueError(
+                "ToPort/FromPort must be specified for proto %s" % proto)
+
+
 class SecurityGroupEgress(AWSObject):
     resource_type = "AWS::EC2::SecurityGroupEgress"
 
@@ -435,10 +446,10 @@ class SecurityGroupEgress(AWSObject):
         'Description': (basestring, False),
         'DestinationPrefixListId': (basestring, False),
         'DestinationSecurityGroupId': (basestring, False),
-        'FromPort': (network_port, True),
+        'FromPort': (network_port, False),
         'GroupId': (basestring, True),
         'IpProtocol': (basestring, True),
-        'ToPort': (network_port, True),
+        'ToPort': (network_port, False),
         #
         # Workaround for a bug in CloudFormation and EC2 where the
         # DestinationSecurityGroupId property is ignored causing
@@ -457,6 +468,7 @@ class SecurityGroupEgress(AWSObject):
             'DestinationSecurityGroupId',
         ]
         exactly_one(self.__class__.__name__, self.properties, conds)
+        check_ports(self.properties)
 
 
 class SecurityGroupIngress(AWSObject):
@@ -466,14 +478,14 @@ class SecurityGroupIngress(AWSObject):
         'CidrIp': (basestring, False),
         'CidrIpv6': (basestring, False),
         'Description': (basestring, False),
-        'FromPort': (network_port, False),  # conditional
+        'FromPort': (network_port, False),
         'GroupName': (basestring, False),
         'GroupId': (basestring, False),
         'IpProtocol': (basestring, True),
         'SourceSecurityGroupName': (basestring, False),
         'SourceSecurityGroupId': (basestring, False),
         'SourceSecurityGroupOwnerId': (basestring, False),
-        'ToPort': (network_port, False),  # conditional
+        'ToPort': (network_port, False),
     }
 
     def validate(self):
@@ -484,6 +496,7 @@ class SecurityGroupIngress(AWSObject):
             'SourceSecurityGroupId',
         ]
         exactly_one(self.__class__.__name__, self.properties, conds)
+        check_ports(self.properties)
 
 
 class SecurityGroupRule(AWSProperty):


### PR DESCRIPTION
Here is a proposed change to allow ToPort and FromPort to not be required. This should address #1208 and #1245.

Any one want to code review or test?
@daugustus @orenmazor @medwig @phobologic @axelpavageau 