### PR TITLE
AWS::KinesisFirehose::DeliveryStream.ElasticsearchDestinationConfiguration.TypeName not required

### DIFF
--- a/troposphere/firehose.py
+++ b/troposphere/firehose.py
@@ -143,7 +143,7 @@ class ElasticsearchDestinationConfiguration(AWSProperty):
         'RoleARN': (basestring, True),
         'S3BackupMode': (s3_backup_mode_elastic_search_validator, True),
         'S3Configuration': (S3Configuration, False),
-        'TypeName': (basestring, True),
+        'TypeName': (basestring, False),
         'VpcConfiguration': (VpcConfiguration, False),
     }
 


### PR DESCRIPTION
fixes https://github.com/cloudtools/troposphere/issues/1744
[`AWS::KinesisFirehose::DeliveryStream.ElasticsearchDestinationConfiguration.TypeName`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisfirehose-deliverystream-elasticsearchdestinationconfiguration.html#cfn-kinesisfirehose-deliverystream-elasticsearchdestinationconfiguration-typename)