### PR TITLE
Travis CI: Add flake8 which is a superset of pycodestyle and pyflakes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ install:
 before_script:
   - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then 2to3 -n -w --no-diffs troposphere scripts/cfn2py scripts/gen.py examples/CustomResource.py tests; fi
   - flake8 --version
-  - pycodestyle --show-source --show-pep8 .
-  - pyflakes .
   - flake8 . --show-source 
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,14 @@ before_install:
   - pip install --upgrade pip setuptools wheel
 
 install:
-  - pip install --upgrade pycodestyle
-  - pip install --upgrade pyflakes
+  - pip install --upgrade flake8
 
 before_script:
   - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then 2to3 -n -w --no-diffs troposphere scripts/cfn2py scripts/gen.py examples/CustomResource.py tests; fi
-  - pycodestyle --version
+  - flake8 --version
   - pycodestyle --show-source --show-pep8 .
   - pyflakes .
+  - flake8 . --show-source 
 
 script:
   - python setup.py test


### PR DESCRIPTION
[__flake8__](http://flake8.pycqa.org/) runs all the tests that pycodestyle and pyflakes do but also adds the Fxxx errors.

__basestring__ was removed in Python 3.