### PR TITLE
Add ReplicaModifications of s3

### DIFF
--- a/troposphere/s3.py
+++ b/troposphere/s3.py
@@ -295,6 +295,12 @@ class ReplicationConfigurationRulesDestination(AWSProperty):
     }
 
 
+class ReplicaModifications(AWSProperty):
+    props = {
+        'Status': (basestring, True),
+    }
+
+
 class SseKmsEncryptedObjects(AWSProperty):
     props = {
         'Status': (basestring, True),
@@ -303,7 +309,8 @@ class SseKmsEncryptedObjects(AWSProperty):
 
 class SourceSelectionCriteria(AWSProperty):
     props = {
-        'SseKmsEncryptedObjects': (SseKmsEncryptedObjects, True),
+        'ReplicaModifications': (ReplicaModifications, False),
+        'SseKmsEncryptedObjects': (SseKmsEncryptedObjects, False),
     }
 
 


### PR DESCRIPTION
Add ReplicaModifications, which is introduced in https://aws.amazon.com/about-aws/whats-new/2020/12/amazon-s3-replication-adds-support-two-way-replication/.

Reference:

- https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-replicamodifications.html
- https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-sourceselectioncriteria.html