### PR TITLE
Ignore If expression in validation of AutoScalingRollingUpdate min instances

### DIFF
--- a/troposphere/autoscaling.py
+++ b/troposphere/autoscaling.py
@@ -205,7 +205,7 @@ class AutoScalingGroup(AWSObject):
                     min_instances = rolling_update.properties.get(
                         "MinInstancesInService", "0")
                     is_min_no_check = isinstance(
-                        min_instances, (FindInMap, Ref)
+                        min_instances, (If, FindInMap, Ref)
                     )
                     is_max_no_check = isinstance(self.MaxSize,
                                                  (If, FindInMap, Ref))


### PR DESCRIPTION
Ignore If expression in validation of AutoScalingRollingUpdate min instances

Same thing as in https://github.com/cloudtools/troposphere/pull/446, but only for min instances instead of max instances.