### PR TITLE
Revert "Fix capitalization in AwsVpcConfiguration (#1788)"

### DIFF
--- a/examples/ECSFargate.py
+++ b/examples/ECSFargate.py
@@ -2,7 +2,7 @@ from troposphere import Parameter, Ref, Template
 from troposphere.ecs import (
     Cluster, Service, TaskDefinition,
     ContainerDefinition, NetworkConfiguration,
-    AwsVpcConfiguration, PortMapping
+    AwsvpcConfiguration, PortMapping
 )
 
 t = Template()
@@ -40,7 +40,7 @@ service = t.add_resource(Service(
     TaskDefinition=Ref(task_definition),
     LaunchType='FARGATE',
     NetworkConfiguration=NetworkConfiguration(
-        AwsVpcConfiguration=AwsVpcConfiguration(
+        AwsvpcConfiguration=AwsvpcConfiguration(
             Subnets=[Ref('Subnet')]
         )
     )

--- a/tests/examples_output/ECSFargate.template
+++ b/tests/examples_output/ECSFargate.template
@@ -18,7 +18,7 @@
                 "DesiredCount": 1,
                 "LaunchType": "FARGATE",
                 "NetworkConfiguration": {
-                    "AwsVpcConfiguration": {
+                    "AwsvpcConfiguration": {
                         "Subnets": [
                             {
                                 "Ref": "Subnet"

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -88,7 +88,7 @@ class TestECS(unittest.TestCase):
             ],
             LaunchType='FARGATE',
             NetworkConfiguration=ecs.NetworkConfiguration(
-                AwsVpcConfiguration=ecs.AwsVpcConfiguration(
+                AwsvpcConfiguration=ecs.AwsvpcConfiguration(
                     AssignPublicIp='DISABLED',
                     SecurityGroups=['sg-1234'],
                     Subnets=['subnet-1234']

--- a/troposphere/ecs.py
+++ b/troposphere/ecs.py
@@ -147,7 +147,7 @@ class PlacementStrategy(AWSProperty):
     }
 
 
-class AwsVpcConfiguration(AWSProperty):
+class AwsvpcConfiguration(AWSProperty):
     props = {
         'AssignPublicIp': (basestring, False),
         'SecurityGroups': (list, False),
@@ -157,7 +157,7 @@ class AwsVpcConfiguration(AWSProperty):
 
 class NetworkConfiguration(AWSProperty):
     props = {
-        'AwsVpcConfiguration': (AwsVpcConfiguration, False),
+        'AwsvpcConfiguration': (AwsvpcConfiguration, False),
     }
 
 


### PR DESCRIPTION
See comment by Pat Myron from AWS (https://github.com/cloudtools/troposphere/pull/1788#issuecomment-702982230):

    This property was accidentally uppercased during the migration of
    `AWS::ECS::Service` to the CloudFormation Registry in Resource
    Specification 18.4.0 and reverted in 18.6.0. It should probably be
    kept lowercase

For more details see also aws-cloudformation/cfn-python-lint#1706