### PR TITLE
Adding AWS::Backup resources from May 23, 2019 update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ nosetests.xml
 
 # Sphinx
 docs/_build/
+
+# VSCode
+.vscode

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -6,6 +6,7 @@ from troposphere.validators import tg_healthcheck_port
 from troposphere.validators import s3_bucket_name, encoding, status
 from troposphere.validators import iam_path, iam_names, iam_role_name
 from troposphere.validators import iam_group_name, iam_user_name, elb_name
+from troposphere.validators import backup_vault_name
 from troposphere.validators import mutually_exclusive, notification_type
 from troposphere.validators import notification_event, task_type
 from troposphere.validators import compliance_level, operating_system
@@ -148,6 +149,13 @@ class TestValidators(unittest.TestCase):
         for s in ['', 'a'*65, 'a%', 'a#', 'A a']:
             with self.assertRaises(ValueError):
                 iam_user_name(s)
+
+    def test_backup_vault_name(self):
+        for s in ['a', 'a'*50, 'A', 'Aa', 'A1', 'A-a', 'A_a', 'A.a']:
+            backup_vault_name(s)
+        for s in ['', 'a'*65, 'a%', 'a#', 'A a']:
+            with self.assertRaises(ValueError):
+                backup_vault_name(s)
 
     def test_one_of(self):
         conds = ['Bilbo', 'Frodo']

--- a/troposphere/backup.py
+++ b/troposphere/backup.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2012-2018, Mark Peek <mark@peek.org>
+# All rights reserved.
+#
+# See LICENSE file for full license.
+
+from . import AWSObject, AWSProperty, If
+from .validators import backup_vault_name, double, exactly_one, json_checker
+
+
+class LifecycleResourceType(AWSProperty):
+    props = {
+        'DeleteAfterDays': (double, False),
+        'MoveToColdStorageAfterDays': (double, False),
+    }
+
+
+class BackupRuleResourceType(AWSProperty):
+    props = {
+        'CompletionWindowMinutes': (double, False),
+        'Lifecycle': (LifecycleResourceType, False),
+        'RecoveryPointTags': (json_checker, False),
+        'RuleName': (basestring, True),
+        'ScheduleExpresion': (basestring, False),
+        'StartWindowMinutes': (double, False),
+        'TargetBackupVault': (basestring, True),
+    }
+
+
+class BackupPlanResourceType(AWSProperty):
+    props = {
+        'BackupPlanName': (basestring, True),
+        'BackupPlanRule': ([BackupRuleResourceType], True),
+    }
+
+
+class BackupPlan(AWSObject):
+    resource_type = "AWS::Backup::BackupPlan"
+
+    props = {
+        'BackupPlan': (BackupPlanResourceType, True),
+        'BackupPlanTags': (dict, False),
+    }
+
+
+class ConditionResourceType(AWSProperty):
+    props = {
+        'ConditionKey': (basestring, True),
+        'ConditionType': (basestring, True),
+        'ConditionValue': (basestring, True),
+    }
+
+
+class BackupSelectionResourceType(AWSProperty):
+    props = {
+        'IamRoleArn': (basestring, True),
+        'ListOfTags': ([ConditionResourceType], False),
+        'Resources': ([basestring], False),
+        'SelectionName': (basestring, True),
+    }
+
+    def validate(self):
+        conds = [
+            'ListOfTags',
+            'Resources',
+        ]
+
+        def check_if(names, props):
+            validated = []
+            for name in names:
+                validated.append(name in props and isinstance(props[name], If))
+            return all(validated)
+
+        if check_if(conds, self.properties):
+            return
+
+        exactly_one(self.__class__.__name__, self.properties, conds)
+
+
+class BackupSelection(AWSObject):
+    resource_type = "AWS::Backup::BackupSelection"
+
+    props = {
+        'BackupPlanId': (basestring, True),
+        'BackupSelection': (BackupSelectionResourceType, True),
+    }
+
+
+class NotificationObjectType(AWSProperty):
+    props = {
+        'BackupVaultEvents': ([basestring], True),
+        'SNSTopicArn': (basestring, True)
+    }
+
+
+class BackupVault(AWSObject):
+    resource_type = "AWS::Backup::BackupVault"
+
+    props = {
+        'AccessPolicy': (json_checker, False),
+        'BackupVaultName': (backup_vault_name, True),
+        'BackupVaultTags': (json_checker, False),
+        'EncryptionKeyArn': (basestring, False),
+        'Notifications': (NotificationObjectType, False),
+    }

--- a/troposphere/backup.py
+++ b/troposphere/backup.py
@@ -20,7 +20,7 @@ class BackupRuleResourceType(AWSProperty):
         'Lifecycle': (LifecycleResourceType, False),
         'RecoveryPointTags': (json_checker, False),
         'RuleName': (basestring, True),
-        'ScheduleExpresion': (basestring, False),
+        'ScheduleExpression': (basestring, False),
         'StartWindowMinutes': (double, False),
         'TargetBackupVault': (basestring, True),
     }

--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -484,3 +484,11 @@ def ecs_proxy_type(proxy_type):
             )
         )
     return(proxy_type)
+
+
+def backup_vault_name(name):
+    vault_name_re = compile(r'^[a-zA-Z0-9\-\_\.]{1,50}$')  # noqa
+    if vault_name_re.match(name):
+        return name
+    else:
+        raise ValueError("%s is not a valid backup vault name" % name)


### PR DESCRIPTION
Adds support for AWS::Backup resources added in a [May 23rd update](https://aws.amazon.com/about-aws/whats-new/2019/05/aws-backup-now-supports-aws-cloudformation/).

- [AWS::Backup::BackupPlan](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-backup-backupplan.html)
- [AWS::Backup::BackupSelection](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-backup-backupselection.html)
- [AWS::Backup::BackupVault](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-backup-backupvault.html)

**Note:** These resources are not present in the CloudFormation Resource Specification file as far as I can tell.  I have cut a support case with AWS asking about it, but wanted to get the ball rolling on adding these resources.  Once they are added, I plan to generate and update as needed.