### PR TITLE
Fix bug where FilterGroups were required, when technically they are not

### DIFF
--- a/tests/test_codebuild.py
+++ b/tests/test_codebuild.py
@@ -36,9 +36,9 @@ class TestCodeBuildFilters(unittest.TestCase):
         ]).validate()
 
     def test_filter_no_filtergroup(self):
-        match = "'FilterGroups is required when creating triggers'"
-        with self.assertRaisesRegexp(KeyError, match):
-            codebuild.ProjectTriggers().validate()
+        codebuild.ProjectTriggers(Webhook=True).validate()
+        # Technically this is valid, not sure why you would want this though?
+        codebuild.ProjectTriggers().validate()
 
     def test_filter_not_list(self):
         match = "<type 'int'>, expected <type 'list'>"

--- a/troposphere/codebuild.py
+++ b/troposphere/codebuild.py
@@ -241,22 +241,26 @@ class ProjectTriggers(AWSProperty):
     }
 
     def validate(self):
-        if 'FilterGroups' not in self.properties:
-            raise KeyError('FilterGroups is required when creating triggers')
-        if not isinstance(self.FilterGroups, list):
-            self._raise_type('FilterGroups', self.FilterGroups, list)
-        for counti, elem in enumerate(self.properties.get('FilterGroups')):
-            if not isinstance(elem, list):
-                self._raise_type(
-                    'FilterGroups[{}]'.format(counti),
-                    self.FilterGroups[counti], list
-                )
-            for countj, hook in enumerate(self.FilterGroups[counti]):
-                if not isinstance(hook, WebhookFilter):
+        """ FilterGroups, if set, needs to be a list of a list of
+        WebhookFilters
+        """
+        filter_groups = self.properties.get('FilterGroups')
+        if filter_groups is not None:
+            if not isinstance(filter_groups, list):
+                self._raise_type('FilterGroups', filter_groups, list)
+
+            for counti, elem in enumerate(filter_groups):
+                if not isinstance(elem, list):
                     self._raise_type(
-                        'FilterGroups[{}][{}]'.format(counti, countj),
-                        hook, WebhookFilter
+                        'FilterGroups[{}]'.format(counti),
+                        filter_groups[counti], list
                     )
+                for countj, hook in enumerate(filter_groups[counti]):
+                    if not isinstance(hook, WebhookFilter):
+                        self._raise_type(
+                            'FilterGroups[{}][{}]'.format(counti, countj),
+                            hook, WebhookFilter
+                        )
 
 
 def validate_status(status):


### PR DESCRIPTION
Fixes a bug introduced here https://github.com/cloudtools/troposphere/pull/1372

Basically while FilterGroups aren't required, the validate() function
was effectively making them required.  This makes it so validate only
validates FilterGroups if they're actually set.