### PR TITLE
Added capacity providers for ECS Cluster

### DIFF
--- a/troposphere/ecs.py
+++ b/troposphere/ecs.py
@@ -1,14 +1,59 @@
 from . import AWSObject, AWSProperty, Tags
 from .validators import (
-    boolean, double, integer, network_port, positive_integer, ecs_proxy_type
+    boolean, double, integer, network_port, positive_integer, integer_range, ecs_proxy_type
 )
-
 
 LAUNCH_TYPE_EC2 = 'EC2'
 LAUNCH_TYPE_FARGATE = 'FARGATE'
 
 SCHEDULING_STRATEGY_REPLICA = 'REPLICA'
 SCHEDULING_STRATEGY_DAEMON = 'DAEMON'
+
+
+class ManagedScaling(AWSProperty):
+    """
+    Class for ManagedScaling for AutoScalingGroupProvider
+    """
+    props = {
+        "MaximumScalingStepSize": (integer_range(1, 10000), False),
+        "MinimumScalingStepSize": (integer_range(1, 10000), False),
+        "Status": (basestring, False),
+        "TargetCapacity": (integer_range(1, 100), False)
+    }
+
+
+class AutoScalingGroupProvider(AWSProperty):
+    """
+    Class for property AutoScalingGroupProvider in AWS::ECS::CpacityProvider
+    """
+    props = {
+        'AutoScalingGroupArn': (basestring, True),
+        'ManagedScaling': (ManagedScaling, False),
+        'ManagedTerminationProtection': (basestring, False)
+    }
+
+
+class CapacityProvider(AWSObject):
+    """
+    Class for AWS::ECS::CpacityProvider
+    """
+    resource_type = "AWS::ECS::CapacityProvider"
+    props = {
+        'Name': (basestring, False),
+        'Tags': (Tags, False),
+        'AutoScalingGroupProvider': (AutoScalingGroupProvider, True)
+    }
+
+
+class CapacityProviderStrategyItem(AWSProperty):
+    """
+    Class for the AWS::ECS::Cluster-CapacityProviderStrategyItem
+    """
+    props = {
+        'Base': (integer, False),
+        'Weight': (integer, False),
+        'CapacityProvider': (basestring, False)
+    }
 
 
 class ClusterSetting(AWSProperty):
@@ -24,6 +69,9 @@ class Cluster(AWSObject):
     props = {
         'ClusterName': (basestring, False),
         'ClusterSettings': ([ClusterSetting], False),
+        'CapacityProviders': ([basestring], False),
+        'DefaultCapacityProviderStrategy': (
+        [CapacityProviderStrategyItem], False),
         'Tags': (Tags, False),
     }
 


### PR DESCRIPTION
Tested and functional with following code sample:

```
    Cluster(
        ROOT_CLUSTER_NAME,
        template=template,
        ClusterName=If(CLUSTER_NAME_CON_T, Ref(AWS_STACK_NAME), Ref(CLUSTER_NAME_T)),
        DependsOn=depends_on,
        CapacityProviders=["FARGATE", "FARGATE_SPOT"],
        DefaultCapacityProviderStrategy=[
            CapacityProviderStrategyItem(
                Weight=2,
                CapacityProvider="FARGATE_SPOT"
            ),
            CapacityProviderStrategyItem(
                Weight=1,
                CapacityProvider="FARGATE"
            )
        ]
    )
```

Generated following template (snippet):

```

Resources:
  EcsCluster:
    DependsOn:
      - vpc
    Properties:
      CapacityProviders:
        - FARGATE
        - FARGATE_SPOT
      ClusterName: !If
        - SetClusterNameFromRootStack
        - !Ref 'AWS::StackName'
        - !Ref 'EcsClusterName'
      DefaultCapacityProviderStrategy:
        - CapacityProvider: FARGATE_SPOT
          Weight: 2
        - CapacityProvider: FARGATE
          Weight: 1
    Type: AWS::ECS::Cluster
```
Created the following cluster with settings:

![image](https://user-images.githubusercontent.com/1236150/85201083-70a75400-b2f4-11ea-8f83-508e0cd88522.png)
