### PR TITLE
Update AWS::CodeArtifact::Repository

### DIFF
--- a/troposphere/codeartifact.py
+++ b/troposphere/codeartifact.py
@@ -25,6 +25,7 @@ class Repository(AWSObject):
     props = {
         'Description': (basestring, False),
         'DomainName': (basestring, True),
+        'DomainOwner': (basestring, False),
         'ExternalConnections': ([basestring], False),
         'PermissionsPolicyDocument': (dict, False),
         'RepositoryName': (basestring, True),

--- a/troposphere/codeartifact.py
+++ b/troposphere/codeartifact.py
@@ -24,6 +24,7 @@ class Repository(AWSObject):
 
     props = {
         'Description': (basestring, False),
+        'DomainName': (basestring, True),
         'ExternalConnections': ([basestring], False),
         'PermissionsPolicyDocument': (dict, False),
         'RepositoryName': (basestring, True),


### PR DESCRIPTION
Add missing, required DomainName property. 

See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codeartifact-repository.html for details. 

```
DomainName

    The name of the domain that contains the repository.
    Required: Yes
    Type: String
    Minimum: 2
    Maximum: 50
    Pattern: [a-z][a-z0-9\-]{0,48}[a-z0-9]
    Update requires: Replacement
```