### PR TITLE
AWS::Glue::Connection.ConnectionInput.ConnectionType AllowedValues expansion (NETWORK)

### DIFF
--- a/troposphere/glue.py
+++ b/troposphere/glue.py
@@ -68,6 +68,7 @@ def connection_type_validator(type):
         'JDBC',
         'KAFKA',
         'MONGODB',
+        'NETWORK',
         'SFTP',
     ]
     if type not in valid_types:


### PR DESCRIPTION
[`AWS::Glue::Connection.ConnectionInput.ConnectionType`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-connection-connectioninput.html#cfn-glue-connection-connectioninput-connectiontype)
[could be sourced automatically from botocore](https://github.com/aws-cloudformation/cfn-python-lint/pull/1682/)