### PR TITLE
AWS::CodeBuild::Project.Environment.Type AllowedValues expansion (WINDOWS_SERVER_2019_CONTAINER)

### DIFF
--- a/troposphere/codebuild.py
+++ b/troposphere/codebuild.py
@@ -145,6 +145,7 @@ class Environment(AWSProperty):
             'LINUX_CONTAINER',
             'LINUX_GPU_CONTAINER',
             'WINDOWS_CONTAINER',
+            'WINDOWS_SERVER_2019_CONTAINER',
         ]
         env_type = self.properties.get('Type')
         if env_type not in valid_types:


### PR DESCRIPTION
[`AWS::CodeBuild::Project.Environment.Type`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-environment.html#cfn-codebuild-project-environment-type)
[could be sourced automatically from botocore](https://github.com/aws-cloudformation/cfn-python-lint/pull/1682)