### PR TITLE
AWS::SecretsManager::RotationSchedule.RotationLambdaARN not required

### DIFF
--- a/troposphere/secretsmanager.py
+++ b/troposphere/secretsmanager.py
@@ -53,7 +53,7 @@ class RotationSchedule(AWSObject):
 
     props = {
         'HostedRotationLambda': (HostedRotationLambda, False),
-        'RotationLambdaARN': (basestring, True),
+        'RotationLambdaARN': (basestring, False),
         'RotationRules': (RotationRules, False),
         'SecretId': (basestring, True),
     }


### PR DESCRIPTION
This property is only conditionally required. Per CloudFormation, "Transform AWS::SecretsManager-2020-07-23 failed with: Can only specify either HostedRotationLambda or RotationLambdaARN."

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-secretsmanager-rotationschedule.html#cfn-secretsmanager-rotationschedule-rotationlambdaarn