### PR TITLE
Fix Parameters on AWS::Batch::JobDefinition

### DIFF
--- a/troposphere/batch.py
+++ b/troposphere/batch.py
@@ -124,7 +124,7 @@ class JobDefinition(AWSObject):
     props = {
         'ContainerProperties': (ContainerProperties, True),
         'JobDefinitionName': (basestring, False),
-        'Parameters': (dict, True),
+        'Parameters': (dict, False),
         'RetryStrategy': (RetryStrategy, False),
         'Timeout': (Timeout, False),
         'Type': (basestring, True),


### PR DESCRIPTION
Parameters is not a required property as per https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-batch-jobdefinition.html#cfn-batch-jobdefinition-parameters