### PR TITLE
Fixes to acmpca

### DIFF
--- a/troposphere/acmpca.py
+++ b/troposphere/acmpca.py
@@ -55,7 +55,7 @@ class Validity(AWSProperty):
     }
 
 
-class Certificate(AWSProperty):
+class Certificate(AWSObject):
     resource_type = "AWS::ACMPCA::Certificate"
 
     props = {

--- a/troposphere/acmpca.py
+++ b/troposphere/acmpca.py
@@ -93,7 +93,7 @@ class RevocationConfiguration(AWSProperty):
     }
 
 
-class Subject(AWSObject):
+class Subject(AWSProperty):
     props = {
         'CommonName': (basestring, False),
         'Country': (basestring, False),


### PR DESCRIPTION
Subject should be AWSProperty not AWSObject

[aws-resource-acmpca-certificateauthority](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-acmpca-certificateauthority.html)

Certificate should be AWSObject not AWSProperty

[aws-resource-acmpca-certificate](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-acmpca-certificate.html )
