### PR TITLE
Fix MethodSettings on AWS::Serverless::Api

### DIFF
--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -204,7 +204,7 @@ class Api(AWSObject):
         'DefinitionBody': (dict, False),
         'DefinitionUri': (basestring, False),
         'EndpointConfiguration': (basestring, False),
-        'MethodSetting': (MethodSetting, False),
+        'MethodSettings': ([MethodSetting], False),
         'Name': (basestring, False),
         'StageName': (basestring, True),
         "TracingEnabled": (bool, False),


### PR DESCRIPTION
According to the SAM documentation (and
https://github.com/awslabs/serverless-application-model/blob/master/samtranslator/model/sam_resources.py):
* MethodSetting -> MethodSettings
* this is an array of MethodSetting, not a single MethodSetting