### PR TITLE
AWS::EC2::SecurityGroupIngress.SourcePrefixListId

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -534,6 +534,7 @@ class SecurityGroupIngress(AWSObject):
         'GroupName': (basestring, False),
         'GroupId': (basestring, False),
         'IpProtocol': (basestring, True),
+        'SourcePrefixListId': (basestring, False),
         'SourceSecurityGroupName': (basestring, False),
         'SourceSecurityGroupId': (basestring, False),
         'SourceSecurityGroupOwnerId': (basestring, False),


### PR DESCRIPTION
fixes https://github.com/cloudtools/troposphere/issues/1621