### PR TITLE
Adding AWS::ApiGatewayV2 Resources

### DIFF
--- a/tests/test_apigatewayv2.py
+++ b/tests/test_apigatewayv2.py
@@ -1,0 +1,108 @@
+import unittest
+from troposphere import Join
+from troposphere.apigatewayv2 import IntegrationResponse, Authorizer, Model
+
+
+class TestModel(unittest.TestCase):
+    def test_schema(self):
+        # Check with no schema
+        model = Model(
+            "schema",
+            Name="model",
+            ApiId="apiid",
+        )
+        model.validate()
+
+        # Check valid json schema string
+        model = Model(
+            "schema",
+            ApiId="apiid",
+            Name="model",
+            Schema='{"a": "b"}',
+        )
+        model.validate()
+
+        # Check invalid json schema string
+        model = Model(
+            "schema",
+            ApiId="apiid",
+            Name="model",
+            Schema='{"a: "b"}',
+        )
+        with self.assertRaises(ValueError):
+            model.validate()
+
+        # Check accepting dict and converting to string in validate
+        d = {"c": "d"}
+        model = Model(
+            "schema",
+            ApiId="apiid",
+            Name="model",
+            Schema=d
+        )
+        model.validate()
+        self.assertEqual(model.properties['Schema'], '{"c": "d"}')
+
+        # Check invalid Schema type
+        with self.assertRaises(TypeError):
+            model = Model(
+                "schema",
+                ApiId="apiid",
+                Name="model",
+                Schema=1
+            )
+
+        # Check Schema being an AWSHelperFn
+        model = Model(
+            "schema",
+            ApiId="apiid",
+            Name="model",
+            Schema=Join(':', ['{"a', ': "b"}']),
+        )
+        model.validate()
+
+
+class TestIntegrationResponse(unittest.TestCase):
+    def test_response_type(self):
+        integration_response = IntegrationResponse(
+            "IntegrationResponse",
+            IntegrationId="integrationid",
+            ApiId="apiid",
+            IntegrationResponseKey="/400/"
+        )
+
+        integration_response.validate()
+
+        with self.assertRaises(ValueError):
+            integration_response = IntegrationResponse(
+                "GatewayResponse",
+                IntegrationId="integrationid",
+                ApiId="apiid",
+                IntegrationResponseKey="/400/",
+                ContentHandlingStrategy="CONVERT_TO_SOMETHING"
+            )
+
+
+class TestAuthorizer(unittest.TestCase):
+
+    def test_response_type(self):
+        authorizer = Authorizer(
+            "Authorizer",
+            ApiId="apiid",
+            AuthorizerType="REQUEST",
+            AuthorizerUri="arn:lambda:function"
+        )
+
+        authorizer.validate()
+
+        with self.assertRaises(ValueError):
+            authorizer = Authorizer(
+                "Authorizer",
+                ApiId="apiid",
+                AuthorizerType="RESPONSE",
+                AuthorizerUri="arn:lambda:function"
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/troposphere/apigatewayv2.py
+++ b/troposphere/apigatewayv2.py
@@ -4,6 +4,80 @@ from .validators import (
 )
 
 
+def validate_integration_type(integration_type):
+
+    valid_integration_types = [
+        "AWS",
+        "AWS_PROXY",
+        "HTTP",
+        "HTTP_PROXY",
+        "MOCK"
+    ]
+    if integration_type not in valid_integration_types:
+        raise ValueError(
+            "{} is not a valid IntegrationType".format(
+                integration_type)
+        )
+    return integration_type
+
+
+def validate_authorizer_type(authorizer_type):
+
+    valid_authorizer_types = [
+        "REQUEST"
+    ]
+    if authorizer_type not in valid_authorizer_types:
+        raise ValueError(
+            "{} is not a valid AuthorizerType".format(
+                authorizer_type)
+        )
+    return authorizer_type
+
+
+def validate_logging_level(logging_level):
+
+    valid_logging_levels = [
+        "WARN",
+        "INFO",
+        "DEBUG"
+    ]
+    if logging_level not in valid_logging_levels:
+        raise ValueError(
+            "{} is not a valid LoggingLevel".format(
+                logging_level)
+        )
+    return logging_level
+
+
+def validate_passthrough_behavior(passthrough_behavior):
+
+    valid_passthrough_behaviors = [
+        "WHEN_NO_MATCH",
+        "WHEN_NO_TEMPLATES",
+        "NEVER"
+    ]
+    if passthrough_behavior not in valid_passthrough_behaviors:
+        raise ValueError(
+            "{} is not a valid PassthroughBehavior".format(
+                passthrough_behavior)
+        )
+    return passthrough_behavior
+
+
+def validate_content_handling_strategy(content_handling_strategy):
+
+    valid_handling_strategy_values = [
+        "CONVERT_TO_TEXT",
+        "CONVERT_TO_BINARY"
+    ]
+    if content_handling_strategy not in valid_handling_strategy_values:
+        raise ValueError(
+            "{} is not a valid ContentHandlingStrategy".format(
+                content_handling_strategy)
+        )
+    return content_handling_strategy
+
+
 def validate_authorizer_ttl(ttl_value):
     """ Validate authorizer ttl timeout
     :param ttl_value: The TTL timeout in seconds
@@ -13,6 +87,23 @@ def validate_authorizer_ttl(ttl_value):
     if ttl_value > 3600:
         raise ValueError("The AuthorizerResultTtlInSeconds should be <= 3600")
     return ttl_value
+
+
+class AccessLogSettings(AWSProperty):
+    props = {
+        "DestinationArn": (basestring, False),
+        "Format": (basestring, False)
+    }
+
+
+class RouteSettings(AWSProperty):
+    props = {
+        "DataTraceEnabled": (basestring, False),
+        "DetailedMetricsEnabled": (boolean, False),
+        "LoggingLevel": (validate_logging_level, False),
+        "ThrottlingBurstLimit": (positive_integer, False),
+        "ThrottlingRateLimit": (double, False)
+    }
 
 
 class Api(AWSObject):
@@ -32,19 +123,19 @@ class Api(AWSObject):
 class Authorizer(AWSObject):
     resource_type = "AWS::ApiGatewayV2::Authorizer"
 
-    props =
+    props = {
         "ApiId":  (basestring, True),
         "AuthorizerCredentialsArn":  (basestring, False),
-        "AuthorizerResultTtlInSeconds": (integer, False),
-        "AuthorizerType":  (basestring, True),
+        "AuthorizerResultTtlInSeconds": (validate_authorizer_ttl, False),
+        "AuthorizerType":  (validate_authorizer_type, True),
         "AuthorizerUri":  (basestring, True),
         "IdentitySource": ([basestring], True),
         "IdentityValidationExpression":  (basestring, False),
         "Name":  (basestring, True)
     }
 
-class Deployment(AWSObject):
 
+class Deployment(AWSObject):
     resource_type = "AWS::ApiGatewayV2::Deployment"
 
     props = {
@@ -53,33 +144,33 @@ class Deployment(AWSObject):
         "StageName": (basestring, False),
     }
 
-class Integration(AWSObject):
 
+class Integration(AWSObject):
     resource_type = "AWS::ApiGatewayV2::Integration"
 
     props = {
         "ApiId": (basestring, True),
         "ConnectionType": (basestring, False),
-        "ContentHandlingStrategy": (basestring, False),
+        "ContentHandlingStrategy": (validate_content_handling_strategy, False),
         "CredentialsArn": (basestring, False),
         "Description": (basestring, False),
         "IntegrationMethod": (basestring, False),
-        "IntegrationType": (basestring, True),
+        "IntegrationType": (validate_integration_type, True),
         "IntegrationUri": (basestring, False),
-        "PassthroughBehavior": (basestring, False),
+        "PassthroughBehavior": (validate_passthrough_behavior, False),
         "RequestParameters": (dict, False),
         "RequestTemplates": (dict, False),
         "TemplateSelectionExpression": (basestring, False),
-        "TimeoutInMillis": (integer, False)
+        "TimeoutInMillis": (integer_range(50, 29000), False)
     }
 
-class IntegrationResponse(AWSObject):
 
+class IntegrationResponse(AWSObject):
     resource_type = "AWS::ApiGatewayV2::IntegrationResponse"
 
     props = {
         "ApiId": (basestring, True),
-        "ContentHandlingStrategy": (basestring, False),
+        "ContentHandlingStrategy": (validate_content_handling_strategy, False),
         "IntegrationId": (basestring, True),
         "IntegrationResponseKey": (basestring, True),
         "ResponseParameters": (dict, False),
@@ -87,8 +178,8 @@ class IntegrationResponse(AWSObject):
         "TemplateSelectionExpression": (basestring, False)
     }
 
-class Route(AWSObject):
 
+class Model(AWSObject):
     resource_type = "AWS::ApiGatewayV2::Model"
 
     props = {
@@ -96,11 +187,17 @@ class Route(AWSObject):
         "ContentType": (basestring, False),
         "Description": (basestring, False),
         "Name": (basestring, True),
-        "Schema": (dict, False)
+        "Schema": ((basestring, dict), True)
     }
 
-class Route(AWSObject):
+    def validate(self):
+        name = 'Schema'
+        if name in self.properties:
+            schema = self.properties.get(name)
+            self.properties[name] = json_checker(schema)
 
+
+class Route(AWSObject):
     resource_type = "AWS::ApiGatewayV2::Route"
 
     props = {
@@ -120,7 +217,6 @@ class Route(AWSObject):
 
 
 class RouteResponse(AWSObject):
-
     resource_type = "AWS::ApiGatewayV2::RouteResponse"
 
     props = {
@@ -132,36 +228,18 @@ class RouteResponse(AWSObject):
         "RouteResponseKey": (basestring, True)
     }
 
-class Stage(AWSObject):
 
+class Stage(AWSObject):
     resource_type = "AWS::ApiGatewayV2::Stage"
 
     props = {
-        "AccessLogSettings": AccessLogSettings,
+        "AccessLogSettings": (AccessLogSettings, False),
         "ApiId": (basestring, True),
         "ClientCertificateId": (basestring, False),
-        "DefaultRouteSettings": RouteSettings,
+        "DefaultRouteSettings": (RouteSettings, False),
         "DeploymentId": (basestring, False),
         "Description": (basestring, False),
         "RouteSettings": (dict, False),
         "StageName": (basestring, True),
         "StageVariables": (dict, False)
-    }
-
-
-class AccessLogSettings(AWSProperty):
-
-    props = {
-        "DestinationArn": (basestring, False),
-        "Format": (basestring, False)
-    }
-
-class RouteSettings(AWSProperty):
-
-    props = {
-        "DataTraceEnabled": (basestring, False),
-        "DetailedMetricsEnabled": (boolean, False),
-        "LoggingLevel": (basestring, False),
-        "ThrottlingBurstLimit": (integer, False),
-        "ThrottlingRateLimit": (double, False)
     }

--- a/troposphere/apigatewayv2.py
+++ b/troposphere/apigatewayv2.py
@@ -1,4 +1,4 @@
-from . import AWSObject, AWSProperty, Tags
+from . import AWSObject, AWSProperty
 from .validators import (
     boolean, double, integer_range, json_checker, positive_integer
 )

--- a/troposphere/apigatewayv2.py
+++ b/troposphere/apigatewayv2.py
@@ -1,0 +1,167 @@
+from . import AWSObject, AWSProperty, Tags
+from .validators import (
+    boolean, double, integer_range, json_checker, positive_integer
+)
+
+
+def validate_authorizer_ttl(ttl_value):
+    """ Validate authorizer ttl timeout
+    :param ttl_value: The TTL timeout in seconds
+    :return: The provided TTL value if valid
+    """
+    ttl_value = int(positive_integer(ttl_value))
+    if ttl_value > 3600:
+        raise ValueError("The AuthorizerResultTtlInSeconds should be <= 3600")
+    return ttl_value
+
+
+class Api(AWSObject):
+    resource_type = "AWS::ApiGatewayV2::Api"
+
+    props = {
+        "ApiKeySelectionExpression": (basestring, False),
+        "Description": (basestring, False),
+        "DisableSchemaValidation": (boolean, False),
+        "Name": (basestring, True),
+        "ProtocolType": (basestring, True),
+        "RouteSelectionExpression": (basestring, True),
+        "Version": (basestring, False)
+    }
+
+
+class Authorizer(AWSObject):
+    resource_type = "AWS::ApiGatewayV2::Authorizer"
+
+    props =
+        "ApiId":  (basestring, True),
+        "AuthorizerCredentialsArn":  (basestring, False),
+        "AuthorizerResultTtlInSeconds": (integer, False),
+        "AuthorizerType":  (basestring, True),
+        "AuthorizerUri":  (basestring, True),
+        "IdentitySource": ([basestring], True),
+        "IdentityValidationExpression":  (basestring, False),
+        "Name":  (basestring, True)
+    }
+
+class Deployment(AWSObject):
+
+    resource_type = "AWS::ApiGatewayV2::Deployment"
+
+    props = {
+        "ApiId": (basestring, True),
+        "Description": (basestring, False),
+        "StageName": (basestring, False),
+    }
+
+class Integration(AWSObject):
+
+    resource_type = "AWS::ApiGatewayV2::Integration"
+
+    props = {
+        "ApiId": (basestring, True),
+        "ConnectionType": (basestring, False),
+        "ContentHandlingStrategy": (basestring, False),
+        "CredentialsArn": (basestring, False),
+        "Description": (basestring, False),
+        "IntegrationMethod": (basestring, False),
+        "IntegrationType": (basestring, True),
+        "IntegrationUri": (basestring, False),
+        "PassthroughBehavior": (basestring, False),
+        "RequestParameters": (dict, False),
+        "RequestTemplates": (dict, False),
+        "TemplateSelectionExpression": (basestring, False),
+        "TimeoutInMillis": (integer, False)
+    }
+
+class IntegrationResponse(AWSObject):
+
+    resource_type = "AWS::ApiGatewayV2::IntegrationResponse"
+
+    props = {
+        "ApiId": (basestring, True),
+        "ContentHandlingStrategy": (basestring, False),
+        "IntegrationId": (basestring, True),
+        "IntegrationResponseKey": (basestring, True),
+        "ResponseParameters": (dict, False),
+        "ResponseTemplates": (dict, False),
+        "TemplateSelectionExpression": (basestring, False)
+    }
+
+class Route(AWSObject):
+
+    resource_type = "AWS::ApiGatewayV2::Model"
+
+    props = {
+        "ApiId": (basestring, True),
+        "ContentType": (basestring, False),
+        "Description": (basestring, False),
+        "Name": (basestring, True),
+        "Schema": (dict, False)
+    }
+
+class Route(AWSObject):
+
+    resource_type = "AWS::ApiGatewayV2::Route"
+
+    props = {
+        "ApiId": (basestring, True),
+        "ApiKeyRequired": (boolean, False),
+        "AuthorizationScopes": ([basestring], False),
+        "AuthorizationType": (basestring, False),
+        "AuthorizerId": (basestring, False),
+        "ModelSelectionExpression": (basestring, False),
+        "OperationName": (basestring, False),
+        "RequestModels": (dict, False),
+        "RequestParameters": (dict, False),
+        "RouteKey": (basestring, True),
+        "RouteResponseSelectionExpression": (basestring, False),
+        "Target": (basestring, False)
+    }
+
+
+class RouteResponse(AWSObject):
+
+    resource_type = "AWS::ApiGatewayV2::RouteResponse"
+
+    props = {
+        "ApiId": (basestring, True),
+        "ModelSelectionExpression": (basestring, False),
+        "ResponseModels": (dict, False),
+        "ResponseParameters": (dict, False),
+        "RouteId": (basestring, True),
+        "RouteResponseKey": (basestring, True)
+    }
+
+class Stage(AWSObject):
+
+    resource_type = "AWS::ApiGatewayV2::Stage"
+
+    props = {
+        "AccessLogSettings": AccessLogSettings,
+        "ApiId": (basestring, True),
+        "ClientCertificateId": (basestring, False),
+        "DefaultRouteSettings": RouteSettings,
+        "DeploymentId": (basestring, False),
+        "Description": (basestring, False),
+        "RouteSettings": (dict, False),
+        "StageName": (basestring, True),
+        "StageVariables": (dict, False)
+    }
+
+
+class AccessLogSettings(AWSProperty):
+
+    props = {
+        "DestinationArn": (basestring, False),
+        "Format": (basestring, False)
+    }
+
+class RouteSettings(AWSProperty):
+
+    props = {
+        "DataTraceEnabled": (basestring, False),
+        "DetailedMetricsEnabled": (boolean, False),
+        "LoggingLevel": (basestring, False),
+        "ThrottlingBurstLimit": (integer, False),
+        "ThrottlingRateLimit": (double, False)
+    }


### PR DESCRIPTION
Based on updates made to CloudFormation made on the 7th Of Feb, this PR includes apigatewayv2 which is inline with https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-reference-apigatewayv2.html



