### PR TITLE
Strategy in AWS::EC2::PlacementGroup is not required

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -929,7 +929,7 @@ class PlacementGroup(AWSObject):
     resource_type = "AWS::EC2::PlacementGroup"
 
     props = {
-        'Strategy': (basestring, True),
+        'Strategy': (basestring, False),
     }
 
 


### PR DESCRIPTION
Both the [documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-placementgroup.html) and the spec say it's not required. `gen.py` also outputs it as not required.