### PR TITLE
Updating AWS::StepFunctions::StateMachine props, per May 21, 2020 update

### DIFF
--- a/troposphere/stepfunctions.py
+++ b/troposphere/stepfunctions.py
@@ -42,11 +42,27 @@ class LoggingConfiguration(AWSProperty):
     }
 
 
+class S3Location(AWSProperty):
+    props = {
+        'Bucket': (basestring, True),
+        'Key': (basestring, True),
+        'Version': (basestring, True)
+    }
+
+
+class DefinitionSubstitutions(AWSProperty):
+    props = {
+
+    }
+
+
 class StateMachine(AWSObject):
     resource_type = "AWS::StepFunctions::StateMachine"
 
     props = {
+        'DefinitionS3Location': (S3Location, False),
         'DefinitionString': (basestring, True),
+        'DefinitionSubstitutions': (DefinitionSubstitutions, False),
         'LoggingConfiguration': (LoggingConfiguration, False),
         'RoleArn': (basestring, True),
         'StateMachineName': (basestring, False),


### PR DESCRIPTION
note that https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-statemachine-definitionsubstitutions.html is currently empty