### PR TITLE
Add CopyActions prop to BackupRuleResourceType for Backup

### DIFF
--- a/examples/Backup.py
+++ b/examples/Backup.py
@@ -17,6 +17,12 @@ backup_vault = template.add_resource(
     )
 )
 
+vault_arn = "arn:aws:backup:ca-central-1:111112222212:backup-vault:TestVault"
+copy_action = backup.CopyActionResourceType(
+    DestinationBackupVaultArn=vault_arn,
+    Lifecycle=backup.LifecycleResourceType(DeleteAfterDays=31),
+)
+
 backup_plan = template.add_resource(
     backup.BackupPlan(
         "Backup",
@@ -33,6 +39,7 @@ backup_plan = template.add_resource(
                     ),
                     RuleName="Rule 1",
                     ScheduleExpression="cron(0 0/12 * * ? *)",
+                    CopyActions=[copy_action],
                 )
             ],
         ),

--- a/tests/examples_output/Backup.template
+++ b/tests/examples_output/Backup.template
@@ -8,6 +8,14 @@
                     "BackupPlanName": "BackupPlan",
                     "BackupPlanRule": [
                         {
+                            "CopyActions": [
+                                {
+                                    "DestinationBackupVaultArn": "arn:aws:backup:ca-central-1:111112222212:backup-vault:TestVault",
+                                    "Lifecycle": {
+                                        "DeleteAfterDays": 31
+                                    }
+                                }
+                            ],
                             "Lifecycle": {
                                 "DeleteAfterDays": 31
                             },

--- a/troposphere/backup.py
+++ b/troposphere/backup.py
@@ -21,9 +21,17 @@ class LifecycleResourceType(AWSProperty):
     }
 
 
+class CopyActionResourceType(AWSProperty):
+    props = {
+        'DestinationBackupVaultArn': (basestring, True),
+        'Lifecycle': (LifecycleResourceType, False),
+    }
+
+
 class BackupRuleResourceType(AWSProperty):
     props = {
         'CompletionWindowMinutes': (double, False),
+        'CopyActions': ([CopyActionResourceType], False),
         'Lifecycle': (LifecycleResourceType, False),
         'RecoveryPointTags': (dict, False),
         'RuleName': (basestring, True),


### PR DESCRIPTION
AWS Backup now supports cross-account backups. This is supported by the new CloudFormation property CopyActions for the BackupRuleResourceType.