### PR TITLE
Allow for AWSHelperFn objects in Tags

### DIFF
--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,5 +1,5 @@
 import unittest
-from troposphere import Sub, Tags
+from troposphere import If, Sub, Tag, Tags
 from troposphere.autoscaling import Tags as ASTags
 
 
@@ -12,6 +12,17 @@ class TestTags(unittest.TestCase):
             {'Value': 'foo', 'Key': 'foo'},
             {'Value': 'bar', 'Key': 'bar'},
             {'Value': 'baz', 'Key': 'baz'},
+        ]
+        self.assertEqual(tags.to_dict(), result)
+
+    def test_TagConditional(self):
+        tags = Tags(
+            {'foo': 'foo'},
+            If('MyCondition', Tag('bar', 'bar'), Tag('baz', 'baz'))
+        )
+        result = [
+            {"Fn::If": ["MyCondition", {"Key": "bar", "Value": "bar"}, {"Key": "baz", "Value": "baz"}]},
+            {'Value': 'foo', 'Key': 'foo'},
         ]
         self.assertEqual(tags.to_dict(), result)
 

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -525,24 +525,31 @@ class ImportValue(AWSHelperFn):
         self.data = {'Fn::ImportValue': data}
 
 
+class Tag(AWSHelperFn):
+    def __init__(self, k, v):
+        self.data = {'Key': k, 'Value': v, }
+
+
 class Tags(AWSHelperFn):
     def __init__(self, *args, **kwargs):
+        self.tags = []
         if not args:
             # Assume kwargs variant
             tag_dict = kwargs
         else:
-            if len(args) != 1:
-                raise(TypeError, "Multiple non-kwargs passed to Tags")
-
-            # Validate single argument passed in is a dict
-            if not isinstance(args[0], dict):
-                raise(TypeError, "Tags needs to be either kwargs or dict")
-            tag_dict = args[0]
+            tag_dict = {}
+            for arg in args:
+                # Validate argument passed in is an AWSHelperFn or...
+                if isinstance(arg, AWSHelperFn):
+                    self.tags.append(arg)
+                # Validate argument passed in is a dict
+                elif isinstance(arg, dict):
+                    tag_dict.update(arg)
+                else:
+                    raise(TypeError, "Tags needs to be either kwargs, dict, or AWSHelperFn")
 
         def add_tag(tag_list, k, v):
             tag_list.append({'Key': k, 'Value': v, })
-
-        self.tags = []
 
         # Detect and handle non-string Tag items which do not sort in Python3
         if all(isinstance(k, basestring) for k in tag_dict):


### PR DESCRIPTION
Fixes #1385 

Usecase: We would like to add a dynamically named tag, depending on the value of a Stack parameter, for example if a string is provided, create a tag based on that value.  Currently this is not possible.

This update allows for multiple args to be passed into the `Tags` constructor, as long as all are either dictionaries, or `AWSHelperFn` objects.  It also adds a `Tag` object, to represent a single resource tag, and enforce proper formatting.