### PR TITLE
AWS::Synthetics::Canary.RuntimeVersion AllowedValues expansion

### DIFF
--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -604,7 +604,8 @@ def storage_type(storage_type):
 
 
 def canary_runtime_version(runtime_version):
-    valid_runtime_versions = ['syn-nodejs-2.0', 'syn-nodejs-2.0-beta', 'syn-1.0']
+    valid_runtime_versions = [
+        'syn-nodejs-2.0', 'syn-nodejs-2.0-beta', 'syn-1.0']
     if runtime_version not in valid_runtime_versions:
         raise ValueError(
             'RuntimeVersion must be one of: "%s"' % (

--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -604,7 +604,7 @@ def storage_type(storage_type):
 
 
 def canary_runtime_version(runtime_version):
-    valid_runtime_versions = ['syn-1.0']
+    valid_runtime_versions = ['syn-nodejs-2.0', 'syn-nodejs-2.0-beta', 'syn-1.0']
     if runtime_version not in valid_runtime_versions:
         raise ValueError(
             'RuntimeVersion must be one of: "%s"' % (


### PR DESCRIPTION
Update canary version validation to include the new synthetics canary runtimes: 'syn-nodejs-2.0', 'syn-nodejs-2.0-beta'

[`AWS::Synthetics::Canary.RuntimeVersion`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-synthetics-canary.html#cfn-synthetics-canary-runtimeversion)