### PR TITLE
Prefer awacs.aws.PolicyDocument over awacs.aws.Policy

### DIFF
--- a/examples/Dlm.py
+++ b/examples/Dlm.py
@@ -2,7 +2,7 @@ from troposphere import GetAtt, Template, Tags
 from troposphere.dlm import (LifecyclePolicy, PolicyDetails, Schedule,
                              RetainRule, CreateRule)
 from troposphere.iam import Role
-from awacs.aws import Allow, Statement, Principal, Policy
+from awacs.aws import Allow, Statement, Principal, PolicyDocument
 from awacs.sts import AssumeRole
 
 t = Template()
@@ -10,7 +10,7 @@ t.add_version('2010-09-09')
 
 dlm_role = t.add_resource(Role(
     "DlmRole",
-    AssumeRolePolicyDocument=Policy(
+    AssumeRolePolicyDocument=PolicyDocument(
         Statement=[
             Statement(
                 Effect=Allow,

--- a/examples/ECRSample.py
+++ b/examples/ECRSample.py
@@ -1,6 +1,6 @@
 from troposphere import Template
 from troposphere.ecr import Repository
-from awacs.aws import Allow, Policy, AWSPrincipal, Statement
+from awacs.aws import Allow, PolicyDocument, AWSPrincipal, Statement
 import awacs.ecr as ecr
 import awacs.iam as iam
 
@@ -11,7 +11,7 @@ t.add_resource(
     Repository(
         'MyRepository',
         RepositoryName='test-repository',
-        RepositoryPolicyText=Policy(
+        RepositoryPolicyText=PolicyDocument(
             Version='2008-10-17',
             Statement=[
                 Statement(

--- a/examples/EFS.py
+++ b/examples/EFS.py
@@ -2,7 +2,7 @@ from troposphere import FindInMap, Ref, Template, Parameter, Tags
 from troposphere.iam import InstanceProfile, Role
 from troposphere.efs import FileSystem, MountTarget
 from troposphere.ec2 import SecurityGroup, SecurityGroupRule, Instance
-from awacs.aws import Allow, Statement, Policy, Action
+from awacs.aws import Allow, Statement, PolicyDocument, Action
 
 
 template = Template()
@@ -89,7 +89,7 @@ template.add_resource(efs_mount_target)
 # pass in the FileSystem name as UserData.
 efs_host_role = Role(
     "EFSHostRole",
-    AssumeRolePolicyDocument=Policy(
+    AssumeRolePolicyDocument=PolicyDocument(
         Statement=[
             Statement(
                 Effect=Allow,

--- a/examples/ElastiCacheRedis.py
+++ b/examples/ElastiCacheRedis.py
@@ -16,7 +16,7 @@ import awacs
 from awacs.aws import (Allow,
                        Statement,
                        Principal,
-                       Policy)
+                       PolicyDocument)
 from awacs.sts import AssumeRole
 
 from troposphere import (Base64,
@@ -250,7 +250,7 @@ def main():
     # Resources
     webserverrole = template.add_resource(iam.Role(
         'WebServerRole',
-        AssumeRolePolicyDocument=Policy(
+        AssumeRolePolicyDocument=PolicyDocument(
             Statement=[
                 Statement(
                     Effect=Allow,
@@ -268,7 +268,7 @@ def main():
     template.add_resource(iam.PolicyType(
         'WebServerRolePolicy',
         PolicyName='WebServerRole',
-        PolicyDocument=awacs.aws.Policy(
+        PolicyDocument=PolicyDocument(
             Statement=[awacs.aws.Statement(
                 Action=[awacs.aws.Action("elasticache",
                         "DescribeCacheClusters")],

--- a/examples/ElasticBeanstalk_Nodejs_Sample.py
+++ b/examples/ElasticBeanstalk_Nodejs_Sample.py
@@ -14,7 +14,7 @@ from troposphere.elasticbeanstalk import (
 from troposphere.iam import Role, InstanceProfile
 from troposphere.iam import PolicyType as IAMPolicy
 
-from awacs.aws import Allow, Statement, Action, Principal, Policy
+from awacs.aws import Allow, Statement, Action, Principal, PolicyDocument
 from awacs.sts import AssumeRole
 
 
@@ -73,7 +73,7 @@ t.add_mapping("Region2Principal", {
 
 t.add_resource(Role(
     "WebServerRole",
-    AssumeRolePolicyDocument=Policy(
+    AssumeRolePolicyDocument=PolicyDocument(
         Statement=[
             Statement(
                 Effect=Allow, Action=[AssumeRole],
@@ -93,7 +93,7 @@ t.add_resource(Role(
 t.add_resource(IAMPolicy(
     "WebServerRolePolicy",
     PolicyName="WebServerRole",
-    PolicyDocument=Policy(
+    PolicyDocument=PolicyDocument(
         Statement=[
             Statement(Effect=Allow, NotAction=Action("iam", "*"),
                       Resource=["*"])

--- a/examples/IAM_Roles_and_InstanceProfiles.py
+++ b/examples/IAM_Roles_and_InstanceProfiles.py
@@ -2,7 +2,7 @@ from troposphere import Template, Ref
 
 from troposphere.iam import Role, InstanceProfile
 
-from awacs.aws import Allow, Statement, Principal, Policy
+from awacs.aws import Allow, Statement, Principal, PolicyDocument
 from awacs.sts import AssumeRole
 
 t = Template()
@@ -13,7 +13,7 @@ t.set_description("AWS CloudFormation Sample Template: This template "
 
 cfnrole = t.add_resource(Role(
     "CFNRole",
-    AssumeRolePolicyDocument=Policy(
+    AssumeRolePolicyDocument=PolicyDocument(
         Statement=[
             Statement(
                 Effect=Allow,

--- a/examples/IAM_Users_snippet.py
+++ b/examples/IAM_Users_snippet.py
@@ -18,7 +18,7 @@ t.add_resource(User(
     Policies=[
         Policy(
             PolicyName="giveaccesstoqueueonly",
-            PolicyDocument=awacs.aws.Policy(
+            PolicyDocument=awacs.aws.PolicyDocument(
                 Statement=[
                     awacs.aws.Statement(
                         Effect=awacs.aws.Allow,
@@ -35,7 +35,7 @@ t.add_resource(User(
         ),
         Policy(
             PolicyName="giveaccesstotopiconly",
-            PolicyDocument=awacs.aws.Policy(
+            PolicyDocument=awacs.aws.PolicyDocument(
                 Statement=[
                     awacs.aws.Statement(
                         Effect=awacs.aws.Allow,

--- a/troposphere/compat.py
+++ b/troposphere/compat.py
@@ -1,0 +1,18 @@
+try:
+    from awacs.aws import Policy, PolicyDocument
+
+    policytypes = (dict, Policy, PolicyDocument)  # type: tuple
+except ImportError:
+    try:
+        # A future release of awacs might remove `Policy` in which case
+        # `PolicyDocument` should still be supported.  This ensures forward
+        # compatibility of current releases of troposphere with future
+        # releases of awacs.
+        from awacs.aws import PolicyDocument
+
+        policytypes = (dict, PolicyDocument)
+    except ImportError:
+        policytypes = (dict,)
+
+
+__all__ = ["policytypes"]

--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -4,19 +4,12 @@
 # See LICENSE file for full license.
 
 from . import AWSHelperFn, AWSObject, AWSProperty, Tags
+from .compat import policytypes
 from .validators import (
     boolean, exactly_one, integer, integer_range, double,
     network_port, positive_integer, vpn_pre_shared_key, vpn_tunnel_inside_cidr,
     vpc_endpoint_type
 )
-
-try:
-    from awacs.aws import Policy
-
-    policytypes = (dict, Policy)
-except ImportError:
-    policytypes = dict,
-
 
 VALID_ELASTICINFERENCEACCELERATOR_TYPES = ('eia1.medium', 'eia1.large',
                                            'eia1.xlarge')

--- a/troposphere/ecr.py
+++ b/troposphere/ecr.py
@@ -1,9 +1,5 @@
 from . import AWSObject, AWSProperty, Tags
-try:
-    from awacs.aws import Policy
-    policytypes = (dict, Policy)
-except ImportError:
-    policytypes = dict,
+from .compat import policytypes
 
 
 class LifecyclePolicy(AWSProperty):

--- a/troposphere/elasticsearch.py
+++ b/troposphere/elasticsearch.py
@@ -4,15 +4,10 @@
 # See LICENSE file for full license.
 
 from . import AWSProperty, AWSObject, Tags
+from .compat import policytypes
 from .validators import boolean, integer, integer_range, positive_integer
 
 VALID_VOLUME_TYPES = ('standard', 'gp2', 'io1')
-
-try:
-    from awacs.aws import Policy
-    policytypes = (dict, Policy)
-except ImportError:
-    policytypes = dict,
 
 
 def validate_volume_type(volume_type):

--- a/troposphere/iam.py
+++ b/troposphere/iam.py
@@ -4,15 +4,9 @@
 # See LICENSE file for full license.
 
 from . import AWSObject, AWSProperty, Tags
+from .compat import policytypes
 from .validators import integer, boolean, status
 from .validators import iam_path, iam_role_name, iam_group_name, iam_user_name
-
-try:
-    from awacs.aws import Policy
-    policytypes = (dict, Policy)
-except ImportError:
-    policytypes = dict,
-
 
 Active = "Active"
 Inactive = "Inactive"

--- a/troposphere/iot.py
+++ b/troposphere/iot.py
@@ -1,10 +1,6 @@
 from . import AWSObject, AWSProperty
+from .compat import policytypes
 from .validators import boolean
-try:
-    from awacs.aws import Policy
-    policytypes = (dict, Policy)
-except ImportError:
-    policytypes = dict,
 
 
 class CloudwatchAlarmAction(AWSProperty):

--- a/troposphere/iotanalytics.py
+++ b/troposphere/iotanalytics.py
@@ -5,11 +5,6 @@
 
 from . import AWSObject, AWSProperty, Tags
 from .validators import boolean, integer, json_checker, double
-try:
-    from awacs.aws import Policy
-    policytypes = (dict, Policy)
-except ImportError:
-    policytypes = dict,
 
 
 class RetentionPeriod(AWSProperty):

--- a/troposphere/kms.py
+++ b/troposphere/kms.py
@@ -4,12 +4,8 @@
 # See LICENSE file for full license.
 
 from . import AWSObject, Tags
+from .compat import policytypes
 from .validators import boolean, integer_range, key_usage_type
-try:
-    from awacs.aws import Policy
-    policytypes = (dict, Policy)
-except ImportError:
-    policytypes = dict,
 
 
 class Alias(AWSObject):

--- a/troposphere/s3.py
+++ b/troposphere/s3.py
@@ -5,15 +5,9 @@
 import warnings
 
 from . import AWSHelperFn, AWSObject, AWSProperty, Tags
+from .compat import policytypes
 from .validators import boolean, integer, positive_integer, s3_bucket_name
 from .validators import s3_transfer_acceleration_status
-
-try:
-    from awacs.aws import Policy
-
-    policytypes = (dict, Policy)
-except ImportError:
-    policytypes = dict,
 
 Private = "Private"
 PublicRead = "PublicRead"

--- a/troposphere/secretsmanager.py
+++ b/troposphere/secretsmanager.py
@@ -4,14 +4,8 @@
 # See LICENSE file for full license.
 
 from . import AWSObject, AWSProperty, Tags
+from .compat import policytypes
 from .validators import integer, boolean
-
-try:
-    from awacs.aws import Policy
-    policytypes = (dict, Policy)
-except ImportError:
-    policytypes = dict,
-
 
 VALID_TARGET_TYPES = ('AWS::RDS::DBInstance', 'AWS::RDS::DBCluster')
 

--- a/troposphere/sns.py
+++ b/troposphere/sns.py
@@ -4,12 +4,8 @@
 # See LICENSE file for full license.
 
 from . import AWSObject, AWSProperty
+from .compat import policytypes
 from .validators import boolean
-try:
-    from awacs.aws import Policy
-    policytypes = (dict, Policy)
-except ImportError:
-    policytypes = dict,
 
 
 class Subscription(AWSProperty):

--- a/troposphere/sqs.py
+++ b/troposphere/sqs.py
@@ -4,12 +4,8 @@
 # See LICENSE file for full license.
 
 from . import AWSHelperFn, AWSObject, AWSProperty, Tags
+from .compat import policytypes
 from .validators import integer
-try:
-    from awacs.aws import Policy
-    policytypes = (dict, Policy)
-except ImportError:
-    policytypes = dict,
 
 
 class RedrivePolicy(AWSProperty):


### PR DESCRIPTION
`awacs.aws.PolicyDocument` was introduced in awacs 0.7.1 to prevent confusions with `troposphere.iam.Policy`.  troposphere requires awacs >= 0.8.