### PR TITLE
uncaught syntax error on EnabledMfa's

### DIFF
--- a/troposphere/cognito.py
+++ b/troposphere/cognito.py
@@ -204,7 +204,7 @@ class UserPool(AWSObject):
         'EmailConfiguration': (EmailConfiguration, False),
         'EmailVerificationMessage': (basestring, False),
         'EmailVerificationSubject': (basestring, False),
-        'EnabledMfas': (basestring, False),
+        'EnabledMfas': ([basestring], False),
         'LambdaConfig': (LambdaConfig, False),
         'MfaConfiguration': (basestring, False),
         'Policies': (Policies, False),


### PR DESCRIPTION
missed that EnabledMfa's needs to be a list of strings.

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpool.html#cfn-cognito-userpool-enabledmfas