### PR TITLE
Fixing tags data type for the issue #1784

### DIFF
--- a/troposphere/athena.py
+++ b/troposphere/athena.py
@@ -105,7 +105,7 @@ class WorkGroup(AWSObject):
         'Name': (basestring, True),
         'RecursiveDeleteOption': (boolean, False),
         'State': (validate_workgroup_state, False),
-        'Tags': (dict, False),
+        'Tags': ((Tags, list), False),
         'WorkGroupConfiguration': (WorkGroupConfiguration, False),
         'WorkGroupConfigurationUpdates': (WorkGroupConfigurationUpdates,
                                           False),


### PR DESCRIPTION
According to the aws cloudformation docs for athena workgroup, they are expecting an array of key-value pair of type `Tags`