### PR TITLE
Add required TargetGroupName to AWS::RDS::DBProxyTargetGroup

### DIFF
--- a/troposphere/rds.py
+++ b/troposphere/rds.py
@@ -356,6 +356,7 @@ class DBProxyTargetGroup(AWSObject):
         'DBClusterIdentifiers': ([basestring], False),
         'DBInstanceIdentifiers': ([basestring], False),
         'DBProxyName': (basestring, True),
+        'TargetGroupName': (basestring, True),
     }
 
 


### PR DESCRIPTION
Cloudformation seems to throw an error when a DBProxyTargetGroup lacks
the TargetGroupName property.  [The Cloudformation documentation for the
DBProxyTargetGroup resource](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbproxytargetgroup.html) has no reference to this property, but the
[examples on the page for DBProxy](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbproxy.html#aws-resource-rds-dbproxy--examples) shows the TargetGroupName being set to
"default" in the DBProxyTargetGroup resource.