### PR TITLE
EBSBlockDevice supports KmsKeyId

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -129,6 +129,7 @@ class EBSBlockDevice(AWSProperty):
     props = {
         'DeleteOnTermination': (boolean, False),
         'Encrypted': (boolean, False),
+        'KmsKeyId': (basestring, False),
         'Iops': (integer, False),  # Conditional
         'SnapshotId': (basestring, False),  # Conditional
         'VolumeSize': (integer, False),  # Conditional


### PR DESCRIPTION
Per AWS Documentation, EBSBlockDevice supports KmsKeyId now

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-blockdevicemapping-ebs.html