### PR TITLE
Adding missing property for FindingPublishing

### DIFF
--- a/troposphere/guardduty.py
+++ b/troposphere/guardduty.py
@@ -12,6 +12,7 @@ class Detector(AWSObject):
 
     props = {
         'Enable': (boolean, True),
+        'FindingPublishingFrequency': ([basestring], False),
     }
 
 

--- a/troposphere/guardduty.py
+++ b/troposphere/guardduty.py
@@ -12,7 +12,7 @@ class Detector(AWSObject):
 
     props = {
         'Enable': (boolean, True),
-        'FindingPublishingFrequency': ([basestring], False),
+        'FindingPublishingFrequency': (basestring, False),
     }
 
 


### PR DESCRIPTION
Add property listed here in AWS documentation. : 

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-detector.html#cfn-guardduty-detector-findingpublishingfrequency