### PR TITLE
Added missing container name property

### DIFF
--- a/troposphere/ecs.py
+++ b/troposphere/ecs.py
@@ -297,6 +297,7 @@ class Volume(AWSProperty):
 
 class ProxyConfiguration(AWSProperty):
     props = {
+        'ContainerName': (basestring, True),
         'ProxyConfigurationProperties': (list, False),
         'Type': (ecs_proxy_type, False)
     }


### PR DESCRIPTION
ContainerName is a required property according to this documentation: https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ProxyConfiguration.html