### PR TITLE
Convert stepfunctions.DefinitionSubstitutions to dict

### DIFF
--- a/troposphere/stepfunctions.py
+++ b/troposphere/stepfunctions.py
@@ -50,19 +50,13 @@ class S3Location(AWSProperty):
     }
 
 
-class DefinitionSubstitutions(AWSProperty):
-    props = {
-
-    }
-
-
 class StateMachine(AWSObject):
     resource_type = "AWS::StepFunctions::StateMachine"
 
     props = {
         'DefinitionS3Location': (S3Location, False),
         'DefinitionString': (basestring, True),
-        'DefinitionSubstitutions': (DefinitionSubstitutions, False),
+        'DefinitionSubstitutions': (dict, False),
         'LoggingConfiguration': (LoggingConfiguration, False),
         'RoleArn': (basestring, True),
         'StateMachineName': (basestring, False),


### PR DESCRIPTION
DefinitionSubstitutions is declared in the documentation for AWS::StepFunctions::StateMachine as a map (string to string).

Tested to work with entries such as

```
stepfunctions.StateMachine(
            "ExampleStepFunction",
            DefinitionString=json.dumps({
                "Comment": "Ohayo gozaimasu",
                "StartAt": "Begin",
                "States": {
                    "Begin": {
                        "Type": "Task",
                        "Resource": "${arn_1}",
                    },
                },
            }),
            DefinitionSubstitutions={
                "arn1": "arn...",
            },
            RoleArn=...
)
```