### PR TITLE
AWS::AutoScaling::AutoScalingGroup.CapacityRebalance

### DIFF
--- a/troposphere/autoscaling.py
+++ b/troposphere/autoscaling.py
@@ -169,6 +169,7 @@ class AutoScalingGroup(AWSObject):
     props = {
         'AutoScalingGroupName': (basestring, False),
         'AvailabilityZones': (list, False),
+        'CapacityRebalance': (boolean, False),
         'Cooldown': (integer, False),
         'DesiredCapacity': (integer, False),
         'HealthCheckGracePeriod': (integer, False),


### PR DESCRIPTION
Trivial support for new boolean CapacityRebalance property of AutoScalingGroup objects [added by AWS on 04 Nov](https://aws.amazon.com/blogs/compute/proactively-manage-spot-instance-lifecycle-using-the-new-capacity-rebalancing-feature-for-ec2-auto-scaling/).

Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-capacityrebalance

Thank you. :heart: 