### PR TITLE
AWS::EC2::VPCEndpoint.VpcEndpointType AllowedValues expansion (GatewayLoadBalancer)

### DIFF
--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -363,7 +363,7 @@ def vpn_tunnel_inside_cidr(cidr):
 
 
 def vpc_endpoint_type(endpoint_type):
-    valid_types = ['Interface', 'Gateway']
+    valid_types = ['Interface', 'Gateway', 'GatewayLoadBalancer']
     if endpoint_type not in valid_types:
         raise ValueError(
             'VpcEndpointType must be one of: "%s"' % (


### PR DESCRIPTION
[`AWS::EC2::VPCEndpoint.VpcEndpointType`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpcendpoint.html#cfn-ec2-vpcendpoint-vpcendpointtype)
[could be sourced automatically from botocore](https://github.com/aws-cloudformation/cfn-python-lint/pull/1682)