### PR TITLE
updated glue crawler tag attribute to match aws cloudformation doc

### DIFF
--- a/troposphere/glue.py
+++ b/troposphere/glue.py
@@ -163,7 +163,7 @@ class Crawler(AWSObject):
         'Schedule': (Schedule, False),
         'SchemaChangePolicy': (SchemaChangePolicy, False),
         'TablePrefix': (basestring, False),
-        'Tags': (Tags, False),
+        'Tags': (dict, False),
         'Targets': (Targets, True),
     }
 


### PR DESCRIPTION
As described in this [issue](https://github.com/cloudtools/troposphere/issues/1481) there is an attribute type mismatch that this patch resolves. 
