### PR TITLE
Fix several problems in wafv2

### DIFF
--- a/troposphere/wafv2.py
+++ b/troposphere/wafv2.py
@@ -90,31 +90,31 @@ class SingleQueryArgument(AWSProperty):
     }
 
 
-class Body(AWSObject):
+class Body(AWSProperty):
     props = {
 
     }
 
 
-class Method(AWSObject):
+class Method(AWSProperty):
     props = {
 
     }
 
 
-class AllQueryArguments(AWSObject):
+class AllQueryArguments(AWSProperty):
     props = {
 
     }
 
 
-class QueryString(AWSObject):
+class QueryString(AWSProperty):
     props = {
 
     }
 
 
-class UriPath(AWSObject):
+class UriPath(AWSProperty):
     props = {
 
     }
@@ -173,15 +173,9 @@ class ByteMatchStatement(AWSProperty):
     }
 
 
-class CountryCodes(AWSProperty):
-    props = {
-        'CountryCodes': ([basestring], False)
-    }
-
-
 class GeoMatchStatement(AWSProperty):
     props = {
-        'CountryCodes': (CountryCodes, False)
+        'CountryCodes': ([basestring], False)
     }
 
 
@@ -215,15 +209,9 @@ class StatementThree(AWSProperty):
     }
 
 
-class StatementThrees(AWSProperty):
-    props = {
-        'StatementThrees': ([StatementThree], False)
-    }
-
-
 class AndStatementTwo(AWSProperty):
     props = {
-        'Statements': (StatementThrees, False)
+        'Statements': ([StatementThree], False)
     }
 
 
@@ -235,7 +223,7 @@ class NotStatementTwo(AWSProperty):
 
 class OrStatementTwo(AWSProperty):
     props = {
-        'Statements': (StatementThrees, False)
+        'Statements': ([StatementThree], False)
     }
 
 
@@ -267,15 +255,9 @@ class StatementTwo(AWSProperty):
     }
 
 
-class StatementTwos(AWSProperty):
-    props = {
-        'StatementTwos': ([StatementTwo], False)
-    }
-
-
 class AndStatementOne(AWSProperty):
     props = {
-        'Statements': (StatementTwos, False)
+        'Statements': ([StatementTwo], False)
     }
 
 
@@ -287,7 +269,7 @@ class NotStatementOne(AWSProperty):
 
 class OrStatementOne(AWSProperty):
     props = {
-        'Statements': (StatementTwos, False)
+        'Statements': ([StatementTwo], False)
     }
 
 


### PR DESCRIPTION
- Several classes were subclasses of AWSObject when they should be  subclasses of AWSProperty.

- Several classes have arguments that are lists. These args were defined via intermediate classes that in turn defined the lists. This was incorrect. The classes should accept the lists directly.

  I fixed the list arguments for these classes:

    GeoMatchStatement
    AndStatementOne
    OrStatementOne
    AndStatementTwo
    OrStatementTwo

  I remove these unnecessary intermediate list classes:

    CountryCodes
    StatementTwos
    StatementThrees