### PR TITLE
Add missing Role property for DeploymentPreference

### DIFF
--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -61,6 +61,7 @@ class DeploymentPreference(AWSProperty):
         "Alarms": (list, False),
         "Hooks": (Hooks, False),
         "Enabled": (bool, False),
+        "Role": (basestring, False),
     }
 
 


### PR DESCRIPTION
Role is an optional parameter for DeploymentPreference according to the following section of the AWS SAM documentation:
https://github.com/awslabs/serverless-application-model/blob/master/docs/safe_lambda_deployments.rst#traffic-shifting-using-codedeploy

The AWS SAM documentation doesn't seem to be consistent, so I verified in the code itself.
https://github.com/awslabs/serverless-application-model/blob/master/samtranslator/model/preferences/deployment_preference.py#L20