### PR TITLE
Add 'Kind' property to AWS::AppSync::Resolver

### DIFF
--- a/tests/test_appsync.py
+++ b/tests/test_appsync.py
@@ -4,7 +4,7 @@ from troposphere.appsync import Resolver, PipelineConfig
 
 class TestAppsyncResolver(unittest.TestCase):
     def test_resolver_kind_bad_value(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegexp(ValueError, 'Kind must be one of'):
             Resolver(
                 'MutationField',
                 DataSourceName='SomeDatasource',

--- a/tests/test_appsync.py
+++ b/tests/test_appsync.py
@@ -1,0 +1,46 @@
+import unittest
+from troposphere.appsync import Resolver, PipelineConfig
+
+
+class TestAppsyncResolver(unittest.TestCase):
+    def test_resolver_kind_bad_value(self):
+        with self.assertRaises(ValueError):
+            Resolver(
+                'MutationField',
+                DataSourceName='SomeDatasource',
+                FieldName='Field',
+                TypeName='Mutation',
+                ApiId='some_api_id',
+                Kind='SOME_KIND',
+                PipelineConfig=PipelineConfig(
+                    Functions=['FunctionId1', 'FunctionId']
+                ),
+                RequestMappingTemplateS3Location=('s3://bucket/key.req.vtl'),
+                ResponseMappingTemplateS3Location=('s3://bucket/key.res.vtl')
+            )
+
+    def test_resolver(self):
+        Resolver(
+            'MutationField',
+            DataSourceName='SomeDatasource',
+            FieldName='Field',
+            TypeName='Mutation',
+            ApiId='some_api_id',
+            Kind='PIPELINE',
+            PipelineConfig=PipelineConfig(
+                Functions=['FunctionId1', 'FunctionId']
+            ),
+            RequestMappingTemplateS3Location=('s3://bucket/key.req.vtl'),
+            ResponseMappingTemplateS3Location=('s3://bucket/key.res.vtl')
+        )
+
+        Resolver(
+            'MutationField',
+            DataSourceName='SomeDatasource',
+            FieldName='Field',
+            TypeName='Mutation',
+            ApiId='some_api_id',
+            Kind='UNIT',
+            RequestMappingTemplateS3Location=('s3://bucket/key.req.vtl'),
+            ResponseMappingTemplateS3Location=('s3://bucket/key.res.vtl')
+        )

--- a/troposphere/appsync.py
+++ b/troposphere/appsync.py
@@ -7,6 +7,13 @@ from . import AWSObject, AWSProperty
 from .validators import boolean, integer
 
 
+def resolver_kind_validator(x):
+    valid_types = ["UNIT", "PIPELINE"]
+    if x not in valid_types:
+        raise ValueError("KeyType must be one of: %s" % ", ".join(valid_types))
+    return x
+
+
 class ApiKey(AWSObject):
     resource_type = "AWS::AppSync::ApiKey"
 
@@ -154,6 +161,7 @@ class Resolver(AWSObject):
         'DataSourceName': (basestring, True),
         'FieldName': (basestring, True),
         'PipelineConfig': (PipelineConfig, False),
+        'Kind': (resolver_kind_validator, False),
         'RequestMappingTemplate': (basestring, False),
         'RequestMappingTemplateS3Location': (basestring, False),
         'ResponseMappingTemplate': (basestring, False),

--- a/troposphere/appsync.py
+++ b/troposphere/appsync.py
@@ -10,7 +10,7 @@ from .validators import boolean, integer
 def resolver_kind_validator(x):
     valid_types = ["UNIT", "PIPELINE"]
     if x not in valid_types:
-        raise ValueError("KeyType must be one of: %s" % ", ".join(valid_types))
+        raise ValueError("Kind must be one of: %s" % ", ".join(valid_types))
     return x
 
 
@@ -160,8 +160,8 @@ class Resolver(AWSObject):
         'ApiId': (basestring, True),
         'DataSourceName': (basestring, True),
         'FieldName': (basestring, True),
-        'PipelineConfig': (PipelineConfig, False),
         'Kind': (resolver_kind_validator, False),
+        'PipelineConfig': (PipelineConfig, False),
         'RequestMappingTemplate': (basestring, False),
         'RequestMappingTemplateS3Location': (basestring, False),
         'ResponseMappingTemplate': (basestring, False),


### PR DESCRIPTION
To use the PipelineConfig feature for AppSync resolvers, the Kind property is required to be PIPELINE.

Adding this property to the resolver class will allow consumers to properly configure Pipeline resolvers.

Fixes #1286
