### PR TITLE
NamespaceId is not strictly required

### DIFF
--- a/troposphere/servicediscovery.py
+++ b/troposphere/servicediscovery.py
@@ -59,7 +59,7 @@ class DnsRecord(AWSProperty):
 class DnsConfig(AWSProperty):
     props = {
         'DnsRecords': ([DnsRecord], True),
-        'NamespaceId': (basestring, True),
+        'NamespaceId': (basestring, False),
         'RoutingPolicy': (basestring, False),
     }
 


### PR DESCRIPTION
NamespaceId is not strictly required. And NamespaceId is only required once, either there, or in the Service object.

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-servicediscovery-service-dnsconfig.html

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicediscovery-service.html#cfn-servicediscovery-service-namespaceid