### PR TITLE
docs: fix simple typo, shoud -> should

### DIFF
--- a/troposphere/helpers/userdata.py
+++ b/troposphere/helpers/userdata.py
@@ -16,7 +16,7 @@ def from_file(filepath, delimiter='', blanklines=False):
 
     :type blanklines: boolean
 
-    :param blanklines  If blank lines shoud be ignored
+    :param blanklines  If blank lines should be ignored
 
     rtype: troposphere.Base64
     :return The base64 representation of the file.


### PR DESCRIPTION
There is a small typo in troposphere/helpers/userdata.py.

Should read `should` rather than `shoud`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md