### PR TITLE
Added missing rds scaling configuration capacity

### DIFF
--- a/troposphere/rds.py
+++ b/troposphere/rds.py
@@ -20,7 +20,7 @@ VALID_DB_ENGINES = ('MySQL', 'mysql', 'oracle-se1', 'oracle-se2', 'oracle-se',
 VALID_DB_ENGINE_MODES = ('provisioned', 'serverless')
 VALID_LICENSE_MODELS = ('license-included', 'bring-your-own-license',
                         'general-public-license', 'postgresql-license')
-VALID_SCALING_CONFIGURATION_CAPACITIES = (2, 4, 8, 16, 32, 64, 128, 256)
+VALID_SCALING_CONFIGURATION_CAPACITIES = (1, 2, 4, 8, 16, 32, 64, 128, 256)
 
 
 def validate_iops(iops):


### PR DESCRIPTION
[The documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-dbcluster-scalingconfiguration.html) states that the value "1" is a valid value, which was missing.

> Valid capacity values are 1, 2, 4, 8, 16, 32, 64, 128, and 256