### PR TITLE
RegularExpressionList fix

### DIFF
--- a/troposphere/wafv2.py
+++ b/troposphere/wafv2.py
@@ -393,19 +393,13 @@ class IPSet(AWSObject):
     }
 
 
-class Regex(AWSProperty):
-    props = {
-        'RegexString': (basestring, False)
-    }
-
-
 class RegexPatternSet(AWSObject):
     resource_type = "AWS::WAFv2::RegexPatternSet"
 
     props = {
         'Description': (basestring, False),
         'Name': (basestring, True),
-        'RegularExpressionList': ([Regex], True),
+        'RegularExpressionList': ([basestring], True),
         'Scope': (basestring, True),
         'Tags': (Tags, False),
     }


### PR DESCRIPTION
Potential fix for issue https://github.com/cloudtools/troposphere/issues/1677

Change RegularExpressionList to take a list of Regex and set required True as per the documentation - https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-regexpatternset.html#cfn-wafv2-regexpatternset-regularexpressionlist