### PR TITLE
Extending Firehose with support for DataFormatConversionConfiguration prop

### DIFF
--- a/troposphere/firehose.py
+++ b/troposphere/firehose.py
@@ -14,12 +14,14 @@ def processor_type_validator(x):
                          ", ".join(valid_types))
     return x
 
+
 def compression_type_validator_orcserde(x):
     valid_types = ["UNCOMPRESSED", "GZIP", "SNAPPY"]
     if x not in valid_types:
         raise ValueError("Type must be one of: %s" %
                          ", ".join(valid_types))
     return x
+
 
 def compression_type_validator_parquet(x):
     valid_types = ["NONE", "ZLIB", "SNAPPY"]
@@ -28,11 +30,13 @@ def compression_type_validator_parquet(x):
                          ", ".join(valid_types))
     return x
 
+
 def validate_orcserde_format_version(x):
     valid_types = ["V0_11", "V0_12"]
     if x not in valid_types:
         raise ValueError("Type must be one of: %s" %
                          ", ".join(valid_types))
+
 
 def writer_vesion_type_validator(x):
     valid_types = ["V1", "V2"]
@@ -40,6 +44,7 @@ def writer_vesion_type_validator(x):
         raise ValueError("Type must be one of: %s" %
                          ", ".join(valid_types))
     return x
+
 
 def delivery_stream_type_validator(x):
     valid_types = ["DirectPut", "KinesisStreamAsSource"]
@@ -76,7 +81,7 @@ def s3_backup_mode_extended_s3_validator(x):
 class BufferingHints(AWSProperty):
     props = {
         'IntervalInSeconds': (positive_integer, True),
-        'SizeInMBs': (positive_integer, True)
+        'SizeInMBs': (positive_integer, True),
     }
 
 
@@ -115,7 +120,7 @@ class S3Configuration(AWSProperty):
         'CompressionFormat': (basestring, True),
         'EncryptionConfiguration': (EncryptionConfiguration, False),
         'Prefix': (basestring, False),
-        'RoleARN': (basestring, True)
+        'RoleARN': (basestring, True),
     }
 
 
@@ -204,19 +209,19 @@ class OpenXJsonSerDe(AWSProperty):
     props = {
         'ConvertDotsInJsonKeysToUnderscores': (boolean, False),
         'CaseInsensitive': (boolean, False),
-        'ColumnToJsonKeyMappings': (dict, False)
+        'ColumnToJsonKeyMappings': (dict, False),
     }
 
 
 class HiveJsonSerDe(AWSProperty):
     props = {
-        'TimestampFormats': (list, False)
+        'TimestampFormats': (list, False),
     }
 
 
 class Deserializer(AWSProperty):
     props = {
-        'OpenXJsonSerDe': (OpenXJsonSerDe, False)
+        'OpenXJsonSerDe': (OpenXJsonSerDe, False),
     }
 
 
@@ -233,7 +238,7 @@ class ParquetSerDe(AWSProperty):
         'Compression': (compression_type_validator_orcserde, False),
         'EnableDictionaryCompression': (boolean, False),
         'MaxPaddingBytes': (positive_integer, False),
-        'WriterVersion': (writer_vesion_type_validator, False)
+        'WriterVersion': (writer_vesion_type_validator, False),
     }
 
 
@@ -242,26 +247,26 @@ class OrcSerDe(AWSProperty):
         'StripeSizeBytes': (positive_integer, False),
         'BlockSizeBytes': (positive_integer, False),
         'RowIndexStride': (positive_integer, False),
-        'EnablePadding': (boolean, False), 
+        'EnablePadding': (boolean, False),
         'PaddingTolerance': (float, False),
-        'Compression': (compression_type_validator_parquet),
+        'Compression': (compression_type_validator_parquet, False),
         'BloomFilterColumns': (list, False),
         'BloomFilterFalsePositiveProbability': (float, False),
         'DictionaryKeyThreshold': (float, False),
-        'FormatVersion': (validate_orcserde_format_version, False)
+        'FormatVersion': (validate_orcserde_format_version, False),
     }
 
 
 class Serializer(AWSProperty):
     props = {
         'ParquetSerDe': (ParquetSerDe, False),
-        'OrcSerDe': (OrcSerDe, False)
+        'OrcSerDe': (OrcSerDe, False),
     }
 
 
 class OutputFormatConfiguration(AWSProperty):
     props = {
-        'Serializer': (Serializer, False)
+        'Serializer': (Serializer, False),
     }
 
 
@@ -270,7 +275,7 @@ class DataFormatConversionConfiguration(AWSProperty):
         'SchemaConfiguration': (SchemaConfiguration, False),
         'InputFormatConfiguration': (InputFormatConfiguration, False),
         'OutputFormatConfiguration': (OutputFormatConfiguration, False),
-        'Enabled': (boolean, True)
+        'Enabled': (boolean, True),
     }
 
 
@@ -286,7 +291,8 @@ class ExtendedS3DestinationConfiguration(AWSProperty):
         'RoleARN': (basestring, True),
         'S3BackupConfiguration': (S3DestinationConfiguration, False),
         'S3BackupMode': (s3_backup_mode_extended_s3_validator, False),
-        'DataFormatConversionConfiguration': (DataFormatConversionConfiguration, False)
+        'DataFormatConversionConfiguration':
+            (DataFormatConversionConfiguration, False),
     }
 
 

--- a/troposphere/firehose.py
+++ b/troposphere/firehose.py
@@ -266,7 +266,8 @@ class DataFormatConversionConfiguration(AWSProperty):
     props = {
         'SchemaConfiguration': (SchemaConfiguration, False),
         'InputFormatConfiguration': (InputFormatConfiguration, False),
-        'OutputFormatConfiguration': (OutputFormatConfiguration, False)
+        'OutputFormatConfiguration': (OutputFormatConfiguration, False),
+        'Enabled': (boolean, True)
     }
 
 

--- a/troposphere/firehose.py
+++ b/troposphere/firehose.py
@@ -190,12 +190,12 @@ class S3DestinationConfiguration(AWSProperty):
 
 class SchemaConfiguration(AWSProperty):
     props = {
-        'RoleARN': (basestring, True)
-        'CatalogId': (basestring, True),
-        'DatabaseName': (basestring, True),
-        'TableName': (basestring, True),
-        'Region': (basestring, True),
-        'VersionId': (basestring, True),
+        'RoleARN': (basestring, False),
+        'CatalogId': (basestring, False),
+        'DatabaseName': (basestring, False),
+        'TableName': (basestring, False),
+        'Region': (basestring, False),
+        'VersionId': (basestring, False),
     }
 class OpenXJsonSerDe(AWSProperty):
     props = {
@@ -223,13 +223,6 @@ class InputFormatConfiguration(AWSProperty):
     }
 
 
-class Serializer(AWSProperty):
-    props = {
-        'ParquetSerDe': (ParquetSerDe, False),
-        'OrcSerDe': (OrcSerDe, False)
-    }
-
-
 class ParquetSerDe(AWSProperty):
     props = {
         'BlockSizeBytes': (positive_integer, False),
@@ -253,6 +246,13 @@ class OrcSerDe(AWSProperty):
         'BloomFilterFalsePositiveProbability': (float, False),
         'DictionaryKeyThreshold': (float, False),
         'FormatVersion': (validate_orcserde_format_version, False)
+    }
+
+
+class Serializer(AWSProperty):
+    props = {
+        'ParquetSerDe': (ParquetSerDe, False),
+        'OrcSerDe': (OrcSerDe, False)
     }
 
 

--- a/troposphere/firehose.py
+++ b/troposphere/firehose.py
@@ -188,6 +188,7 @@ class S3DestinationConfiguration(AWSProperty):
         'RoleARN': (basestring, True),
     }
 
+
 class SchemaConfiguration(AWSProperty):
     props = {
         'RoleARN': (basestring, False),
@@ -197,6 +198,8 @@ class SchemaConfiguration(AWSProperty):
         'Region': (basestring, False),
         'VersionId': (basestring, False),
     }
+
+
 class OpenXJsonSerDe(AWSProperty):
     props = {
         'ConvertDotsInJsonKeysToUnderscores': (boolean, False),

--- a/troposphere/firehose.py
+++ b/troposphere/firehose.py
@@ -14,6 +14,32 @@ def processor_type_validator(x):
                          ", ".join(valid_types))
     return x
 
+def compression_type_validator_orcserde(x):
+    valid_types = ["UNCOMPRESSED", "GZIP", "SNAPPY"]
+    if x not in valid_types:
+        raise ValueError("Type must be one of: %s" %
+                         ", ".join(valid_types))
+    return x
+
+def compression_type_validator_parquet(x):
+    valid_types = ["NONE", "ZLIB", "SNAPPY"]
+    if x not in valid_types:
+        raise ValueError("Type must be one of: %s" %
+                         ", ".join(valid_types))
+    return x
+
+def validate_orcserde_format_version(x):
+    valid_types = ["V0_11", "V0_12"]
+    if x not in valid_types:
+        raise ValueError("Type must be one of: %s" %
+                         ", ".join(valid_types))
+
+def writer_vesion_type_validator(x):
+    valid_types = ["V1", "V2"]
+    if x not in valid_types:
+        raise ValueError("Type must be one of: %s" %
+                         ", ".join(valid_types))
+    return x
 
 def delivery_stream_type_validator(x):
     valid_types = ["DirectPut", "KinesisStreamAsSource"]
@@ -162,6 +188,87 @@ class S3DestinationConfiguration(AWSProperty):
         'RoleARN': (basestring, True),
     }
 
+class SchemaConfiguration(AWSProperty):
+    props = {
+        'RoleARN': (basestring, True)
+        'CatalogId': (basestring, True),
+        'DatabaseName': (basestring, True),
+        'TableName': (basestring, True),
+        'Region': (basestring, True),
+        'VersionId': (basestring, True),
+    }
+class OpenXJsonSerDe(AWSProperty):
+    props = {
+        'ConvertDotsInJsonKeysToUnderscores': (boolean, False),
+        'CaseInsensitive': (boolean, False),
+        'ColumnToJsonKeyMappings': (dict, False)
+    }
+
+
+class HiveJsonSerDe(AWSProperty):
+    props = {
+        'TimestampFormats': (list, False)
+    }
+
+
+class Deserializer(AWSProperty):
+    props = {
+        'OpenXJsonSerDe': (OpenXJsonSerDe, False)
+    }
+
+
+class InputFormatConfiguration(AWSProperty):
+    props = {
+        'Deserializer': (Deserializer, False),
+    }
+
+
+class Serializer(AWSProperty):
+    props = {
+        'ParquetSerDe': (ParquetSerDe, False),
+        'OrcSerDe': (OrcSerDe, False)
+    }
+
+
+class ParquetSerDe(AWSProperty):
+    props = {
+        'BlockSizeBytes': (positive_integer, False),
+        'PageSizeBytes': (positive_integer, False),
+        'Compression': (compression_type_validator_orcserde, False),
+        'EnableDictionaryCompression': (boolean, False),
+        'MaxPaddingBytes': (positive_integer, False),
+        'WriterVersion': (writer_vesion_type_validator, False)
+    }
+
+
+class OrcSerDe(AWSProperty):
+    props = {
+        'StripeSizeBytes': (positive_integer, False),
+        'BlockSizeBytes': (positive_integer, False),
+        'RowIndexStride': (positive_integer, False),
+        'EnablePadding': (boolean, False), 
+        'PaddingTolerance': (float, False),
+        'Compression': (compression_type_validator_parquet),
+        'BloomFilterColumns': (list, False),
+        'BloomFilterFalsePositiveProbability': (float, False),
+        'DictionaryKeyThreshold': (float, False),
+        'FormatVersion': (validate_orcserde_format_version, False)
+    }
+
+
+class OutputFormatConfiguration(AWSProperty):
+    props = {
+        'Serializer': (Serializer, False)
+    }
+
+
+class DataFormatConversionConfiguration(AWSProperty):
+    props = {
+        'SchemaConfiguration': (SchemaConfiguration, False),
+        'InputFormatConfiguration': (InputFormatConfiguration, False),
+        'OutputFormatConfiguration': (OutputFormatConfiguration, False)
+    }
+
 
 class ExtendedS3DestinationConfiguration(AWSProperty):
     props = {
@@ -175,6 +282,7 @@ class ExtendedS3DestinationConfiguration(AWSProperty):
         'RoleARN': (basestring, True),
         'S3BackupConfiguration': (S3DestinationConfiguration, False),
         'S3BackupMode': (s3_backup_mode_extended_s3_validator, False),
+        'DataFormatConversionConfiguration': (DataFormatConversionConfiguration, False)
     }
 
 


### PR DESCRIPTION
Came across missing properties for Firehose JSON to Parquet or OCR converting. Props added against boto3 1.9.150 documentation. 