### PR TITLE
Add authenticate-cognito and authenticate-oidc to elb v2 Action's "type" validator

### DIFF
--- a/troposphere/elasticloadbalancingv2.py
+++ b/troposphere/elasticloadbalancingv2.py
@@ -103,7 +103,7 @@ class Action(AWSProperty):
         one_of(self.__class__.__name__,
                self.properties,
                'Type',
-               ['forward', 'redirect', 'fixed-response'])
+               ['forward', 'redirect', 'fixed-response', 'authenticate-cognito', 'authenticate-oidc'])
 
         def requires(action_type, prop):
             if self.properties.get('Type') == action_type and \

--- a/troposphere/elasticloadbalancingv2.py
+++ b/troposphere/elasticloadbalancingv2.py
@@ -103,7 +103,8 @@ class Action(AWSProperty):
         one_of(self.__class__.__name__,
                self.properties,
                'Type',
-               ['forward', 'redirect', 'fixed-response', 'authenticate-cognito', 'authenticate-oidc'])
+               ['forward', 'redirect', 'fixed-response',
+                'authenticate-cognito', 'authenticate-oidc'])
 
         def requires(action_type, prop):
             if self.properties.get('Type') == action_type and \


### PR DESCRIPTION
Supporting metadata types were added, but can't be used properly without changing the "Type" parameter.