### PR TITLE
fix: include valid postgres capacity configurations

### DIFF
--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -324,8 +324,14 @@ class TestRDSValidators(unittest.TestCase):
         rds.validate_backup_retention_period(10)
 
     def test_validate_capacity(self):
-        for e in rds.VALID_SCALING_CONFIGURATION_CAPACITIES:
+        for e in rds.VALID_MYSQL_SCALING_CONFIGURATION_CAPACITIES:
+            rds.validate_capacity(e)
+
+        for e in rds.VALID_POSTGRESL_SCALING_CONFIGURATION_CAPACITIES:
             rds.validate_capacity(e)
 
         with self.assertRaises(ValueError):
             rds.validate_capacity(3)
+
+        with self.assertRaises(ValueError):
+            rds.validate_capacity(100001)

--- a/troposphere/rds.py
+++ b/troposphere/rds.py
@@ -21,7 +21,10 @@ VALID_DB_ENGINE_MODES = ('provisioned', 'serverless', 'parallelquery',
                          'global', 'multimaster')
 VALID_LICENSE_MODELS = ('license-included', 'bring-your-own-license',
                         'general-public-license', 'postgresql-license')
-VALID_SCALING_CONFIGURATION_CAPACITIES = (1, 2, 4, 8, 16, 32, 64, 128, 256)
+VALID_MYSQL_SCALING_CONFIGURATION_CAPACITIES = (1, 2, 4, 8, 16, 32, 64, 128,
+                                                256)
+VALID_POSTGRESL_SCALING_CONFIGURATION_CAPACITIES = (2, 4, 8, 16, 32, 64, 192,
+                                                    384)
 
 
 def validate_iops(iops):
@@ -136,12 +139,14 @@ def validate_backup_retention_period(days):
 def validate_capacity(capacity):
     """Validate ScalingConfiguration capacity for serverless DBCluster"""
 
-    if capacity not in VALID_SCALING_CONFIGURATION_CAPACITIES:
+    if capacity not in VALID_POSTGRESL_SCALING_CONFIGURATION_CAPACITIES and \
+            capacity not in VALID_MYSQL_SCALING_CONFIGURATION_CAPACITIES:
         raise ValueError(
             "ScalingConfiguration capacity must be one of: {}".format(
                 ", ".join(map(
                     str,
-                    VALID_SCALING_CONFIGURATION_CAPACITIES
+                    VALID_MYSQL_SCALING_CONFIGURATION_CAPACITIES +
+                    VALID_POSTGRESL_SCALING_CONFIGURATION_CAPACITIES
                 ))
             )
         )


### PR DESCRIPTION
Fixes https://github.com/cloudtools/troposphere/issues/1600
We are using troposphere and stacker to spin up Aurora Serverless
clusters using Postgresql and received errors that our MaxCapacity
arguments to ScalingConfiguration were failing validation even though
AWS documentation showed them to be correct.

This adds the valid options for postgres as well as mysql