### PR TITLE
Updating Serverless Apis's Auth

### DIFF
--- a/tests/test_serverless.py
+++ b/tests/test_serverless.py
@@ -2,8 +2,9 @@ import unittest
 from troposphere import Tags, Template
 from troposphere.s3 import Filter, Rules, S3Key
 from troposphere.serverless import (
-    Api, DeadLetterQueue, DeploymentPreference, Function, FunctionForPackaging,
-    LayerVersion, S3Event, S3Location, SimpleTable,
+    Api, Auth, DeadLetterQueue, DeploymentPreference, Function,
+    FunctionForPackaging, LayerVersion, ResourcePolicyStatement, S3Event,
+    S3Location, SimpleTable,
 )
 
 
@@ -155,6 +156,26 @@ class TestServerless(unittest.TestCase):
         serverless_api = Api(
             "SomeApi",
             StageName='test',
+        )
+        t = Template()
+        t.add_resource(serverless_api)
+        t.to_json()
+
+    def test_api_auth_resource_policy(self):
+        serverless_api = Api(
+            title='SomeApi',
+            Auth=Auth(
+                ResourcePolicy=ResourcePolicyStatement(
+                    AwsAccountBlacklist=['testAwsAccountBlacklist'],
+                    AwsAccountWhitelist=['testAwsAccountWhitelist'],
+                    CustomStatements=['testCustomStatements'],
+                    IpRangeBlacklist=['testIpRangeBlacklist'],
+                    IpRangeWhitelist=['testIpRangeWhitelist'],
+                    SourceVpcBlacklist=['testVpcBlacklist'],
+                    SourceVpcWhitelist=['testVpcWhitelist'],
+                ),
+            ),
+            StageName='testStageName',
         )
         t = Template()
         t.add_resource(serverless_api)

--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -177,10 +177,26 @@ class Authorizers(AWSProperty):
     }
 
 
+class ResourcePolicyStatement(AWSProperty):
+    props = {
+        'AwsAccountBlacklist': (list, False),
+        'AwsAccountWhitelist': (list, False),
+        'CustomStatements': (list, False),
+        'IpRangeBlacklist': (list, False),
+        'IpRangeWhitelist': (list, False),
+        'SourceVpcBlacklist': (list, False),
+        'SourceVpcWhitelist': (list, False),
+    }
+
+
 class Auth(AWSProperty):
     props = {
-        'DefaultAuthorizer': (basestring, False),
+        'AddDefaultAuthorizerToCorsPreflight': (bool, False),
+        'ApiKeyRequired': (bool, False),
         'Authorizers': (Authorizers, False),
+        'DefaultAuthorizer': (basestring, False),
+        'InvokeRole': (basestring, False),
+        'ResourcePolicy': (ResourcePolicyStatement, False),
     }
 
 


### PR DESCRIPTION
Adding AddDefaultAuthorizerToCorsPreflight, ApiKeyRequired, InvokeRole and ResourcePolicy to AWS::Serverless::Api's Auth