### PR TITLE
Modified AdditionalAuthenticationProviders field in GraphQlApi to be a list

### DIFF
--- a/troposphere/appsync.py
+++ b/troposphere/appsync.py
@@ -154,7 +154,7 @@ class GraphQLApi(AWSObject):
 
     props = {
         'AdditionalAuthenticationProviders':
-            (AdditionalAuthenticationProviders, False),
+            ([AdditionalAuthenticationProviders], False),
         'AuthenticationType': (basestring, True),
         'LogConfig': (LogConfig, False),
         'Name': (basestring, True),

--- a/troposphere/appsync.py
+++ b/troposphere/appsync.py
@@ -141,7 +141,7 @@ class UserPoolConfig(AWSProperty):
     }
 
 
-class AdditionalAuthenticationProviders(AWSProperty):
+class AdditionalAuthenticationProvider(AWSProperty):
     props = {
         'AuthenticationType': (basestring, True),
         'OpenIDConnectConfig': (OpenIDConnectConfig, False),
@@ -154,7 +154,7 @@ class GraphQLApi(AWSObject):
 
     props = {
         'AdditionalAuthenticationProviders':
-            ([AdditionalAuthenticationProviders], False),
+            ([AdditionalAuthenticationProvider], False),
         'AuthenticationType': (basestring, True),
         'LogConfig': (LogConfig, False),
         'Name': (basestring, True),


### PR DESCRIPTION
AppSync [Documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appsync-graphqlapi-additionalauthenticationproviders.html) states that  AdditionalAuthenticationProviders must be of type list. 

Cheers, 
Leo