### PR TITLE
ResourceGroupArn is no longer mandatory for AWS::Inspector::AssessmentTarget, per 2019 Jan 17 update

### DIFF
--- a/troposphere/inspector.py
+++ b/troposphere/inspector.py
@@ -12,7 +12,7 @@ class AssessmentTarget(AWSObject):
 
     props = {
         'AssessmentTargetName': (basestring, False),
-        'ResourceGroupArn': (basestring, True),
+        'ResourceGroupArn': (basestring, False),
     }
 
 


### PR DESCRIPTION
…tTarget, per 2019 Jan 17 update