### PR TITLE
AWS::ImageBuilder::ImageRecipe.EbsInstanceBlockDeviceSpecification.VolumeType AllowedValues expansion (io2)

### DIFF
--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -651,7 +651,7 @@ def schedule_pipelineexecutionstartcondition(startcondition):
 
 
 def ebsinstanceblockdevicespecification_volume_type(type):
-    valid_types = ['gp2', 'io1', 'sc1', 'st1', 'standard']
+    valid_types = ['gp2', 'io1', 'io2', 'sc1', 'st1', 'standard']
     if type not in valid_types:
         raise ValueError(
             'VolumeType must be one of: "%s"' % (


### PR DESCRIPTION
[`AWS::ImageBuilder::ImageRecipe.EbsInstanceBlockDeviceSpecification.VolumeType`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-imagebuilder-imagerecipe-ebsinstanceblockdevicespecification.html#cfn-imagebuilder-imagerecipe-ebsinstanceblockdevicespecification-volumetype)

[could be sourced automatically from botocore](https://github.com/aws-cloudformation/cfn-python-lint/pull/1682/)