### PR TITLE
AWS::CloudFront::Distribution.Origin.OriginShield

### DIFF
--- a/troposphere/cloudfront.py
+++ b/troposphere/cloudfront.py
@@ -114,11 +114,13 @@ class S3OriginConfig(AWSProperty):
         'OriginAccessIdentity': (basestring, False),
     }
 
+
 class OriginShield(AWSProperty):
     props = {
         'Enabled': (boolean, True),
         'OriginShieldRegion': (basestring, False),
     }
+
 
 class Origin(AWSProperty):
     props = {

--- a/troposphere/cloudfront.py
+++ b/troposphere/cloudfront.py
@@ -114,6 +114,11 @@ class S3OriginConfig(AWSProperty):
         'OriginAccessIdentity': (basestring, False),
     }
 
+class OriginShield(AWSProperty):
+    props = {
+        'Enabled': (boolean, True),
+        'OriginShieldRegion': (basestring, False),
+    }
 
 class Origin(AWSProperty):
     props = {
@@ -124,6 +129,7 @@ class Origin(AWSProperty):
         'Id': (basestring, True),
         'OriginCustomHeaders': ([OriginCustomHeader], False),
         'OriginPath': (basestring, False),
+        'OriginShield': (OriginShield, False),
         'S3OriginConfig': (S3OriginConfig, False),
     }
 


### PR DESCRIPTION
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-origin.html#cfn-cloudfront-distribution-origin-originshield

Not add the validate for shield region as all other regions in other stacks not using validation.