### PR TITLE
AWS::CloudFront::Distribution.LambdaFunctionAssociation.IncludeBody

### DIFF
--- a/troposphere/cloudfront.py
+++ b/troposphere/cloudfront.py
@@ -36,6 +36,7 @@ class ForwardedValues(AWSProperty):
 class LambdaFunctionAssociation(AWSProperty):
     props = {
         'EventType': (cloudfront_event_type, False),
+        'IncludeBody': (boolean, False),
         'LambdaFunctionARN': (basestring, False),
     }
 


### PR DESCRIPTION
Supporting CloudFormation documentation for the property: [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-lambdafunctionassociation.html#cfn-cloudfront-distribution-lambdafunctionassociation-includebody](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-lambdafunctionassociation.html#cfn-cloudfront-distribution-lambdafunctionassociation-includebody)