### PR TITLE
Added Types to EndpointConfiguration

### DIFF
--- a/tests/test_serverless.py
+++ b/tests/test_serverless.py
@@ -2,9 +2,9 @@ import unittest
 from troposphere import ImportValue, Parameter, Ref, Sub, Tags, Template
 from troposphere.s3 import Filter, Rules, S3Key
 from troposphere.serverless import (
-    Api, Auth, DeadLetterQueue, DeploymentPreference, Domain, Function,
-    FunctionForPackaging, LayerVersion, ResourcePolicyStatement, Route53,
-    S3Event, S3Location, SimpleTable,
+    Api, Auth, DeadLetterQueue, DeploymentPreference, Domain,
+    EndpointConfiguration, Function, FunctionForPackaging, LayerVersion,
+    ResourcePolicyStatement, Route53, S3Event, S3Location, SimpleTable,
 )
 
 
@@ -176,6 +176,18 @@ class TestServerless(unittest.TestCase):
                 ),
             ),
             StageName='testStageName',
+        )
+        t = Template()
+        t.add_resource(serverless_api)
+        t.to_json()
+
+    def test_api_with_endpoint_configuation(self):
+        serverless_api = Api(
+            title="SomeApi",
+            StageName="testStageName",
+            EndpointConfiguration=EndpointConfiguration(
+                Type="PRIVATE"
+            ),
         )
         t = Template()
         t.add_resource(serverless_api)

--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -252,6 +252,24 @@ class Domain(AWSProperty):
             )
 
 
+class EndpointConfiguration(AWSProperty):
+    props = {
+        "Type": (basestring, False),
+        "VPCEndpointIds": (list, False)
+    }
+
+    def validate(self):
+        valid_types = ["REGIONAL", "EDGE", "PRIVATE"]
+        if (
+            "Type" in self.properties
+            and self.properties["Type"]
+            not in valid_types
+        ):
+            raise ValueError(
+                "EndpointConfiguration Type must be REGIONAL, EDGE or PRIVATE"
+            )
+
+
 class Api(AWSObject):
     resource_type = "AWS::Serverless::Api"
 
@@ -266,7 +284,7 @@ class Api(AWSObject):
         'DefinitionBody': (dict, False),
         'DefinitionUri': (basestring, False),
         'Domain': (Domain, False),
-        'EndpointConfiguration': (basestring, False),
+        'EndpointConfiguration': (EndpointConfiguration, False),
         'MethodSettings': ([MethodSetting], False),
         'Name': (basestring, False),
         'OpenApiVersion': (basestring, False),
@@ -453,3 +471,4 @@ class Application(AWSObject):
             'DefinitionUri',
         ]
         mutually_exclusive(self.__class__.__name__, self.properties, conds)
+


### PR DESCRIPTION
Serverless APIs can have Endpoint Configurations set that are more complex than a standard String