### PR TITLE
AWS::KinesisFirehose::DeliveryStream BufferingHints and CompressionFormat not required in S3DestinationConfigurations

### DIFF
--- a/troposphere/firehose.py
+++ b/troposphere/firehose.py
@@ -164,9 +164,9 @@ class RedshiftDestinationConfiguration(AWSProperty):
 class S3DestinationConfiguration(AWSProperty):
     props = {
         'BucketARN': (basestring, True),
-        'BufferingHints': (BufferingHints, True),
+        'BufferingHints': (BufferingHints, False),
         'CloudWatchLoggingOptions': (CloudWatchLoggingOptions, False),
-        'CompressionFormat': (basestring, True),
+        'CompressionFormat': (basestring, False),
         'EncryptionConfiguration': (EncryptionConfiguration, False),
         'ErrorOutputPrefix': (basestring, False),
         'Prefix': (basestring, False),
@@ -263,9 +263,9 @@ class DataFormatConversionConfiguration(AWSProperty):
 class ExtendedS3DestinationConfiguration(AWSProperty):
     props = {
         'BucketARN': (basestring, True),
-        'BufferingHints': (BufferingHints, True),
+        'BufferingHints': (BufferingHints, False),
         'CloudWatchLoggingOptions': (CloudWatchLoggingOptions, False),
-        'CompressionFormat': (basestring, True),
+        'CompressionFormat': (basestring, False),
         'DataFormatConversionConfiguration':
             (DataFormatConversionConfiguration, False),
         'EncryptionConfiguration': (EncryptionConfiguration, False),


### PR DESCRIPTION
fixes https://github.com/cloudtools/troposphere/issues/1753
[`AWS::KinesisFirehose::DeliveryStream.ExtendedS3DestinationConfiguration`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisfirehose-deliverystream-extendeds3destinationconfiguration.html)
[`AWS::KinesisFirehose::DeliveryStream.S3DestinationConfiguration`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisfirehose-deliverystream-s3destinationconfiguration.html)