### PR TITLE
Changing True to False for Username property in Endpoint class

### DIFF
--- a/troposphere/dms.py
+++ b/troposphere/dms.py
@@ -75,7 +75,7 @@ class Endpoint(AWSObject):
         'ServerName': (basestring, False),
         'SslMode': (basestring, False),
         'Tags': (Tags, False),
-        'Username': (basestring, True),
+        'Username': (basestring, False),
     }
 
 


### PR DESCRIPTION
Changing behavior to that of Cloudformation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dms-endpoint.html#cfn-dms-endpoint-username

Given how some Endpoint engine types do not work with the Username property set, this will be more consistent with what's expected.

Related to: https://github.com/cloudtools/troposphere/issues/1019