### PR TITLE
Cloudfront cache and origin policy

### DIFF
--- a/troposphere/cloudfront.py
+++ b/troposphere/cloudfront.py
@@ -319,7 +319,7 @@ class CachePolicyConfig(AWSProperty):
         'Comment': (basestring, False),
         'DefaultTTL': (integer, False),
         'MaxTTL': (integer, False),
-        'MinTTL': (integer, False),
+        'MinTTL': (integer, True),
         'Name': (basestring, True),
         'ParametersInCacheKeyAndForwardedToOrigin': (
             ParametersInCacheKeyAndForwardedToOrigin, False),

--- a/troposphere/cloudfront.py
+++ b/troposphere/cloudfront.py
@@ -281,7 +281,7 @@ class StreamingDistribution(AWSObject):
 class CacheCookiesConfig(AWSProperty):
     props = {
         'CookieBehavior': (cloudfront_cache_cookie_behavior, True),
-        'Cookies': ([basestring], False), 
+        'Cookies': ([basestring], False),
     }
 
 
@@ -329,16 +329,10 @@ class CachePolicy(AWSObject):
     }
 
 
-
-
-
-
-
-
 class OriginRequestCookiesConfig(AWSProperty):
     props = {
         'CookieBehavior': (cloudfront_origin_request_cookie_behavior, True),
-        'Cookies': ([basestring], False), 
+        'Cookies': ([basestring], False),
     }
 
 

--- a/troposphere/cloudfront.py
+++ b/troposphere/cloudfront.py
@@ -317,12 +317,12 @@ class ParametersInCacheKeyAndForwardedToOrigin(AWSProperty):
 class CachePolicyConfig(AWSProperty):
     props = {
         'Comment': (basestring, False),
-        'DefaultTTL': (integer, False),
-        'MaxTTL': (integer, False),
+        'DefaultTTL': (integer, True),
+        'MaxTTL': (integer, True),
         'MinTTL': (integer, True),
         'Name': (basestring, True),
         'ParametersInCacheKeyAndForwardedToOrigin': (
-            ParametersInCacheKeyAndForwardedToOrigin, False),
+            ParametersInCacheKeyAndForwardedToOrigin, True),
     }
 
 

--- a/troposphere/cloudfront.py
+++ b/troposphere/cloudfront.py
@@ -309,6 +309,7 @@ class ParametersInCacheKeyAndForwardedToOrigin(AWSProperty):
     props = {
         'CookiesConfig': (CacheCookiesConfig, True),
         'EnableAcceptEncodingGzip': (boolean, True),
+        'EnableAcceptEncodingBrotli': (boolean, False),
         'HeadersConfig': (CacheHeadersConfig, True),
         'QueryStringsConfig': (CacheQueryStringsConfig, True),
     }

--- a/troposphere/cloudfront.py
+++ b/troposphere/cloudfront.py
@@ -7,6 +7,7 @@ from . import AWSObject, AWSProperty, Tags
 from .validators import (boolean, cloudfront_restriction_type,
                          cloudfront_event_type,
                          cloudfront_forward_type,
+                         cloudfront_cache_cookie_behavior,
                          cloudfront_viewer_protocol_policy, integer,
                          positive_integer, priceclass_type, network_port)
 
@@ -274,4 +275,101 @@ class StreamingDistribution(AWSObject):
     props = {
         'StreamingDistributionConfig': (StreamingDistributionConfig, True),
         'Tags': ((Tags, list), False),
+    }
+
+
+class CacheCookiesConfig(AWSProperty):
+    props = {
+        'CookieBehavior': (cloudfront_cache_cookie_behavior, True),
+        'Cookies': ([basestring], False), 
+    }
+
+
+class CacheHeadersConfig(AWSProperty):
+    props = {
+        'HeaderBehavior': (cloudfront_cache_header_behavior, True),
+        'Headers': ([basestring], False),
+    }
+
+
+class CacheQueryStringsConfig(AWSProperty):
+    props = {
+        'QueryStringBehavior': (
+            cloudfront_cache_query_string_behavior, True),
+        'QueryStrings': ([basestring], False),
+    }
+
+
+class ParametersInCacheKeyAndForwardedToOrigin(AWSProperty):
+    props = {
+        'CookiesConfig': (CacheCookiesConfig, True),
+        'EnableAcceptEncodingGzip': (boolean, True),
+        'HeadersConfig': (CacheHeadersConfig, True),
+        'QueryStringsConfig': (CacheQueryStringsConfig, True),
+    }
+
+
+class CachePolicyConfig(AWSProperty):
+    props = {
+        'Comment': (basestring, False),
+        'DefaultTTL': (integer, False),
+        'MaxTTL': (integer, False),
+        'MinTTL': (integer, False),
+        'Name': (basestring, True),
+        'ParametersInCacheKeyAndForwardedToOrigin': (
+            ParametersInCacheKeyAndForwardedToOrigin, False),
+    }
+
+
+class CachePolicy(AWSObject):
+    resource_type = "AWS::CloudFront::CachePolicy"
+
+    props = {
+        'CachePolicyConfig': (CachePolicyConfig, True),
+    }
+
+
+
+
+
+
+
+
+class OriginRequestCookiesConfig(AWSProperty):
+    props = {
+        'CookieBehavior': (cloudfront_origin_request_cookie_behavior, True),
+        'Cookies': ([basestring], False), 
+    }
+
+
+class OriginRequestHeadersConfig(AWSProperty):
+    props = {
+        'HeaderBehavior': (cloudfront_origin_request_header_behavior, True),
+        'Headers': ([basestring], False),
+    }
+
+
+class OriginRequestQueryStringsConfig(AWSProperty):
+    props = {
+        'QueryStringBehavior': (
+            cloudfront_origin_request_query_string_behavior, True),
+        'QueryStrings': ([basestring], False),
+    }
+
+
+class OriginRequestPolicyConfig(AWSProperty):
+    props = {
+        'Comment': (basestring, False),
+        'CookiesConfig': (OriginRequestCookiesConfig, True),
+        'HeadersConfig': (OriginRequestHeadersConfig, True),
+        'Name': (basestring, True),
+        'QueryStringsConfig': (OriginRequestQueryStringsConfig, True),
+    }
+
+
+class OriginRequestPolicy(AWSObject):
+    resource_type = "AWS::CloudFront::OriginRequestPolicy"
+
+    props = {
+        'OriginRequestPolicyConfig': (OriginRequestPolicyConfig, True),
     }

--- a/troposphere/cloudfront.py
+++ b/troposphere/cloudfront.py
@@ -8,6 +8,11 @@ from .validators import (boolean, cloudfront_restriction_type,
                          cloudfront_event_type,
                          cloudfront_forward_type,
                          cloudfront_cache_cookie_behavior,
+                         cloudfront_cache_header_behavior,
+                         cloudfront_cache_query_string_behavior,
+                         cloudfront_origin_request_cookie_behavior,
+                         cloudfront_origin_request_header_behavior,
+                         cloudfront_origin_request_query_string_behavior,
                          cloudfront_viewer_protocol_policy, integer,
                          positive_integer, priceclass_type, network_port)
 

--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -472,6 +472,73 @@ def cloudfront_forward_type(forward):
     return(forward)
 
 
+def cloudfront_cache_cookie_behavior(cookie_behavior):
+    valid_values = ['none', 'whitelist', 'allExcept', 'all']
+    if cookie_behavior not in valid_values:
+        raise ValueError(
+            'CookieBehavior must be one of: "%s"' % (
+                ', '.join(valid_values)
+            )
+        )
+    return(cookie_behavior)
+
+
+def cloudfront_cache_header_behavior(header_behavior):
+    valid_values = ['none', 'whitelist']
+    if header_behavior not in valid_values:
+        raise ValueError(
+            'HeaderBehavior must be one of: "%s"' % (
+                ', '.join(valid_values)
+            )
+        )
+    return(header_behavior)
+
+
+def cloudfront_cache_query_string_behavior(query_string_behavior):
+    valid_values = ['none', 'whitelist', 'all']
+    if query_string_behavior not in valid_values:
+        raise ValueError(
+            'QueryStringBehavior must be one of: "%s"' % (
+                ', '.join(valid_values)
+            )
+        )
+    return(query_string_behavior)
+
+
+def cloudfront_origin_request_cookie_behavior(cookie_behavior):
+    valid_values = ['none', 'whitelist', 'all']
+    if cookie_behavior not in valid_values:
+        raise ValueError(
+            'CookieBehavior must be one of: "%s"' % (
+                ', '.join(valid_values)
+            )
+        )
+    return(cookie_behavior)
+
+
+def cloudfront_origin_request_header_behavior(header_behavior):
+    valid_values = [
+        'none', 'whitelist', 'allViewer', 'allViewerAndWhitelistCloudFront']
+    if header_behavior not in valid_values:
+        raise ValueError(
+            'HeaderBehavior must be one of: "%s"' % (
+                ', '.join(valid_values)
+            )
+        )
+    return(header_behavior)
+
+
+def cloudfront_origin_request_query_string_behavior(query_string_behavior):
+    valid_values = ['none', 'whitelist', 'all']
+    if query_string_behavior not in valid_values:
+        raise ValueError(
+            'QueryStringBehavior must be one of: "%s"' % (
+                ', '.join(valid_values)
+            )
+        )
+    return(query_string_behavior)
+
+
 def priceclass_type(price_class):
     valid_values = ['PriceClass_100', 'PriceClass_200',
                     'PriceClass_All']


### PR DESCRIPTION
Added support for Cloudfront CachePolicy and OriginRequestPolicy with proper validators.

Tested creation with a template containing both CachePolicy and OriginRequestPolicy.


Note:
You cannot set MaxTLL = MinTLL = DefaultTTL = 0 in CachePolicyConfig.
If you do this CloudFormation give error ("Invalid request provided: AWS::CloudFront::CachePolicy").

By WebGui if you set all to zero you are no more able to configure ParametersInCacheKeyAndForwardedToOrigin's parameters as Cookie, Headers and QueryStrings.
This is probably the root cause of the error.
(ParametersInCacheKeyAndForwardedToOrigin is always required, so omitting it is not a solution)

In that case just set MaxTLL to one (maybe AWS will fix this in the future).