### PR TITLE
Add Tags to ECR Repository definition

### DIFF
--- a/tests/test_ecr.py
+++ b/tests/test_ecr.py
@@ -1,0 +1,18 @@
+import unittest
+import troposphere.ecr as ecr
+
+
+class TestECS(unittest.TestCase):
+
+    def test_ecr_with_tags(self):
+        repo = ecr.Repository(
+            "ECRRepo",
+            RepositoryName="myrepo",
+            Tags=[
+                {
+                    'Key': 'Name',
+                    'Value': 'myrepo',
+                },
+            ]
+        )
+        repo.to_dict()

--- a/tests/test_ecr.py
+++ b/tests/test_ecr.py
@@ -1,4 +1,5 @@
 import unittest
+from troposphere import Tags
 import troposphere.ecr as ecr
 
 
@@ -8,11 +9,6 @@ class TestECS(unittest.TestCase):
         repo = ecr.Repository(
             "ECRRepo",
             RepositoryName="myrepo",
-            Tags=[
-                {
-                    'Key': 'Name',
-                    'Value': 'myrepo',
-                },
-            ]
+            Tags=Tags(Name='myrepo'),
         )
         repo.to_dict()

--- a/troposphere/ecr.py
+++ b/troposphere/ecr.py
@@ -1,4 +1,4 @@
-from . import AWSObject, AWSProperty
+from . import AWSObject, AWSProperty, Tags
 try:
     from awacs.aws import Policy
     policytypes = (dict, Policy)
@@ -20,4 +20,5 @@ class Repository(AWSObject):
         'LifecyclePolicy': (LifecyclePolicy, False),
         'RepositoryName': (basestring, False),
         'RepositoryPolicyText': (policytypes, False),
+        'Tags': ((Tags, list), False),
     }

--- a/troposphere/ecr.py
+++ b/troposphere/ecr.py
@@ -20,5 +20,5 @@ class Repository(AWSObject):
         'LifecyclePolicy': (LifecyclePolicy, False),
         'RepositoryName': (basestring, False),
         'RepositoryPolicyText': (policytypes, False),
-        'Tags': ((Tags, list), False),
+        'Tags': (Tags, False),
     }


### PR DESCRIPTION
ECR added support for tags back in December:
https://aws.amazon.com/about-aws/whats-new/2018/12/amazon-ecr-now-allows-repository-tagging/

Let me know if anything looks out of place. Thanks!