### PR TITLE
Fix waf excluded rules

### DIFF
--- a/troposphere/wafv2.py
+++ b/troposphere/wafv2.py
@@ -58,16 +58,10 @@ class ExcludedRule(AWSProperty):
     }
 
 
-class ExcludedRules(AWSProperty):
-    props = {
-        'ExcludedRules': ([ExcludedRule], False)
-    }
-
-
 class RuleGroupReferenceStatement(AWSProperty):
     props = {
         'Arn': (basestring, False),
-        'ExcludedRules': (ExcludedRules, False)
+        'ExcludedRules': ([ExcludedRule], False)
     }
 
 
@@ -187,7 +181,7 @@ class IPSetReferenceStatement(AWSProperty):
 
 class ManagedRuleGroupStatement(AWSProperty):
     props = {
-        'ExcludedRules': (ExcludedRules, False),
+        'ExcludedRules': ([ExcludedRule], False)
         'Name': (basestring, False),
         'VendorName': (basestring, False),
     }

--- a/troposphere/wafv2.py
+++ b/troposphere/wafv2.py
@@ -181,7 +181,7 @@ class IPSetReferenceStatement(AWSProperty):
 
 class ManagedRuleGroupStatement(AWSProperty):
     props = {
-        'ExcludedRules': ([ExcludedRule], False)
+        'ExcludedRules': ([ExcludedRule], False),
         'Name': (basestring, False),
         'VendorName': (basestring, False),
     }


### PR DESCRIPTION
Currently, the wafv2 module defines `ExcludedRule` and wrapper object `ExcludedRules`:
```python
ManagedRuleGroupStatement(
    ExcludedRules=ExcludedRules(
        ExcludedRules=[ExcludedRule(), ExcludedRule()]
    )
)
```
This outputs something like:
```json
"ManagedRuleGroupStatement": {
    "ExcludedRules": {
        "ExcludedRules": 
            [
                {
                    "Name": "SizeRestrictions_BODY"
                }
            ]
    },
    "Name": "AWSManagedRulesCommonRuleSet",
    "VendorName": "AWS"
}

```

However, this results in a "Internal Failure" error in CloudFormation:


Correct CFT is something like this, without the double-wrapped `ExcludedRules`.
```json
"ManagedRuleGroupStatement": {
    "ExcludedRules": [
        {
            "Name": "SizeRestrictions_BODY"
        }
    ],
    "Name": "AWSManagedRulesCommonRuleSet",
    "VendorName": "AWS"
}
```

Proposed PR fixes this syntax.