### PR TITLE
AWS::ServiceCatalog::LaunchRoleConstraint.RoleArn not required

### DIFF
--- a/troposphere/servicecatalog.py
+++ b/troposphere/servicecatalog.py
@@ -102,7 +102,7 @@ class LaunchRoleConstraint(AWSObject):
         'LocalRoleName': (basestring, False),
         'PortfolioId': (basestring, True),
         'ProductId': (basestring, True),
-        'RoleArn': (basestring, True),
+        'RoleArn': (basestring, False),
     }
 
 


### PR DESCRIPTION
fixes https://github.com/cloudtools/troposphere/issues/1757
[`AWS::ServiceCatalog::LaunchRoleConstraint.RoleArn`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-launchroleconstraint.html#cfn-servicecatalog-launchroleconstraint-rolearn)