### PR TITLE
Fixed a typo in the ClientBroker's value

### DIFF
--- a/examples/MskCluster.py
+++ b/examples/MskCluster.py
@@ -33,7 +33,7 @@ t.add_resource(
                 DataVolumeKMSKeyId="ReplaceWithKmsKeyArn"
             ),
             EncryptionInTransit=msk.EncryptionInTransit(
-                ClientBroker="TLSs",
+                ClientBroker="TLS",
                 InCluster=True,
             ),
         ),


### PR DESCRIPTION
This typo will make CFN error out about invalid tags which is misleading.