### PR TITLE
SageMaker: Mark tags props as optional, per AWS documentation.

### DIFF
--- a/troposphere/sagemaker.py
+++ b/troposphere/sagemaker.py
@@ -30,7 +30,7 @@ class Endpoint(AWSObject):
     props = {
         'EndpointName': (basestring, False),
         'EndpointConfigName': (basestring, True),
-        'Tags': (Tags, True)
+        'Tags': (Tags, False)
     }
 
 
@@ -51,7 +51,7 @@ class EndpointConfig(AWSObject):
         'EndpointConfigName': (basestring, False),
         'ProductionVariants': ([ProductionVariant], True),
         'KmsKeyId': (basestring, False),
-        'Tags': (Tags, True)
+        'Tags': (Tags, False)
     }
 
 


### PR DESCRIPTION
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-endpointconfig.html
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-endpoint.html

In the CloudFormation documentation, the `Tags` property is listed as optional for SageMaker's `Endpoint` and `EndpointConfig`. This PR changes Troposphere to reflect that.