### PR TITLE
Fixed: Codebuild Webhook Filters are to be a list of list of WebhookFilter

### DIFF
--- a/troposphere/codebuild.py
+++ b/troposphere/codebuild.py
@@ -239,19 +239,26 @@ class ProjectTriggers(AWSProperty):
         'FilterGroups': (list, False)
     }
 
-    def __init__(self, title=None, **kwargs):
-        super(AWSProperty, self).__init__(title, **kwargs)
+    def validate(self):
+        if 'FilterGroups' not in self.properties:
+            raise KeyError('FilterGroups is required when creating triggers')
         if not isinstance(self.FilterGroups, list):
             self._raise_type('FilterGroups', self.FilterGroups, list)
-        if not isinstance(self.FilterGroups[0], list):
-            self._raise_type('FilterGroups[0]', self.FilterGroups[0], list)
-        count = 0
-        for hook in self.FilterGroups[0]:
-            if not isinstance(hook, WebhookFilter):
+        counti = 0
+        for elem in self.properties.get('FilterGroups'):
+            if not isinstance(elem, list):
                 self._raise_type(
-                    'FilterGroups[0][{}]'.format(count), hook, WebhookFilter
+                    'FilterGroups[{}]'.format(counti),
+                    self.FilterGroups[counti], list
                 )
-            count += 1
+            countj = 0
+            for hook in self.FilterGroups[counti]:
+                if not isinstance(hook, WebhookFilter):
+                    self._raise_type(
+                        'FilterGroups[{}][{}]'.format(counti, countj),
+                        hook, WebhookFilter
+                    )
+                countj += 1
 
 
 def validate_status(status):

--- a/troposphere/codebuild.py
+++ b/troposphere/codebuild.py
@@ -236,8 +236,22 @@ class WebhookFilter(AWSProperty):
 class ProjectTriggers(AWSProperty):
     props = {
         'Webhook': (boolean, False),
-        'FilterGroups': ([WebhookFilter], False),
+        'FilterGroups': (list, False)
     }
+
+    def __init__(self, title=None, **kwargs):
+        super(AWSProperty, self).__init__(title, **kwargs)
+        if not isinstance(self.FilterGroups, list):
+            self._raise_type('FilterGroups', self.FilterGroups, list)
+        if not isinstance(self.FilterGroups[0], list):
+            self._raise_type('FilterGroups[0]', self.FilterGroups[0], list)
+        count = 0
+        for hook in self.FilterGroups[0]:
+            if not isinstance(hook, WebhookFilter):
+                self._raise_type(
+                    'FilterGroups[0][{}]'.format(count), hook, WebhookFilter
+                )
+            count += 1
 
 
 def validate_status(status):


### PR DESCRIPTION
According to documentation, Web Hooks should be written in the form of List of List of WebHooks
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-projecttriggers.html

API call confirms the structure:
```
"webhook": {
                "url": "https://api.github.com/repos/<OMIT>",
                "payloadUrl": "https://codebuild.eu-west-1.amazonaws.com/webhooks?t=<OMIT>",
                "filterGroups": [
                    [
                        {
                            "type": "EVENT",
                            "pattern": "PULL_REQUEST_CREATED, PULL_REQUEST_UPDATED, PULL_REQUEST_REOPENED",
                            "excludeMatchedPattern": false
                        },
                        {
                            "type": "ACTOR_ACCOUNT_ID",
                            "pattern": "ausername",
                            "excludeMatchedPattern": false
                        }
                    ],
                    [
                        {
                            "type": "EVENT",
                            "pattern": "PULL_REQUEST_CREATED, PULL_REQUEST_UPDATED, PULL_REQUEST_REOPENED",
                            "excludeMatchedPattern": false
                        },
                        {
                            "type": "BASE_REF",
                            "pattern": "ref/heads/master$",
                            "excludeMatchedPattern": false
                        },
                        {
                            "type": "HEAD_REF",
                            "pattern": "ref/heads/branch1$",
                            "excludeMatchedPattern": false
                        }
                    ]
                ]
            },
```
Hope I used the class appropriately.