### PR TITLE
IoT Analytics fixes and additions

### DIFF
--- a/examples/IoTAnalytics.py
+++ b/examples/IoTAnalytics.py
@@ -1,0 +1,126 @@
+from troposphere import Template
+from troposphere import Tags
+from troposphere.iotanalytics import (
+    Channel,
+    ChannelStorage,
+    CustomerManagedS3,
+    ServiceManagedS3,
+    RetentionPeriod,
+    Dataset,
+    Action,
+    DatasetContentDeliveryRule,
+    DatasetContentDeliveryRuleDestination,
+    S3DestinationConfiguration,
+    Trigger,
+    TriggeringDataset,
+    VersioningConfiguration,
+    Pipeline,
+    Activity,
+    ActivityChannel,
+    ActivityDatastore,
+    Datastore,
+    DatastoreStorage,
+)
+
+
+t = Template()
+
+channel = Channel(
+    'TestChannel',
+    ChannelName='testchannel',
+    ChannelStorage=ChannelStorage(
+        CustomerManagedS3=CustomerManagedS3(
+            Bucket='customerbucket',
+            KeyPrefix='bobdog',
+            RoleArn='arn',
+        )
+    ),
+    RetentionPeriod=RetentionPeriod(
+        NumberOfDays=10,
+    ),
+    Tags=Tags(
+        Manufacturer='AmazonWebServices'
+    ),
+)
+
+pipeline = Pipeline(
+    'TestPipeline',
+    PipelineActivities=[
+        Activity(
+            Channel=ActivityChannel(
+                ChannelName='ChannelName',
+                Name='testchannel',
+                Next='DatastoreActivity',
+            ),
+        ),
+        Activity(
+            Datastore=ActivityDatastore(
+                Name='DatastoreActivity',
+                DatastoreName='testdatastore',
+            ),
+        ),
+    ],
+    PipelineName='testpipeline',
+    Tags=Tags(
+        Manufacturer='AmazonWebServices'
+    ),
+)
+
+datastore = Datastore(
+    'TestDatastore',
+    DatastoreName='testdatastore',
+    DatastoreStorage=DatastoreStorage(
+        ServiceManagedS3=ServiceManagedS3(),
+    ),
+    RetentionPeriod=RetentionPeriod(
+        NumberOfDays=365,
+    ),
+    Tags=Tags(
+        Manufacturer='AmazonWebServices'
+    ),
+)
+
+dataset = Dataset(
+    'TestDataset',
+    Actions=[
+        Action(
+            ActionName='actionname',
+        ),
+    ],
+    ContentDeliveryRules=[
+        DatasetContentDeliveryRule(
+            Destination=DatasetContentDeliveryRuleDestination(
+                S3DestinationConfiguration=S3DestinationConfiguration(
+                    Bucket='testbucket',
+                    Key='testkey',
+                    RoleArn='arn',
+                ),
+            ),
+            EntryName='entryname',
+        )
+    ],
+    DatasetName='testdataset',
+    RetentionPeriod=RetentionPeriod(
+        Unlimited=True,
+    ),
+    Tags=Tags(
+        Manufacturer='AmazonWebServices'
+    ),
+    Triggers=[
+        Trigger(
+            TriggeringDataset=TriggeringDataset(
+                DatasetName='testdataset'
+            ),
+        ),
+    ],
+    VersioningConfiguration=VersioningConfiguration(
+        Unlimited=True,
+    ),
+)
+
+t.add_resource(channel)
+t.add_resource(pipeline)
+t.add_resource(datastore)
+t.add_resource(dataset)
+
+print(t.to_json())

--- a/examples/IoTSample.py
+++ b/examples/IoTSample.py
@@ -9,6 +9,7 @@ from troposphere.iot import (
     TopicRulePayload,
     Action,
     LambdaAction,
+    IotAnalyticsAction,
 )
 
 
@@ -59,6 +60,12 @@ topic_rule = TopicRule(
             Action(
                 Lambda=LambdaAction(
                     FunctionArn='arn',
+                ),
+            ),
+            Action(
+                IotAnalytics=IotAnalyticsAction(
+                    ChannelName='mychannel',
+                    RoleArn='arn',
                 ),
             ),
         ],

--- a/tests/examples_output/IoTAnalytics.template
+++ b/tests/examples_output/IoTAnalytics.template
@@ -1,0 +1,113 @@
+{
+    "Resources": {
+        "TestChannel": {
+            "Properties": {
+                "ChannelName": "testchannel",
+                "ChannelStorage": {
+                    "CustomerManagedS3": {
+                        "Bucket": "customerbucket",
+                        "KeyPrefix": "bobdog",
+                        "RoleArn": "arn"
+                    }
+                },
+                "RetentionPeriod": {
+                    "NumberOfDays": 10
+                },
+                "Tags": [
+                    {
+                        "Key": "Manufacturer",
+                        "Value": "AmazonWebServices"
+                    }
+                ]
+            },
+            "Type": "AWS::IoTAnalytics::Channel"
+        },
+        "TestDataset": {
+            "Properties": {
+                "Actions": [
+                    {
+                        "ActionName": "actionname"
+                    }
+                ],
+                "ContentDeliveryRules": [
+                    {
+                        "Destination": {
+                            "S3DestinationConfiguration": {
+                                "Bucket": "testbucket",
+                                "Key": "testkey",
+                                "RoleArn": "arn"
+                            }
+                        },
+                        "EntryName": "entryname"
+                    }
+                ],
+                "DatasetName": "testdataset",
+                "RetentionPeriod": {
+                    "Unlimited": "true"
+                },
+                "Tags": [
+                    {
+                        "Key": "Manufacturer",
+                        "Value": "AmazonWebServices"
+                    }
+                ],
+                "Triggers": [
+                    {
+                        "TriggeringDataset": {
+                            "DatasetName": "testdataset"
+                        }
+                    }
+                ],
+                "VersioningConfiguration": {
+                    "Unlimited": "true"
+                }
+            },
+            "Type": "AWS::IoTAnalytics::Dataset"
+        },
+        "TestDatastore": {
+            "Properties": {
+                "DatastoreName": "testdatastore",
+                "DatastoreStorage": {
+                    "ServiceManagedS3": {}
+                },
+                "RetentionPeriod": {
+                    "NumberOfDays": 365
+                },
+                "Tags": [
+                    {
+                        "Key": "Manufacturer",
+                        "Value": "AmazonWebServices"
+                    }
+                ]
+            },
+            "Type": "AWS::IoTAnalytics::Datastore"
+        },
+        "TestPipeline": {
+            "Properties": {
+                "PipelineActivities": [
+                    {
+                        "Channel": {
+                            "ChannelName": "ChannelName",
+                            "Name": "testchannel",
+                            "Next": "DatastoreActivity"
+                        }
+                    },
+                    {
+                        "Datastore": {
+                            "DatastoreName": "testdatastore",
+                            "Name": "DatastoreActivity"
+                        }
+                    }
+                ],
+                "PipelineName": "testpipeline",
+                "Tags": [
+                    {
+                        "Key": "Manufacturer",
+                        "Value": "AmazonWebServices"
+                    }
+                ]
+            },
+            "Type": "AWS::IoTAnalytics::Pipeline"
+        }
+    }
+}

--- a/tests/examples_output/IoTSample.template
+++ b/tests/examples_output/IoTSample.template
@@ -51,9 +51,15 @@
                             "Lambda": {
                                 "FunctionArn": "arn"
                             }
+                        },
+                        {
+                            "IotAnalytics": {
+                                "ChannelName": "mychannel",
+                                "RoleArn": "arn"
+                            }
                         }
                     ],
-                    "RuleDisabled": true,
+                    "RuleDisabled": "true",
                     "Sql": "SELECT temp FROM SomeTopic WHERE temp > 60"
                 }
             },

--- a/troposphere/iot.py
+++ b/troposphere/iot.py
@@ -68,6 +68,13 @@ class FirehoseAction(AWSProperty):
     }
 
 
+class IotAnalyticsAction(AWSProperty):
+    props = {
+        'ChannelName': (basestring, True),
+        'RoleArn': (basestring, True),
+    }
+
+
 class KinesisAction(AWSProperty):
     props = {
         'PartitionKey': (basestring, False),
@@ -113,6 +120,14 @@ class SqsAction(AWSProperty):
     }
 
 
+class StepFunctionsAction(AWSProperty):
+    props = {
+        'ExecutionNamePrefix': (basestring, False),
+        'RoleArn': (basestring, True),
+        'StateMachineName': (basestring, True),
+    }
+
+
 class Action(AWSProperty):
     props = {
         'CloudwatchAlarm': (CloudwatchAlarmAction, False),
@@ -121,12 +136,14 @@ class Action(AWSProperty):
         'DynamoDBv2': (DynamoDBv2Action, False),
         'Elasticsearch': (ElasticsearchAction, False),
         'Firehose': (FirehoseAction, False),
+        'IotAnalytics': (IotAnalyticsAction, False),
         'Kinesis': (KinesisAction, False),
         'Lambda': (LambdaAction, False),
         'Republish': (RepublishAction, False),
         'S3': (S3Action, False),
         'Sns': (SnsAction, False),
         'Sqs': (SqsAction, False),
+        'StepFunctions': (StepFunctionsAction, False)
     }
 
 

--- a/troposphere/iotanalytics.py
+++ b/troposphere/iotanalytics.py
@@ -4,7 +4,7 @@
 # See LICENSE file for full license.
 
 from . import AWSObject, AWSProperty, Tags
-from .validators import boolean, integer, json_checker, double
+from .validators import boolean, integer, double
 
 
 class RetentionPeriod(AWSProperty):
@@ -47,7 +47,7 @@ class Channel(AWSObject):
 
 class AddAttributes(AWSProperty):
     props = {
-        'Attributes': (json_checker, False),
+        'Attributes': (dict, False),
         'Name': (basestring, False),
         'Next': (basestring, False),
     }

--- a/troposphere/iotanalytics.py
+++ b/troposphere/iotanalytics.py
@@ -14,11 +14,32 @@ class RetentionPeriod(AWSProperty):
     }
 
 
+class CustomerManagedS3(AWSProperty):
+    props = {
+        'Bucket': (basestring, True),
+        'KeyPrefix': (basestring, False),
+        'RoleArn': (basestring, True),
+    }
+
+
+class ServiceManagedS3(AWSProperty):
+    props = {
+    }
+
+
+class ChannelStorage(AWSProperty):
+    props = {
+        'CustomerManagedS3': (CustomerManagedS3, False),
+        'ServiceManagedS3': (ServiceManagedS3, False),
+    }
+
+
 class Channel(AWSObject):
     resource_type = "AWS::IoTAnalytics::Channel"
 
     props = {
         'ChannelName': (basestring, False),
+        'ChannelStorage': (ChannelStorage, False),
         'RetentionPeriod': (RetentionPeriod, False),
         'Tags': ((Tags, list), False),
     }
@@ -40,7 +61,7 @@ class ActivityChannel(AWSProperty):
     }
 
 
-class Datastore(AWSProperty):
+class ActivityDatastore(AWSProperty):
     props = {
         'DatastoreName': (basestring, False),
         'Name': (basestring, False),
@@ -113,7 +134,7 @@ class Activity(AWSProperty):
     props = {
         'AddAttributes': (AddAttributes, False),
         'Channel': (ActivityChannel, False),
-        'Datastore': (Datastore, False),
+        'Datastore': (ActivityDatastore, False),
         'DeviceRegistryEnrich': (DeviceRegistryEnrich, False),
         'DeviceShadowEnrich': (DeviceShadowEnrich, False),
         'Filter': (Filter, False),
@@ -130,23 +151,6 @@ class Pipeline(AWSObject):
     props = {
         'PipelineActivities': ([Activity], True),
         'PipelineName': (basestring, False),
-        'Tags': ((Tags, list), False),
-    }
-
-
-class RetentionPeriod(AWSProperty):
-    props = {
-        'NumberOfDays': (integer, False),
-        'Unlimited': (boolean, False),
-    }
-
-
-class Datastore(AWSObject):
-    resource_type = "AWS::IoTAnalytics::Datastore"
-
-    props = {
-        'DatastoreName': (basestring, False),
-        'RetentionPeriod': (RetentionPeriod, False),
         'Tags': ((Tags, list), False),
     }
 
@@ -292,4 +296,22 @@ class Dataset(AWSObject):
         'Tags': (Tags, False),
         'Triggers': ([Trigger], False),
         'VersioningConfiguration': (VersioningConfiguration, False),
+    }
+
+
+class DatastoreStorage(AWSProperty):
+    props = {
+        'CustomerManagedS3': (CustomerManagedS3, False),
+        'ServiceManagedS3': (ServiceManagedS3, False),
+    }
+
+
+class Datastore(AWSObject):
+    resource_type = "AWS::IoTAnalytics::Datastore"
+
+    props = {
+        'DatastoreName': (basestring, False),
+        'DatastoreStorage': (DatastoreStorage, False),
+        'RetentionPeriod': (RetentionPeriod, False),
+        'Tags': ((Tags, list), False),
     }


### PR DESCRIPTION
A number of fixes for IoT Analytics: Datastore AWSProperty name duplicated/shadowed the Datastore AWSObject name; RetentionPeriod class was listed twice, added ChannelStorage and DatastoreStorage AWSProperties.

Adds an example IoTAnalytics.py template.

I think this brings IoTAnalytics up to sync with CloudFormation - I've started using it to make some IoTAnalytics resources.

Also added IotAnalytics and StepFunctions to iot.Action property for iot.py