### PR TITLE
Adding AWS::CodeGuruProfiler::ProfilingGroup resource, per March 19, 2020 update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -170,6 +170,7 @@ Currently supported AWS resource types
 - `AWS::CodeBuild`_
 - `AWS::CodeCommit`_
 - `AWS::CodeDeploy`_
+_ `AWS::CodeGuruProfiler`_
 - `AWS::CodePipeline`_
 - `AWS::CodeStar`_
 - `AWS::CodeStarNotifications`_

--- a/troposphere/codeguruprofiler.py
+++ b/troposphere/codeguruprofiler.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2020, Mark Peek <mark@peek.org>
+# All rights reserved.
+#
+# See LICENSE file for full license.
+
+from . import AWSObject
+
+
+class ProfilingGroup(AWSObject):
+    resource_type = "AWS::CodeGuruProfiler::ProfilingGroup"
+
+    props = {
+        'ProfilingGroupName': (basestring, True),
+    }


### PR DESCRIPTION
implements #1628 