### PR TITLE
Sagemaker coderepository

### DIFF
--- a/troposphere/sagemaker.py
+++ b/troposphere/sagemaker.py
@@ -87,6 +87,9 @@ class NotebookInstance(AWSObject):
     resource_type = "AWS::SageMaker::NotebookInstance"
 
     props = {
+        'AcceleratorTypes': ([basestring], False),
+        'AdditionalCodeRepositories': ([basestring], False),
+        'DefaultCodeRepository': ([basestring], False),
         'DirectInternetAccess': (basestring, False),
         'InstanceType': (basestring, True),
         'KmsKeyId': (basestring, False),

--- a/troposphere/sagemaker.py
+++ b/troposphere/sagemaker.py
@@ -7,20 +7,20 @@ from . import AWSObject, AWSProperty, Tags
 from .validators import integer
 
 
-class CodeRepository(AWSObject):
-    resource_type = "AWS::SageMaker::CodeRepository"
-
-    props = {
-        "CodeRepositoryName": (basestring, False),
-        "GitConfig": (GitConfig, True)
-    }
-
-
 class GitConfig(AWSProperty):
     props = {
         'Branch': (basestring, False),
         'RepositoryUrl': (basestring, True),
         'SecretArn': (basestring, False),
+    }
+
+
+class CodeRepository(AWSObject):
+    resource_type = "AWS::SageMaker::CodeRepository"
+
+    props = {
+        'CodeRepositoryName': (basestring, False),
+        'GitConfig': (GitConfig, True)
     }
 
 

--- a/troposphere/sagemaker.py
+++ b/troposphere/sagemaker.py
@@ -7,6 +7,23 @@ from . import AWSObject, AWSProperty, Tags
 from .validators import integer
 
 
+class CodeRepository(AWSObject):
+    resource_type = "AWS::SageMaker::CodeRepository"
+
+    props = {
+        "CodeRepositoryName": (basestring, False),
+        "GitConfig": (GitConfig, True)
+    }
+
+
+class GitConfig(AWSProperty):
+    props = {
+        'Branch': (basestring, False),
+        'RepositoryUrl': (basestring, True),
+        'SecretArn': (basestring, False),
+    }
+
+
 class Endpoint(AWSObject):
     resource_type = "AWS::SageMaker::Endpoint"
 
@@ -87,9 +104,6 @@ class NotebookInstance(AWSObject):
     resource_type = "AWS::SageMaker::NotebookInstance"
 
     props = {
-        'AcceleratorTypes': ([basestring], False),
-        'AdditionalCodeRepositories': ([basestring], False),
-        'DefaultCodeRepository': ([basestring], False),
         'DirectInternetAccess': (basestring, False),
         'InstanceType': (basestring, True),
         'KmsKeyId': (basestring, False),


### PR DESCRIPTION
A new resource type under SageMaker called AWS::SageMaker::CodeRepository was added. Reference: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-coderepository.html