### PR TITLE
Update placement object

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -151,8 +151,11 @@ class MountPoint(AWSProperty):
 
 class Placement(AWSProperty):
     props = {
+        'Affinity': (basestring, False),
         'AvailabilityZone': (basestring, False),
         'GroupName': (basestring, False),
+        'HostId': (basestring, False),
+        'Tenancy': (basestring, False)
     }
 
 


### PR DESCRIPTION
The placement object is missing a few fields from the upstream
CloudFormation specification:

* Affinity
* HostId
* Tenancy

This commit adds them to the Placement object

Current Placement object specification: https://github.com/cwgem/troposphere/pull/new/updated_launch_template_properties