### PR TITLE
Fix naming of parameters in FindInMap helper.

### DIFF
--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -415,7 +415,11 @@ class Base64(AWSHelperFn):
 
 class FindInMap(AWSHelperFn):
     def __init__(self, mapname, toplevelkey, secondlevelkey):
-        self.data = {'Fn::FindInMap': [self.getdata(mapname), toplevelkey, secondlevelkey]}
+        self.data = {'Fn::FindInMap': [
+            self.getdata(mapname),
+            toplevelkey,
+            secondlevelkey
+        ]}
 
 
 class GetAtt(AWSHelperFn):

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -414,8 +414,8 @@ class Base64(AWSHelperFn):
 
 
 class FindInMap(AWSHelperFn):
-    def __init__(self, mapname, key, value):
-        self.data = {'Fn::FindInMap': [self.getdata(mapname), key, value]}
+    def __init__(self, mapname, toplevelkey, secondlevelkey):
+        self.data = {'Fn::FindInMap': [self.getdata(mapname), toplevelkey, secondlevelkey]}
 
 
 class GetAtt(AWSHelperFn):


### PR DESCRIPTION
Parameters should be two-levels of nesting, rather than <key, value>. See link for reference:

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-findinmap.html