### PR TITLE
Solve problems with attributes in WebAcl and ByteMatchStatement

### DIFF
--- a/troposphere/wafv2.py
+++ b/troposphere/wafv2.py
@@ -175,7 +175,7 @@ class ByteMatchStatement(AWSProperty):
         'PositionalConstraint': (validate_positional_constraint, False),
         'SearchString': (basestring, False),
         'SearchStringBase64': (basestring, False),
-        'TextTransformations': (TextTransformations, False)
+        'TextTransformations': ([TextTransformation], True)
     }
 
 
@@ -403,7 +403,7 @@ class WebACL(AWSObject):
         'DefaultAction': (DefaultAction, False),
         'Description': (basestring, False),
         'Name': (basestring, True),
-        'Rules': (Rules, False),
+        'Rules': ([Rule], False),
         'Scope': (basestring, True),
         'Tags': (Tags, False),
         'VisibilityConfig': (VisibilityConfig, False)


### PR DESCRIPTION
I change this attributes for a direct use of a array of elements for solve errors in cloudformation. Now cloudformation says "Internal error" without this modifications. I think this problem is in other attributes, but I haven't tested ( With the bug of "internal error" is very difficult to debug ).