### PR TITLE
Add AllocationStrategy to EMR instance fleet configuration

### DIFF
--- a/troposphere/emr.py
+++ b/troposphere/emr.py
@@ -271,8 +271,8 @@ class OnDemandProvisioningSpecification(AWSProperty):
 
         if allocation_strategy not in valid_values:
             raise ValueError(
-                'Only lowest-price is a valid AllocationStrategy'
-            )
+                'AllocationStrategy %s is not valid. Valid options are %s' %
+                (allocation_strategy, ', '.join(valid_values)))
 
 
 class SpotProvisioningSpecification(AWSProperty):
@@ -291,8 +291,8 @@ class SpotProvisioningSpecification(AWSProperty):
 
             if allocation_strategy not in valid_values:
                 raise ValueError(
-                    'Only capacity-optimized is a valid AllocationStrategy'
-                )
+                    'AllocationStrategy %s is not valid. Valid options are %s' %
+                    (allocation_strategy, ', '.join(valid_values)))
 
 
 class InstanceFleetProvisioningSpecifications(AWSProperty):

--- a/troposphere/emr.py
+++ b/troposphere/emr.py
@@ -259,18 +259,46 @@ class InstanceGroupConfigProperty(AWSProperty):
         'Name': (basestring, False),
     }
 
+class OnDemandProvisioningSpecification(AWSProperty):
+    props = {
+        'AllocationStrategy': (basestring, True),
+    }
+
+    def validate(self):
+        valid_values = [ 'lowest-price' ]
+
+        allocation_strategy = self.properties.get('AllocationStrategy', None)
+
+        if allocation_strategy not in valid_values:
+            raise ValueError(
+                'Only lowest-price is a valid AllocationStrategy'
+            )
+
 
 class SpotProvisioningSpecification(AWSProperty):
     props = {
+        'AllocationStrategy': (basestring, False),
         'BlockDurationMinutes': (positive_integer, False),
         'TimeoutAction': (basestring, True),
         'TimeoutDurationMinutes': (positive_integer, True),
     }
 
+    def validate(self):
+        if 'AllocationStrategy' in self.properties:
+            valid_values = [ 'capacity-optimized' ]
+
+            allocation_strategy = self.properties.get('AllocationStrategy', None)
+
+            if allocation_strategy not in valid_values:
+                raise ValueError(
+                    'Only capacity-optimized is a valid AllocationStrategy'
+                )
+
 
 class InstanceFleetProvisioningSpecifications(AWSProperty):
     props = {
-        'SpotSpecification': (SpotProvisioningSpecification, True),
+        'OnDemandSpecification': (OnDemandProvisioningSpecification, False),
+        'SpotSpecification': (SpotProvisioningSpecification, False),
     }
 
 


### PR DESCRIPTION
Added ability to add AllocationStrategy to the EMR instance fleet configuration. This change also adds OnDemandSpecification to InstanceFleetProvisioningSpecifications