### PR TITLE
Add cfn-flip's literal option

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 # -------------------------------------
 
 # ---- Need libraries installed by setup.py
-cfn_flip>=1.0.2
+cfn_flip>=1.2.1
 awacs>=0.8
 
 # ---- Documentation Libraries

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@
 # -------------------------------------
 
 # ---- Need libraries installed by setup.py
-cfn_flip>=1.0.2
+cfn_flip>=1.2.1

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -784,9 +784,9 @@ class Template(object):
         return json.dumps(self.to_dict(), indent=indent,
                           sort_keys=sort_keys, separators=separators)
 
-    def to_yaml(self, clean_up=False, long_form=False):
+    def to_yaml(self, clean_up=False, long_form=False, literal=True):
         return cfn_flip.to_yaml(self.to_json(), clean_up=clean_up,
-                                long_form=long_form)
+                                long_form=long_form, literal=literal)
 
     def __eq__(self, other):
         if isinstance(other, Template):


### PR DESCRIPTION
This fixes an issue with cfn-flip that incorrectly translates
JSON for a step function as documented below:

https://github.com/awslabs/aws-cfn-template-flip/pull/80