### PR TITLE
AWS::Glue::Connection.ConnectionInput.ConnectionType AllowedValues expansion

### DIFF
--- a/troposphere/glue.py
+++ b/troposphere/glue.py
@@ -66,6 +66,8 @@ class PhysicalConnectionRequirements(AWSProperty):
 def connection_type_validator(type):
     valid_types = [
         'JDBC',
+        'KAFKA',
+        'MONGODB',
         'SFTP',
     ]
     if type not in valid_types:


### PR DESCRIPTION
fixes https://github.com/cloudtools/troposphere/issues/1776

https://github.com/aws-cloudformation/cfn-python-lint/pull/1673

[`AWS::Glue::Connection.ConnectionInput.ConnectionType`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-connection-connectioninput.html#cfn-glue-connection-connectioninput-connectiontype)