### PR TITLE
Add threshold metric

### DIFF
--- a/troposphere/cloudwatch.py
+++ b/troposphere/cloudwatch.py
@@ -82,6 +82,7 @@ class Alarm(AWSObject):
         'Period': (positive_integer, False),
         'Statistic': (basestring, False),
         'Threshold': (double, True),
+        'ThresholdMetricId': (basestring, False),
         'TreatMissingData': (basestring, False),
         'Unit': (basestring, False),
     }

--- a/troposphere/cloudwatch.py
+++ b/troposphere/cloudwatch.py
@@ -81,7 +81,7 @@ class Alarm(AWSObject):
         'OKActions': ([basestring], False),
         'Period': (positive_integer, False),
         'Statistic': (basestring, False),
-        'Threshold': (double, True),
+        'Threshold': (double, False),
         'ThresholdMetricId': (basestring, False),
         'TreatMissingData': (basestring, False),
         'Unit': (basestring, False),


### PR DESCRIPTION
Add _ThresholdMetricId_ for AWS::CloudWatch::Alarm.

Also according to the CloudFormation specification _Threshold_ is not mandatory.