### PR TITLE
Adding new AWS::CE::CostCategory resource, per April 23, 2020 update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -161,6 +161,7 @@ Currently supported AWS resource types
 - `AWS::AutoScalingPlans`_
 - `AWS::Batch`_
 - `AWS::Budgets`_
+_ `AWS::CE`_
 - `AWS::CertificateManager`_
 - `AWS::Cloud9`_
 - `AWS::CloudFormation`_

--- a/troposphere/ce.py
+++ b/troposphere/ce.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2020, Mark Peek <mark@peek.org>
+# All rights reserved.
+#
+# See LICENSE file for full license.
+
+from . import AWSObject
+
+
+class CostCategory(AWSObject):
+    resource_type = "AWS::CE::CostCategory"
+
+    props = {
+        'Name': (basestring, True),
+        'Rules': (basestring, True),
+        'RuleVersion': (basestring, True),
+    }


### PR DESCRIPTION
implements #1662 