### PR TITLE
Add missing LOCAL ProjectCache location option

### DIFF
--- a/troposphere/codebuild.py
+++ b/troposphere/codebuild.py
@@ -149,6 +149,7 @@ class ProjectCache(AWSProperty):
     def validate(self):
         valid_types = [
             'NO_CACHE',
+            'LOCAL',
             'S3',
         ]
         cache_type = self.properties.get('Type')


### PR DESCRIPTION
Add missing LOCAL location to CodeBuild ProjectCache 

> Location
> 
> Information about the cache location:
> 
> - NO_CACHE or LOCAL: This value is ignored.
>   
> - S3: This is the S3 bucket name/prefix.

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-projectcache.html