### PR TITLE
Fix target type validation

### DIFF
--- a/troposphere/elasticloadbalancingv2.py
+++ b/troposphere/elasticloadbalancingv2.py
@@ -281,6 +281,16 @@ TARGET_TYPE_IP = 'ip'
 TARGET_TYPE_LAMBDA = 'lambda'
 
 
+def validate_target_type(target_type):
+    valid_types = [TARGET_TYPE_INSTANCE, TARGET_TYPE_IP, TARGET_TYPE_LAMBDA]
+    if target_type not in valid_types:
+        raise ValueError(
+            'TargetGroup.TargetType must be one of: "%s"' %
+            ', '.join(valid_types)
+        )
+    return target_type
+
+
 class TargetGroup(AWSObject):
     resource_type = "AWS::ElasticLoadBalancingV2::TargetGroup"
 
@@ -299,22 +309,12 @@ class TargetGroup(AWSObject):
         'Tags': ((Tags, list), False),
         'TargetGroupAttributes': ([TargetGroupAttribute], False),
         'Targets': ([TargetDescription], False),
-        'TargetType': (basestring, False),
+        'TargetType': (validate_target_type, False),
         'UnhealthyThresholdCount': (integer, False),
         'VpcId': (basestring, False),
     }
 
     def validate(self):
-        one_of(self.__class__.__name__,
-               self.properties,
-               'TargetType',
-               [
-                   None,
-                   TARGET_TYPE_INSTANCE,
-                   TARGET_TYPE_IP,
-                   TARGET_TYPE_LAMBDA
-               ])
-
         def check_properties(action_types, props_to_check, required):
 
             for this_type in action_types:
@@ -332,7 +332,7 @@ class TargetGroup(AWSObject):
                     if len(invalid_props) > 0:
                         # Make error message more readable in the default case
                         type_msg = ('Omitting TargetType' if this_type is None
-                                    else 'TargetType of "%s"' % (this_type))
+                                    else 'TargetType of "%s"' % this_type)
 
                         raise ValueError(
                             '%s in "%s" %s definitions of %s' % (

--- a/troposphere/fsx.py
+++ b/troposphere/fsx.py
@@ -12,6 +12,7 @@ VALID_LUSTRECONFIGURATION_DEPLOYMENTTYPE = ('PERSISTENT_1', 'SCRATCH_1',
 
 VALID_LUSTRECONFIGURATION_PERUNITSTORAGETHROUGHPUT = (50, 100, 200)
 
+
 def validate_lustreconfiguration_deploymenttype(lustreconfiguration_deploymenttype):  # NOQA
     """Validate DeploymentType for LustreConfiguration"""
 


### PR DESCRIPTION
Allow TargetType to be Ref items, such as `Ref('AWS::NoValue')`, as well as parameters.

This will not allow using `None`, but one would argue `Ref('AWS::NoValue')` would be a better choice.

Also today, when trying to use `None` (at least in python 2.7), you would get the error:
`TargetType is <type 'NoneType'>, expected <type 'basestring'>`

Fixes #1539 