### PR TITLE
AWS::StepFunctions::StateMachine DefinitionString and S3Location.Version not required

### DIFF
--- a/troposphere/stepfunctions.py
+++ b/troposphere/stepfunctions.py
@@ -46,7 +46,7 @@ class S3Location(AWSProperty):
     props = {
         'Bucket': (basestring, True),
         'Key': (basestring, True),
-        'Version': (basestring, True)
+        'Version': (basestring, False)
     }
 
 
@@ -55,7 +55,7 @@ class StateMachine(AWSObject):
 
     props = {
         'DefinitionS3Location': (S3Location, False),
-        'DefinitionString': (basestring, True),
+        'DefinitionString': (basestring, False),
         'DefinitionSubstitutions': (dict, False),
         'LoggingConfiguration': (LoggingConfiguration, False),
         'RoleArn': (basestring, True),


### PR DESCRIPTION
fixes https://github.com/cloudtools/troposphere/issues/1764
[`AWS::StepFunctions::StateMachine.DefinitionString`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-stepfunctions-statemachine.html#cfn-stepfunctions-statemachine-definitionstring)
[`AWS::StepFunctions::StateMachine.S3Location.Version`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-stepfunctions-statemachine-s3location.html#cfn-stepfunctions-statemachine-s3location-version)