### PR TITLE
add macro

### DIFF
--- a/macro/README.md
+++ b/macro/README.md
@@ -1,0 +1,75 @@
+# Troposphere Macro
+
+The `Troposphere` macro adds the ability to create CloudFormation resources from troposphere stacks.
+
+# How to install and use the Macro in your AWS account
+
+## Deploying
+
+1. You will need an S3 bucket to store the CloudFormation artifacts:
+    * If you don't have one already, create one with `aws s3 mb s3://<bucket name>`
+
+2. Install all python requirements
+
+    ```shell
+    pip install -r source/requirements.txt -t source
+    ```
+
+3. Package the CloudFormation template. The provided template uses [the AWS Serverless Application Model](https://aws.amazon.com/about-aws/whats-new/2016/11/introducing-the-aws-serverless-application-model/) so must be transformed before you can deploy it.
+
+    ```shell
+    aws cloudformation package \
+        --template-file template.yaml \
+        --s3-bucket <your bucket name here> \
+        --output-template-file template.output
+    ```
+
+4. Deploy the packaged CloudFormation template to a CloudFormation stack:
+
+    ```shell
+    aws cloudformation deploy \
+        --stack-name troposphere-macro \
+        --template-file template.output \
+        --capabilities CAPABILITY_IAM
+    ```
+
+5. To test out the macro's capabilities, try launching the provided example template:
+
+    ```shell
+    aws cloudformation deploy \
+        --stack-name template-macro-example \
+        --template-file example.py
+    ```
+
+## Usate
+ 
+Just add your resources to macro_template object, the template object is created by macro itself.
+You can provide your troposphere code in Troposphere tag.
+
+```
+Transform: [Troposhere]
+Description: Example Macro Troposhere.
+
+Parameters:
+  InstanceName:
+    Type: String
+    Default: "MyInstance"
+  ImageId:
+    Type: String
+    Default: "ami-951945d0"
+  InstanceType:
+    Type: String
+    Default: "t1.micro"
+
+Troposhere: |
+  from troposphere import Ref
+  import troposphere.ec2 as ec2
+
+  instance = ec2.Instance('MyInstance')
+
+  instance.ImageId = Ref('ImageId')
+  instance.InstanceType = Ref('InstanceType')
+  instance.Tags = ec2.Tags(Name = Ref('InstanceName'))
+
+  macro_template.add_resource(instance)
+```

--- a/macro/example.py
+++ b/macro/example.py
@@ -1,0 +1,25 @@
+Transform: [Troposhere]
+Description: Example Macro Troposhere.
+
+Parameters:
+  InstanceName:
+    Type: String
+    Default: "MyInstance"
+  ImageId:
+    Type: String
+    Default: "ami-eb0c7791"
+  InstanceType:
+    Type: String
+    Default: "t1.micro"
+
+Troposhere: |
+  from troposphere import Ref
+  import troposphere.ec2 as ec2
+
+  instance = ec2.Instance('MyInstance')
+
+  instance.ImageId = Ref('ImageId')
+  instance.InstanceType = Ref('InstanceType')
+  instance.Tags = ec2.Tags(Name = Ref('InstanceName'))
+
+  macro_template.add_resource(instance)

--- a/macro/source/macro.py
+++ b/macro/source/macro.py
@@ -1,0 +1,29 @@
+import sys, os, io, traceback
+from troposphere.template_generator import TemplateGenerator
+
+def handle_template(template):
+    troposphere_code = template["Troposhere"]
+    del template["Troposhere"]
+
+    macro_template = TemplateGenerator(template)
+    exec(troposphere_code)
+
+    return macro_template.to_json()
+
+def handler(event, context):
+    request_id = event['requestId']
+    parameters = event['templateParameterValues']
+
+    macro_response = {
+        'status': 'success',
+        'requestId': request_id
+    }
+
+    try:
+        macro_response['fragment'] = handle_template(event['fragment'])
+    except Exception as e:
+        traceback.print_exc()
+        macro_response['status'] = 'failure'
+        macro_response['errorMessage'] = str(e)
+
+    return macro_response

--- a/macro/source/requirements.txt
+++ b/macro/source/requirements.txt
@@ -1,0 +1,1 @@
+troposphere[policy]

--- a/macro/template.yaml
+++ b/macro/template.yaml
@@ -1,0 +1,40 @@
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  TransformExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: 
+              - lambda.amazonaws.com
+            Action: 
+            - 'sts:AssumeRole'
+      Path: /
+      Policies:
+        - PolicyName: root
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: 
+                - 'logs:*'
+                Resource: 'arn:aws:logs:*:*:*'
+
+  MacroFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Runtime: python3.6
+      CodeUri: source/
+      Handler: macro.handler
+      Role: !GetAtt TransformExecutionRole.Arn
+      Timeout: 300
+
+  Macro:
+    Type: AWS::CloudFormation::Macro
+    Properties:
+      Name: Troposhere
+      FunctionName: !GetAtt MacroFunction.Arn


### PR DESCRIPTION
Macro adds the possibility to directly create a Cloudformation stack from Troposphere Code.

Just add your resources to macro_template object, the template object is created by macro itself.
You can provide your troposphere code in Troposphere tag. More info in README.md