### PR TITLE
AWS::KinesisFirehose::DeliveryStream.Tags

### DIFF
--- a/troposphere/firehose.py
+++ b/troposphere/firehose.py
@@ -3,7 +3,7 @@
 #
 # See LICENSE file for full license.
 
-from . import AWSObject, AWSProperty
+from . import AWSObject, AWSProperty, Tags
 from .validators import boolean, integer, positive_integer
 
 
@@ -327,4 +327,5 @@ class DeliveryStream(AWSObject):
         'S3DestinationConfiguration': (S3DestinationConfiguration, False),
         'SplunkDestinationConfiguration':
             (SplunkDestinationConfiguration, False),
+        'Tags': (Tags, False),
     }


### PR DESCRIPTION
Kinesis Firehose Delivery Stream is missing tags option. When a stream is created, consumer would like to add some tagging to the resource.