### PR TITLE
Made DataSourceName non-mandatory in appsync resolver

### DIFF
--- a/troposphere/appsync.py
+++ b/troposphere/appsync.py
@@ -158,7 +158,7 @@ class Resolver(AWSObject):
 
     props = {
         'ApiId': (basestring, True),
-        'DataSourceName': (basestring, True),
+        'DataSourceName': (basestring, False),
         'FieldName': (basestring, True),
         'Kind': (resolver_kind_validator, False),
         'PipelineConfig': (PipelineConfig, False),


### PR DESCRIPTION
[AppSync pipeline resolver docs](https://docs.aws.amazon.com/appsync/latest/devguide/pipeline-resolvers.html) specify that pipeline resolvers are not attached to any data source, I noticed my Cloudformation templates failing validation because of the non-allowed presence of "DataSourceName" in pipeline resolvers, so I changed the "DataSourceName" field in appsync.py to be be non-mandatory. 

This is my first pull request, so please let me know if I've missed anything.  I didn't open an issue because it seemed like a very small, self-contained fix. 

Thanks for maintaining this project, it's been incredibly helpful!