### PR TITLE
Adds Tmpfs prop to LinuxParameters

### DIFF
--- a/troposphere/ecs.py
+++ b/troposphere/ecs.py
@@ -188,11 +188,20 @@ class KernelCapabilities(AWSProperty):
     }
 
 
+class Tmpfs(AWSProperty):
+    props = {
+        'ContainerPath': (basestring, False),
+        'MountOptions': ([basestring], False),
+        'Size': (integer, False),
+    }
+
+
 class LinuxParameters(AWSProperty):
     props = {
         'Capabilities': (KernelCapabilities, False),
         'Devices': ([Device], False),
         'InitProcessEnabled': (boolean, False),
+        'Tmpfs': ([Tmpfs], False),
     }
 
 


### PR DESCRIPTION
Noted the Tmpfs prop was missing. Interestingly all the props for TmpFs are optional in the ECS docs!