### PR TITLE
AWS::Elasticsearch::Domain.AdvancedSecurityOptions

### DIFF
--- a/troposphere/elasticsearch.py
+++ b/troposphere/elasticsearch.py
@@ -98,7 +98,7 @@ class AdvancedSecurityOptionsInput(AWSProperty):
     props = {
         'Enabled': (boolean, False),
         'InternalUserDatabaseEnabled': (boolean, False),
-        'MasterUserOptions': MasterUserOptions,
+        'MasterUserOptions': (MasterUserOptions, false),
     }
 
 

--- a/troposphere/elasticsearch.py
+++ b/troposphere/elasticsearch.py
@@ -81,8 +81,24 @@ class SnapshotOptions(AWSProperty):
 
 class VPCOptions(AWSProperty):
     props = {
-        "SecurityGroupIds": ([basestring], False),
-        "SubnetIds": ([basestring], False)
+        'SecurityGroupIds': ([basestring], False),
+        'SubnetIds': ([basestring], False)
+    }
+
+
+class MasterUserOptions(AWSProperty):
+    props = {
+        'MasterUserARN': (basestring, False),
+        'MasterUserName': (basestring, False),
+        'MasterUserPassword': (basestring, False),
+    }
+
+
+class AdvancedSecurityOptionsInput(AWSProperty):
+    props = {
+        'Enabled': (boolean, False),
+        'InternalUserDatabaseEnabled': (boolean, False),
+        'MasterUserOptions': MasterUserOptions,
     }
 
 
@@ -92,6 +108,7 @@ class Domain(AWSObject):
     props = {
         'AccessPolicies': (policytypes, False),
         'AdvancedOptions': (dict, False),
+        'AdvancedSecurityOptions': (AdvancedSecurityOptionsInput, False),
         'CognitoOptions': (CognitoOptions, False),
         'DomainName': (basestring, False),
         'EBSOptions': (EBSOptions, False),

--- a/troposphere/elasticsearch.py
+++ b/troposphere/elasticsearch.py
@@ -98,7 +98,7 @@ class AdvancedSecurityOptionsInput(AWSProperty):
     props = {
         'Enabled': (boolean, False),
         'InternalUserDatabaseEnabled': (boolean, False),
-        'MasterUserOptions': (MasterUserOptions, false),
+        'MasterUserOptions': (MasterUserOptions, False),
     }
 
 


### PR DESCRIPTION
[`AWS::Elasticsearch::Domain`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticsearch-domain.html)

fixes #1774 