### PR TITLE
Support for API Gateway SecurityPolicy

### DIFF
--- a/troposphere/apigateway.py
+++ b/troposphere/apigateway.py
@@ -224,6 +224,7 @@ class DomainName(AWSObject):
         "DomainName": (basestring, True),
         "EndpointConfiguration": (EndpointConfiguration, False),
         "RegionalCertificateArn": (basestring, False),
+        "SecurityPolicy": (basestring, False),
     }
 
 


### PR DESCRIPTION
Added in SecurityPolicy as per:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-domainname.html