### PR TITLE
Added support for lambda in TargetGroup with additional validation

### DIFF
--- a/tests/test_elasticloadbalancerv2.py
+++ b/tests/test_elasticloadbalancerv2.py
@@ -1,7 +1,7 @@
 import unittest
 
 from troposphere.elasticloadbalancingv2 import Action, RedirectConfig, \
-    FixedResponseConfig
+    FixedResponseConfig, TargetGroup
 
 
 class TestListenerActions(unittest.TestCase):
@@ -86,6 +86,73 @@ class TestListenerActions(unittest.TestCase):
                     ContentType='text/plain',
                 )
             ).to_dict()
+
+
+class TestTargetGroup(unittest.TestCase):
+
+    def test_lambda_targettype_rejects_properties(self):
+        with self.assertRaises(ValueError) as valueError:
+            TargetGroup(
+                "targetGroup",
+                TargetType="lambda",
+                Port=433,
+                Protocol="HTTPS",
+                VpcId="unknown"
+            ).to_dict()
+        self.assertEqual(
+            "TargetType of \"lambda\" in \"TargetGroup\" must not contain " +
+            "definitions of 'Port', 'Protocol', 'VpcId'",
+            str(valueError.exception)
+        )
+
+    def test_instance_targettype_requires_properties(self):
+        with self.assertRaises(ValueError) as valueError:
+            TargetGroup(
+                "targetGroup",
+                TargetType="instance"
+            ).to_dict()
+        self.assertEqual(
+            "TargetType of \"instance\" in \"TargetGroup\" requires " +
+            "definitions of 'Port', 'Protocol', 'VpcId'",
+            str(valueError.exception)
+        )
+
+    def test_ip_targettype_requires_properties(self):
+        with self.assertRaises(ValueError) as valueError:
+            TargetGroup(
+                "targetGroup",
+                TargetType="ip"
+            ).to_dict()
+        self.assertEqual(
+            "TargetType of \"ip\" in \"TargetGroup\" " +
+            "requires definitions of 'Port', 'Protocol', 'VpcId'",
+            str(valueError.exception)
+        )
+
+    def test_no_targettype_requires_properties(self):
+        with self.assertRaises(ValueError) as valueError:
+            TargetGroup(
+                "targetGroup"
+            ).to_dict()
+        self.assertEqual(
+            "Omitting TargetType in \"TargetGroup\" " +
+            "requires definitions of 'Port', 'Protocol', 'VpcId'",
+            str(valueError.exception)
+        )
+
+    def test_invalid_targettype_is_rejected(self):
+        with self.assertRaises(ValueError) as valueError:
+            TargetGroup(
+                "targetGroup",
+                TargetType="invalid",
+                Port=433,
+                Protocol="HTTPS",
+                VpcId="unknown"
+            ).to_dict()
+        self.assertEqual(
+            "TargetGroup.TargetType must be one of: \"instance, ip, lambda\"",
+            str(valueError.exception)
+        )
 
 
 if __name__ == '__main__':

--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -197,8 +197,11 @@ def iam_group_name(group_name):
 def one_of(class_name, properties, property, conditionals):
     if properties.get(property) not in conditionals:
         raise ValueError(
+            # Ensure we handle None as a valid value
             '%s.%s must be one of: "%s"' % (
-                class_name, property, ', '.join(conditionals)
+                class_name, property, ', '.join(
+                    condition for condition in conditionals if condition
+                )
             )
         )
 


### PR DESCRIPTION
Added 'lambda' as a valid target type in a TargetGroup, changing the previously required types (which are only required by 'ip' and 'instance' types) to optional.

Added validation to ensure the now-optional properties are present when needed, and not present when the target type is a lambda.

Apologies for the slightly curt formatting, I was struggling to keep some of the lines under 79 characters :)