### PR TITLE
Amend RefreshTokenValidity to match Cognito changes.

### DIFF
--- a/troposphere/cognito.py
+++ b/troposphere/cognito.py
@@ -243,7 +243,7 @@ class UserPoolClient(AWSObject):
         'GenerateSecret': (boolean, False),
         'LogoutURLs': ([basestring], False),
         'ReadAttributes': ([basestring], False),
-        'RefreshTokenValidity': (double, False),
+        'RefreshTokenValidity': (positive_integer, False),
         'SupportedIdentityProviders': ([basestring], False),
         'UserPoolId': (basestring, True),
         'WriteAttributes': ([basestring], False),

--- a/troposphere/cognito.py
+++ b/troposphere/cognito.py
@@ -4,7 +4,7 @@
 # See LICENSE file for full license.
 
 from . import AWSObject, AWSProperty
-from .validators import boolean, double, positive_integer
+from .validators import boolean, positive_integer
 
 
 class CognitoIdentityProvider(AWSProperty):


### PR DESCRIPTION
AWS have changed the type for this property from double to integer, updating type to match.
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpoolclient.html#cfn-cognito-userpoolclient-refreshtokenvalidity