### PR TITLE
Drop support for Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 sudo: false
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
 

--- a/CONTRIBUTE.rst
+++ b/CONTRIBUTE.rst
@@ -33,7 +33,7 @@ will be run against any commits to the project.
     #. `python setup.py test`
 #. Alternatively, make can be used to run the tests, i.e. `make test`.
 
-Tests are run against Python 2.7, 3.4, 3.5 and 3.6.
+Tests are run against Python 2.7, 3.5, and 3.6.
 
 Contributing Example Code
 -------------------------

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
         'scripts/cfn2py'
     ],
 
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     install_requires=file_contents("requirements.txt"),
     test_suite="tests",
     tests_require=["awacs"],

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,6 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 2.7",
     ],
 
@@ -83,6 +82,7 @@ setup(
         'scripts/cfn2py'
     ],
 
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     install_requires=file_contents("requirements.txt"),
     test_suite="tests",
     tests_require=["awacs"],


### PR DESCRIPTION
It will reach its EOL in March 2019, see https://www.python.org/dev/peps/pep-0429/#release-schedule

It has aleady been proposed in cloudtools/troposphere#1295 that Python 3.5 should be the minimal required version.  This PR addresses a low hanging fruit on the road towards this desirable state. :)