### PR TITLE
Adding update policy that allows for in place upgrade of ES cluster

### DIFF
--- a/troposphere/policies.py
+++ b/troposphere/policies.py
@@ -41,6 +41,7 @@ class UpdatePolicy(AWSAttribute):
         'AutoScalingReplacingUpdate': (AutoScalingReplacingUpdate, False),
         'CodeDeployLambdaAliasUpdate': (CodeDeployLambdaAliasUpdate, False),
         'UseOnlineResharding': (boolean, False),
+        'EnableVersionUpgrade': (boolean, False),
     }
 
 


### PR DESCRIPTION
As per https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html#cfn-attributes-updatepolicy-upgradeelasticsearchdomain

This should allow for in place version upgrade of Elasticsearch clusters