### PR TITLE
make DefinitionString and DefinitionBody mutually exclusive

### DIFF
--- a/tests/test_serverless.py
+++ b/tests/test_serverless.py
@@ -151,6 +151,15 @@ class TestServerless(unittest.TestCase):
         t.add_resource(serverless_api)
         t.to_json()
 
+    def test_api_no_definition(self):
+        serverless_api = Api(
+            "SomeApi",
+            StageName='test',
+        )
+        t = Template()
+        t.add_resource(serverless_api)
+        t.to_json()
+
     def test_simple_table(self):
         serverless_table = SimpleTable(
             "SomeTable"

--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -10,7 +10,7 @@ from .apigateway import AccessLogSetting, CanarySetting, MethodSetting
 from .awslambda import Environment, VPCConfig, validate_memory_size
 from .dynamodb import ProvisionedThroughput, SSESpecification
 from .s3 import Filter
-from .validators import exactly_one, positive_integer
+from .validators import exactly_one, positive_integer, mutually_exclusive
 try:
     from awacs.aws import PolicyDocument
     policytypes = (dict, list, basestring, PolicyDocument)
@@ -216,7 +216,7 @@ class Api(AWSObject):
             'DefinitionBody',
             'DefinitionUri',
         ]
-        exactly_one(self.__class__.__name__, self.properties, conds)
+        mutually_exclusive(self.__class__.__name__, self.properties, conds)
 
 
 class PrimaryKey(AWSProperty):


### PR DESCRIPTION
make DefinitionString and DefinitionBody mutually exclusive, but allow no definition

from
https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessapi

```
Swagger specification that describes your API. If neither DefinitionUri
nor DefinitionBody are specified, SAM will generate a DefinitionBody for
you based on your template configuration.
```