### PR TITLE
Add CACertificateIdentifier to DBInstance

### DIFF
--- a/troposphere/rds.py
+++ b/troposphere/rds.py
@@ -172,6 +172,7 @@ class DBInstance(AWSObject):
         'AutoMinorVersionUpgrade': (boolean, False),
         'AvailabilityZone': (basestring, False),
         'BackupRetentionPeriod': (validate_backup_retention_period, False),
+        'CACertificateIdentifier': (basestring, False),
         'CharacterSetName': (basestring, False),
         'CopyTagsToSnapshot': (boolean, False),
         'DBClusterIdentifier': (basestring, False),


### PR DESCRIPTION
This should fix #1520

The property is not in the spec yet, but should already work (source: https://github.com/aws-cloudformation/aws-cloudformation-coverage-roadmap/issues/211#issuecomment-570726064)

