### PR TITLE
duplicate classes VpcConfig, DomainJoinInfo

### DIFF
--- a/troposphere/appstream.py
+++ b/troposphere/appstream.py
@@ -64,20 +64,6 @@ class Fleet(AWSObject):
     }
 
 
-class VpcConfig(AWSProperty):
-    props = {
-        'SecurityGroupIds': ([basestring], False),
-        'SubnetIds': ([basestring], False),
-    }
-
-
-class DomainJoinInfo(AWSProperty):
-    props = {
-        'DirectoryName': (basestring, False),
-        'OrganizationalUnitDistinguishedName': (basestring, False),
-    }
-
-
 class ImageBuilder(AWSObject):
     resource_type = "AWS::AppStream::ImageBuilder"
 


### PR DESCRIPTION
TypeError: <class 'troposphere.appstream.Fleet'>: fleet.DomainJoinInfo is <class 'troposphere.appstream.DomainJoinInfo'>, expected <class 'troposphere.appstream.DomainJoinInfo'>

Verified locally