### PR TITLE
AWS::S3::Bucket ServerSideEncryptionRule: add property BucketKeyEnabled

### DIFF
--- a/troposphere/s3.py
+++ b/troposphere/s3.py
@@ -371,6 +371,7 @@ class ServerSideEncryptionByDefault(AWSProperty):
 
 class ServerSideEncryptionRule(AWSProperty):
     props = {
+        'BucketKeyEnabled': (boolean, False),
         'ServerSideEncryptionByDefault':
             (ServerSideEncryptionByDefault, False),
     }


### PR DESCRIPTION
AWS added a new field `BucketKeyEnabled`, which is an optional boolean. 

Please see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-serversideencryptionrule.html