### PR TITLE
Break out NoDevice property validation (Fixes #1551)

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -138,8 +138,17 @@ class BlockDeviceMapping(AWSProperty):
     props = {
         'DeviceName': (basestring, True),
         'Ebs': (EBSBlockDevice, False),  # Conditional
-        'NoDevice': (dict, False),
         'VirtualName': (basestring, False),  # Conditional
+        'NoDevice': (dict, False)
+    }
+
+
+class LaunchTemplateBlockDeviceMapping(AWSProperty):
+    props = {
+        'DeviceName': (basestring, True),
+        'Ebs': (EBSBlockDevice, False),  # Conditional
+        'VirtualName': (basestring, False),  # Conditional
+        'NoDevice': (basestring, False)
     }
 
 
@@ -975,7 +984,7 @@ class LaunchTemplateCreditSpecification(AWSProperty):
 
 class LaunchTemplateData(AWSProperty):
     props = {
-        'BlockDeviceMappings': ([BlockDeviceMapping], False),
+        'BlockDeviceMappings': ([LaunchTemplateBlockDeviceMapping], False),
         'CpuOptions': (CpuOptions, False),
         'CreditSpecification': (LaunchTemplateCreditSpecification, False),
         'DisableApiTermination': (boolean, False),


### PR DESCRIPTION
* NoDevice is a string for launch template block device mapping and a null object for EC2 block device mapping
* This addresses the issue by breaking out block device mapping to two separate objects. The EC2 version will keep the original name for backwards compatibility purposes and the launch template version will take up a new name