### PR TITLE
[events] add SqsParamaters support to Rule Target

### DIFF
--- a/troposphere/events.py
+++ b/troposphere/events.py
@@ -39,6 +39,12 @@ class RunCommandParameters(AWSProperty):
     }
 
 
+class SqsParameters(AWSProperty):
+    props = {
+        'MessageGroupId': (basestring, True),
+    }
+
+
 class Target(AWSProperty):
     props = {
         'Arn': (basestring, True),
@@ -50,6 +56,7 @@ class Target(AWSProperty):
         'KinesisParameters': (KinesisParameters, False),
         'RoleArn': (basestring, False),
         'RunCommandParameters': (RunCommandParameters, False),
+        'SqsParameters': (SqsParameters, False),
     }
 
 


### PR DESCRIPTION
Contains the message group ID to use when the target is a FIFO queue. 
See for more info https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_Target.html#CWE-Type-Target-SqsParameters