### PR TITLE
Adding AWS::EC2::Volume props, per March 26, 2020 update

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -629,6 +629,7 @@ class Volume(AWSObject):
         'Encrypted': (boolean, False),
         'Iops': (positive_integer, False),
         'KmsKeyId': (basestring, False),
+        'MultiAttachEnabled': (boolean, False),
         'Size': (positive_integer, False),
         'SnapshotId': (basestring, False),
         'Tags': ((Tags, list), False),


### PR DESCRIPTION
implements #1635 