### PR TITLE
Allow List<Number> param to have MinValue, MaxValue

### DIFF
--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -905,7 +905,8 @@ class Parameter(AWSDeclaration):
                 if p in self.properties:
                     raise ValueError("%s can only be used with parameters of "
                                      "the String type." % p)
-        if self.properties['Type'] != 'Number':
+        if (self.properties['Type'] != 'Number' and
+            self.properties['Type'] != 'List<Number>'):
             for p in self.NUMBER_PROPERTIES:
                 if p in self.properties:
                     raise ValueError("%s can only be used with parameters of "


### PR DESCRIPTION
AWS CloudFormation validates the List<Number> parameter value as numbers.

See:
- https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html