### PR TITLE
Fix TemporaryPasswordValidityDays type

### DIFF
--- a/troposphere/cognito.py
+++ b/troposphere/cognito.py
@@ -130,7 +130,7 @@ class PasswordPolicy(AWSProperty):
         'RequireNumbers': (boolean, False),
         'RequireSymbols': (boolean, False),
         'RequireUppercase': (boolean, False),
-        'TemporaryPasswordValidityDays': (float, False),
+        'TemporaryPasswordValidityDays': (positive_integer, False),
     }
 
 


### PR DESCRIPTION
This fixes an invalid type requirement on the 'TemporaryPasswordValidityDays' parameter of the Cognito UserPool Password Policy Object. Setting this to 'float' will invalidate the field if an integer is used, and a float value causes the stack to fail in Cloudformation with an ambiguous error.