### PR TITLE
Add Description field to IAM Role

### DIFF
--- a/troposphere/iam.py
+++ b/troposphere/iam.py
@@ -70,6 +70,7 @@ class Role(AWSObject):
 
     props = {
         'AssumeRolePolicyDocument': (policytypes, True),
+        'Description': (basestring, False),
         'ManagedPolicyArns': ([basestring], False),
         'MaxSessionDuration': (integer, False),
         'Path': (iam_path, False),


### PR DESCRIPTION
IAM Role now support adding a description to them from a CloudFormation template (see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#cfn-iam-role-description), this make it possible to do so in troposphere.