### PR TITLE
Allow Tags to be given as a list when creating Resource that allows Tags

### DIFF
--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -39,6 +39,11 @@ PARAMETER_TITLE_MAX = 255
 
 valid_names = re.compile(r'^[a-zA-Z0-9]+$')
 
+try:
+    basestring
+except NameError:
+    basestring = str
+
 
 def is_aws_object_subclass(cls):
     is_aws_object = False
@@ -98,6 +103,10 @@ class BaseAWSObject(object):
             'Condition', 'CreationPolicy', 'DeletionPolicy', 'DependsOn',
             'Metadata', 'UpdatePolicy', 'UpdateReplacePolicy',
         ]
+        if 'Tags' in kwargs.keys() and 'Tags' in self.propnames:
+            local_tags = kwargs['Tags']
+            if isinstance(local_tags, list):
+                kwargs['Tags'] = Tags(*local_tags)
 
         # try to validate the title if its there
         if self.title:

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -39,6 +39,7 @@ PARAMETER_TITLE_MAX = 255
 
 valid_names = re.compile(r'^[a-zA-Z0-9]+$')
 
+
 try:
     basestring
 except NameError:

--- a/troposphere/sqs.py
+++ b/troposphere/sqs.py
@@ -7,6 +7,10 @@ from . import AWSHelperFn, AWSObject, AWSProperty, Tags
 from .compat import policytypes
 from .validators import integer
 
+try:
+    basestring
+except NameError:
+    basestring = str
 
 class RedrivePolicy(AWSProperty):
     props = {

--- a/troposphere/sqs.py
+++ b/troposphere/sqs.py
@@ -7,10 +7,12 @@ from . import AWSHelperFn, AWSObject, AWSProperty, Tags
 from .compat import policytypes
 from .validators import integer
 
+
 try:
     basestring
 except NameError:
     basestring = str
+
 
 class RedrivePolicy(AWSProperty):
     props = {


### PR DESCRIPTION
Added: Allows to pass in a CFN format list of Tags and transform it into a Tags() object on instantiation.

Added the exception for basestring as it seemed to be yelling in my import thinking

Example of code doing it:

```QueueA:
  Properties:
    Tags:
      - Key: Name
        Value: abcd
      - Key: VPC
        Value: vpc-id
```
```#!/usr/bin/env python
try:
    basestring
except NameError:
    basestring = str


from troposphere.sqs import Queue
with  open('test.yml', 'r') as fd:
    content = fd.read()
import yaml
content_dict = yaml.load(content, Loader=yaml.Loader)
queue = Queue('queuea', **content_dict['QueueA']['Properties'])
print(queue.to_dict())
```
If there is a better place to do it, or a nicer way to import a native CFN format into creating the object in full, I would love to see how :)

Many thanks for your consideration. Keep up the awesome work!
(Reopened from #1502 which was opened with the wrong account :/)