### PR TITLE
AWS::Glue::Connection.ConnectionInput.ConnectionType AllowedValues expansion

### DIFF
--- a/troposphere/glue.py
+++ b/troposphere/glue.py
@@ -65,8 +65,10 @@ class PhysicalConnectionRequirements(AWSProperty):
 
 def connection_type_validator(type):
     valid_types = [
+        'CUSTOM',
         'JDBC',
         'KAFKA',
+        'MARKETPLACE',
         'MONGODB',
         'NETWORK',
         'SFTP',


### PR DESCRIPTION
[`AWS::Glue::Connection.ConnectionInput.ConnectionType`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-connection-connectioninput.html#cfn-glue-connection-connectioninput-connectiontype)
could be sourced automatically from botocore:
https://github.com/aws-cloudformation/cfn-python-lint/pull/1682