### PR TITLE
Updated autoscalingplans to match cloudformation doco

### DIFF
--- a/troposphere/autoscalingplans.py
+++ b/troposphere/autoscalingplans.py
@@ -13,7 +13,7 @@ VALID_PREDICTIVESCALINGMAXCAPACITYBEHAVIOR = (
     'SetMaxCapacityToForecastCapacity',
     'SetMaxCapacityAboveForecastCapacity',
 )
-VALID_PREDICTIVESCALINGMODE = ('ForecastAndScale')
+VALID_PREDICTIVESCALINGMODE = ('ForecastAndScale', 'ForecastOnly')
 VALID_SCALINGPOLICYUPDATEBEHAVIOR = ('KeepExternalPolicies',
                                      'ReplaceExternalPolicies')
 
@@ -112,7 +112,7 @@ class CustomizedLoadMetricSpecification(AWSObject):
     }
 
 
-class PredefinedLoadMetricSpecification(AWSObject):
+class PredefinedLoadMetricSpecification(AWSProperty):
     props = {
         'PredefinedLoadMetricType': (basestring, True),
         'ResourceLabel': (basestring, False),
@@ -135,7 +135,7 @@ class ScalingInstruction(AWSProperty):
         'ScheduledActionBufferTime': (integer, False),
         'ServiceNamespace': (service_namespace_type, True),
         'TargetTrackingConfigurations': (
-            TargetTrackingConfiguration,
+            [TargetTrackingConfiguration],
             True
         ),
     }


### PR DESCRIPTION
Hello!

First time doing a Pull Request but I found some minor bugs and wanted to help fix.

### Fixed ScalingInstruction's TargetTrackingConfigurations object type
Cloudformation is just expecting a list instead of 1.
Ref: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-targettrackingconfigurations


### Added missing valid option for VALID_PREDICTIVESCALINGMODE
Cloudformation allows "ForecastOnly" for the Predictive Scaling Mode.
Ref: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-scalinginstruction.html#cfn-autoscalingplans-scalingplan-scalinginstruction-predictivescalingmode


### Fixed object type of PredefinedLoadMetricSpecification
PredefinedLoadMetricSpecification is just a sub property instead of its own object (AWSObject > AWSProperty).
Ref: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscalingplans-scalingplan-predefinedloadmetricspecification.html

Let me know if I need to change formatting etc 😄 .

Regards,
Paul