### PR TITLE
 Add support for ARM and GPU containers for CodeBuild

### DIFF
--- a/tests/test_codebuild.py
+++ b/tests/test_codebuild.py
@@ -20,6 +20,22 @@ class TestCodeBuild(unittest.TestCase):
         )
         environment.to_dict()
 
+    def test_arm_environment(self):
+        environment = codebuild.Environment(
+            ComputeType='BUILD_GENERAL1_LARGE',
+            Image='aws/codebuild/amazonlinux2-aarch64-standard:1.0',
+            Type='ARM_CONTAINER'
+        )
+        environment.to_dict()
+
+    def test_linux_gpu_environment(self):
+        environment = codebuild.Environment(
+            ComputeType='BUILD_GENERAL1_LARGE',
+            Image='aws/codebuild/standard:4.0',
+            Type='LINUX_GPU_CONTAINER'
+        )
+        environment.to_dict()
+
     def test_source_codepipeline(self):
         source = codebuild.Source(
             Type='CODEPIPELINE'

--- a/troposphere/codebuild.py
+++ b/troposphere/codebuild.py
@@ -141,10 +141,10 @@ class Environment(AWSProperty):
 
     def validate(self):
         valid_types = [
-            'LINUX_CONTAINER',
-            'WINDOWS_CONTAINER',
             'ARM_CONTAINER',
+            'LINUX_CONTAINER',
             'LINUX_GPU_CONTAINER',
+            'WINDOWS_CONTAINER',
         ]
         env_type = self.properties.get('Type')
         if env_type not in valid_types:

--- a/troposphere/codebuild.py
+++ b/troposphere/codebuild.py
@@ -143,6 +143,8 @@ class Environment(AWSProperty):
         valid_types = [
             'LINUX_CONTAINER',
             'WINDOWS_CONTAINER',
+            'ARM_CONTAINER',
+            'LINUX_GPU_CONTAINER',
         ]
         env_type = self.properties.get('Type')
         if env_type not in valid_types:


### PR DESCRIPTION
This adds ARM_CONTAINER and  LINUX_GPU_CONTAINER to the valid list of environment types for a CodeBuild Environment.