### PR TITLE
add secrets manager type to codebuild environment variable types

### DIFF
--- a/troposphere/codebuild.py
+++ b/troposphere/codebuild.py
@@ -111,6 +111,7 @@ class EnvironmentVariable(AWSProperty):
             valid_types = [
                 'PARAMETER_STORE',
                 'PLAINTEXT',
+                'SECRETS_MANAGER'
             ]
             env_type = self.properties.get('Type')
             if env_type not in valid_types:


### PR DESCRIPTION
AWS CodeBuild added support for the SECRETS_MANAGER environment variable type. troposphere should be able to support it as well.