### PR TITLE
Add SourceVersion to CodeBuild::Project

### DIFF
--- a/troposphere/codebuild.py
+++ b/troposphere/codebuild.py
@@ -326,6 +326,7 @@ class Project(AWSObject):
         'SecondarySources': ([Source], False),
         'ServiceRole': (basestring, True),
         'Source': (Source, True),
+        'SourceVersion': (basestring, False),
         'Tags': (Tags, False),
         'TimeoutInMinutes': (integer, False),
         'Triggers': (ProjectTriggers, False),


### PR DESCRIPTION
Was added to documentation in June 2019, see
https://github.com/awsdocs/aws-cloudformation-user-guide/commit/9493fe4d599de6d9f476458f8b849080663b1455#diff-d49f148002b45fafe495c3ea438604f4R176-R187

Current documentation: https://docs.aws.amazon.com/en_pv/AWSCloudFormation/latest/UserGuide/aws-resource-codebuild-project.html#cfn-codebuild-project-sourceversion