### PR TITLE
Fix capitalization in AwsVpcConfiguration

### DIFF
--- a/examples/ECSFargate.py
+++ b/examples/ECSFargate.py
@@ -2,7 +2,7 @@ from troposphere import Parameter, Ref, Template
 from troposphere.ecs import (
     Cluster, Service, TaskDefinition,
     ContainerDefinition, NetworkConfiguration,
-    AwsvpcConfiguration, PortMapping
+    AwsVpcConfiguration, PortMapping
 )
 
 t = Template()
@@ -40,7 +40,7 @@ service = t.add_resource(Service(
     TaskDefinition=Ref(task_definition),
     LaunchType='FARGATE',
     NetworkConfiguration=NetworkConfiguration(
-        AwsvpcConfiguration=AwsvpcConfiguration(
+        AwsVpcConfiguration=AwsVpcConfiguration(
             Subnets=[Ref('Subnet')]
         )
     )

--- a/tests/examples_output/ECSFargate.template
+++ b/tests/examples_output/ECSFargate.template
@@ -18,7 +18,7 @@
                 "DesiredCount": 1,
                 "LaunchType": "FARGATE",
                 "NetworkConfiguration": {
-                    "AwsvpcConfiguration": {
+                    "AwsVpcConfiguration": {
                         "Subnets": [
                             {
                                 "Ref": "Subnet"

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -88,7 +88,7 @@ class TestECS(unittest.TestCase):
             ],
             LaunchType='FARGATE',
             NetworkConfiguration=ecs.NetworkConfiguration(
-                AwsvpcConfiguration=ecs.AwsvpcConfiguration(
+                AwsVpcConfiguration=ecs.AwsVpcConfiguration(
                     AssignPublicIp='DISABLED',
                     SecurityGroups=['sg-1234'],
                     Subnets=['subnet-1234']

--- a/troposphere/ecs.py
+++ b/troposphere/ecs.py
@@ -147,7 +147,7 @@ class PlacementStrategy(AWSProperty):
     }
 
 
-class AwsvpcConfiguration(AWSProperty):
+class AwsVpcConfiguration(AWSProperty):
     props = {
         'AssignPublicIp': (basestring, False),
         'SecurityGroups': (list, False),
@@ -157,7 +157,7 @@ class AwsvpcConfiguration(AWSProperty):
 
 class NetworkConfiguration(AWSProperty):
     props = {
-        'AwsvpcConfiguration': (AwsvpcConfiguration, False),
+        'AwsVpcConfiguration': (AwsVpcConfiguration, False),
     }
 
 


### PR DESCRIPTION
Switch to the [AWS documented capitalization](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-service-awsvpcconfiguration.html) to avoid the following error (and related):
```
E3002 Invalid Property Resources/BulkScannerService/Properties/NetworkConfiguration/AwsvpcConfiguration
```
[which appears in `cfn-lint==0.36.1`](https://github.com/aws-cloudformation/cfn-python-lint/issues/1706)

I attempted to run the unit tests but in vera case bottomed out with
```
======================================================================
ERROR: test_CustomResource (tests.test_examples.TestExamples)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/karve/code/troposphere/.eggs/awacs-0.9.8-py3.6.egg/tests/test_examples.py", line 21, in test_file
    exec(code)
  File "examples/CustomResource.py", line 5, in <module>
    class CustomPlacementGroup(AWSCustomObject):
  File "examples/CustomResource.py", line 9, in CustomPlacementGroup
    'ServiceToken': (basestring, True),
NameError: name 'basestring' is not defined

----------------------------------------------------------------------
Ran 107 tests in 0.302s
```
and didn't see documentation on overcoming the same.
