### PR TITLE
EngineAttributes should take list

### DIFF
--- a/troposphere/opsworks.py
+++ b/troposphere/opsworks.py
@@ -349,7 +349,7 @@ class Server(AWSObject):
         'BackupRetentionCount': (integer, False),
         'DisableAutomatedBackup': (boolean, False),
         'Engine': (basestring, False),
-        'EngineAttributes': (EngineAttribute, False),
+        'EngineAttributes': ([EngineAttribute], False),
         'EngineModel': (basestring, False),
         'EngineVersion': (basestring, False),
         'InstanceProfileArn': (basestring, True),


### PR DESCRIPTION
EngineAttributes variable in the Server class is currently taking a single EngineAttribute object, but Cloudformation allows for a list of attributes, as is necessary when using puppet R10K. See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworkscm-server.html#cfn-opsworkscm-server-engineattributes