### PR TITLE
Add psuedo-parameter Ref for AWS::Partition

### DIFF
--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -508,6 +508,7 @@ class Ref(AWSHelperFn):
 AccountId = Ref(AWS_ACCOUNT_ID)
 NotificationARNs = Ref(AWS_NOTIFICATION_ARNS)
 NoValue = Ref(AWS_NO_VALUE)
+Partition = Ref(AWS_PARTITION)
 Region = Ref(AWS_REGION)
 StackId = Ref(AWS_STACK_ID)
 StackName = Ref(AWS_STACK_NAME)


### PR DESCRIPTION
This change just adds a pre-made Ref object for `AWS::Partition`, an unloved and comparatively recent addition to the list of psuedo-parameters.