### PR TITLE
Adding AWS::ServiceCatalog::LaunchRoleConstraint props, per April 2, 2020 update

### DIFF
--- a/troposphere/servicecatalog.py
+++ b/troposphere/servicecatalog.py
@@ -98,6 +98,7 @@ class LaunchRoleConstraint(AWSObject):
     props = {
         'AcceptLanguage': (basestring, False),
         'Description': (basestring, False),
+        'LocalRoleName': (basestring, False),
         'PortfolioId': (basestring, True),
         'ProductId': (basestring, True),
         'RoleArn': (basestring, True),


### PR DESCRIPTION
implements #1638 