### PR TITLE
Add missing EnableNonSecurity property to Rule

### DIFF
--- a/troposphere/ssm.py
+++ b/troposphere/ssm.py
@@ -78,6 +78,7 @@ class Rule(AWSProperty):
     props = {
         'ApproveAfterDays': (integer, False),
         'ComplianceLevel': (compliance_level, False),
+        'EnableNonSecurity': (boolean, False),
         'PatchFilterGroup': (PatchFilterGroup, False),
     }
 


### PR DESCRIPTION
Adds `EnableNonSecurity` which is a non-required property for [Rule](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ssm-patchbaseline-rule.html)