### PR TITLE
Add missing SecretTargetAttachment TargetTypes

### DIFF
--- a/troposphere/secretsmanager.py
+++ b/troposphere/secretsmanager.py
@@ -7,7 +7,9 @@ from . import AWSObject, AWSProperty, Tags
 from .compat import policytypes
 from .validators import integer, boolean
 
-VALID_TARGET_TYPES = ('AWS::RDS::DBInstance', 'AWS::RDS::DBCluster')
+VALID_TARGET_TYPES = ('AWS::RDS::DBInstance', 'AWS::RDS::DBCluster',
+                      'AWS::Redshift::Cluster', 'AWS::DocDB::DBInstance',
+                      'AWS::DocDB::DBCluster')
 
 
 def validate_target_types(target_type):


### PR DESCRIPTION
CloudFormation supports more TargetTypes than currently present in the
VALID_TARGET_TYPES. This pull request adds the missing values.
List of valid TargetTypes is found at:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-secretsmanager-secrettargetattachment.html#cfn-secretsmanager-secrettargetattachment-targettype