### PR TITLE
Add Tags property to IAMRole definition

### DIFF
--- a/troposphere/iam.py
+++ b/troposphere/iam.py
@@ -3,7 +3,7 @@
 #
 # See LICENSE file for full license.
 
-from . import AWSObject, AWSProperty
+from . import AWSObject, AWSProperty, Tags
 from .validators import integer, boolean, status
 from .validators import iam_path, iam_role_name, iam_group_name, iam_user_name
 
@@ -82,6 +82,7 @@ class Role(AWSObject):
         'PermissionsBoundary': (basestring, False),
         'Policies': ([Policy], False),
         'RoleName': (iam_role_name, False),
+        'Tags': ((Tags, list), False),
     }
 
 


### PR DESCRIPTION
Add the "Tags" property to troposphere's IAM Role definition.
It looks like CloudFormation has started incorporating tags for IAM roles -- the CloudFormation resource specifications for all regions now include a Tags property in the AWS::IAM::Role spec, and stack tags are being applied to generated roles.