### PR TITLE
Fix FailOnWarnings datatype

### DIFF
--- a/troposphere/apigateway.py
+++ b/troposphere/apigateway.py
@@ -352,7 +352,7 @@ class RestApi(AWSObject):
         "CloneFrom": (basestring, False),
         "Description": (basestring, False),
         "EndpointConfiguration": (EndpointConfiguration, False),
-        "FailOnWarnings": (basestring, False),
+        "FailOnWarnings": (bool, False),
         "MinimumCompressionSize": (positive_integer, False),
         "Name": (basestring, False),
         "Parameters": (dict, False),


### PR DESCRIPTION
Change the datatype of ApiGateway::RestApi FailOnWarnings property from string to bool

implements #1655 