### PR TITLE
Support for OpenApiVersion in serverless.Api

### DIFF
--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -233,6 +233,7 @@ class Api(AWSObject):
         'EndpointConfiguration': (basestring, False),
         'MethodSettings': ([MethodSetting], False),
         'Name': (basestring, False),
+        'OpenApiVersion': (basestring, False),
         'StageName': (basestring, True),
         "TracingEnabled": (bool, False),
         'Variables': (dict, False),


### PR DESCRIPTION
The parameter was missing.
Reference: [Cloudformation documentation](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-api.html)