### PR TITLE
Fix tags type for AWS Backup resources

### DIFF
--- a/examples/Backup.py
+++ b/examples/Backup.py
@@ -1,0 +1,90 @@
+from troposphere import Template, backup
+from troposphere.iam import Role
+
+template = Template("AWS Backup")
+template.set_version()
+
+backup_vault = template.add_resource(
+    backup.BackupVault(
+        "Vault",
+        BackupVaultName="my-backup-vault",
+        BackupVaultTags=dict(
+            Project="Project",
+            Environment="Environment",
+            Classifier="Classifier",
+        ),
+        # EncryptionKeyArn="KmsKeyId",
+    )
+)
+
+backup_plan = template.add_resource(
+    backup.BackupPlan(
+        "Backup",
+        BackupPlan=backup.BackupPlanResourceType(
+            BackupPlanName="BackupPlan",
+            BackupPlanRule=[
+                backup.BackupRuleResourceType(
+                    TargetBackupVault=backup_vault.ref(),
+                    Lifecycle=backup.LifecycleResourceType(DeleteAfterDays=31),
+                    RecoveryPointTags=dict(
+                        Project="Project",
+                        Environment="Environment",
+                        Classifier="Classifier",
+                    ),
+                    RuleName="Rule 1",
+                    ScheduleExpression="cron(0 0/12 * * ? *)",
+                )
+            ],
+        ),
+        BackupPlanTags=dict(
+            Project="Project",
+            Environment="Environment",
+            Classifier="Classifier",
+        ),
+    )
+)
+
+service_role = template.add_resource(
+    Role(
+        "BackupServiceRole",
+        AssumeRolePolicyDocument={
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"Service": ["backup.amazonaws.com"]},
+                    "Action": ["sts:AssumeRole"],
+                }
+            ]
+        },
+        ManagedPolicyArns=[
+            (
+                "arn:aws:iam::aws:policy/service-role/"
+                "AWSBackupServiceRolePolicyForBackup"
+            ),
+            (
+                "arn:aws:iam::aws:policy/service-role/"
+                "AWSBackupServiceRolePolicyForRestores"
+            ),
+        ],
+    )
+)
+
+template.add_resource(
+    backup.BackupSelection(
+        "StorageBackupSelectionByTags",
+        BackupSelection=backup.BackupSelectionResourceType(
+            IamRoleArn=service_role.get_att("Arn"),
+            ListOfTags=[
+                backup.ConditionResourceType(
+                    ConditionKey="Backup",
+                    ConditionType="STRINGEQUALS",
+                    ConditionValue="True",
+                )
+            ],
+            SelectionName="MySelection",
+        ),
+        BackupPlanId=backup_plan.ref(),
+    )
+)
+
+print(template.to_json())

--- a/tests/examples_output/Backup.template
+++ b/tests/examples_output/Backup.template
@@ -1,0 +1,95 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "AWS Backup",
+    "Resources": {
+        "Backup": {
+            "Properties": {
+                "BackupPlan": {
+                    "BackupPlanName": "BackupPlan",
+                    "BackupPlanRule": [
+                        {
+                            "Lifecycle": {
+                                "DeleteAfterDays": 31
+                            },
+                            "RecoveryPointTags": {
+                                "Classifier": "Classifier",
+                                "Environment": "Environment",
+                                "Project": "Project"
+                            },
+                            "RuleName": "Rule 1",
+                            "ScheduleExpression": "cron(0 0/12 * * ? *)",
+                            "TargetBackupVault": {
+                                "Ref": "Vault"
+                            }
+                        }
+                    ]
+                },
+                "BackupPlanTags": {
+                    "Classifier": "Classifier",
+                    "Environment": "Environment",
+                    "Project": "Project"
+                }
+            },
+            "Type": "AWS::Backup::BackupPlan"
+        },
+        "BackupServiceRole": {
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [
+                        {
+                            "Action": [
+                                "sts:AssumeRole"
+                            ],
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "backup.amazonaws.com"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "ManagedPolicyArns": [
+                    "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup",
+                    "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores"
+                ]
+            },
+            "Type": "AWS::IAM::Role"
+        },
+        "StorageBackupSelectionByTags": {
+            "Properties": {
+                "BackupPlanId": {
+                    "Ref": "Backup"
+                },
+                "BackupSelection": {
+                    "IamRoleArn": {
+                        "Fn::GetAtt": [
+                            "BackupServiceRole",
+                            "Arn"
+                        ]
+                    },
+                    "ListOfTags": [
+                        {
+                            "ConditionKey": "Backup",
+                            "ConditionType": "STRINGEQUALS",
+                            "ConditionValue": "True"
+                        }
+                    ],
+                    "SelectionName": "MySelection"
+                }
+            },
+            "Type": "AWS::Backup::BackupSelection"
+        },
+        "Vault": {
+            "Properties": {
+                "BackupVaultName": "my-backup-vault",
+                "BackupVaultTags": {
+                    "Classifier": "Classifier",
+                    "Environment": "Environment",
+                    "Project": "Project"
+                }
+            },
+            "Type": "AWS::Backup::BackupVault"
+        }
+    }
+}

--- a/troposphere/backup.py
+++ b/troposphere/backup.py
@@ -18,7 +18,7 @@ class BackupRuleResourceType(AWSProperty):
     props = {
         'CompletionWindowMinutes': (double, False),
         'Lifecycle': (LifecycleResourceType, False),
-        'RecoveryPointTags': (json_checker, False),
+        'RecoveryPointTags': (dict, False),
         'RuleName': (basestring, True),
         'ScheduleExpression': (basestring, False),
         'StartWindowMinutes': (double, False),
@@ -98,7 +98,7 @@ class BackupVault(AWSObject):
     props = {
         'AccessPolicy': (json_checker, False),
         'BackupVaultName': (backup_vault_name, True),
-        'BackupVaultTags': (json_checker, False),
+        'BackupVaultTags': (dict, False),
         'EncryptionKeyArn': (basestring, False),
         'Notifications': (NotificationObjectType, False),
     }


### PR DESCRIPTION
In the current implementation, the properties RecoveryPointTags and BackupVaultTags are defined as json_checker, which returns a string whereas CloudFormation expects a dict
`BackupVaultTags property should be a key value pair and not a string`

The example template in `tests/examples_output/Backup.template` is actually deploys a BackupPlan and Vault.