### PR TITLE
change PropertyMap in kinesisanalyticsv2 PropertyGroup to dict

### DIFF
--- a/troposphere/kinesisanalyticsv2.py
+++ b/troposphere/kinesisanalyticsv2.py
@@ -46,7 +46,7 @@ class ApplicationCodeConfiguration(AWSProperty):
 class PropertyGroup(AWSProperty):
     props = {
         'PropertyGroupId': (basestring, False),
-        'PropertyMap': (json_checker, False),
+        'PropertyMap': (dict, False),
     }
 
 


### PR DESCRIPTION
This PR fixing bug in field definition of PropertyGroup in kinesisanalyticsv2 module.

Reference:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisanalyticsv2-application-propertygroup.html

CF type is Json, bu `json_checker` represents String with json content. Correct type in troposphere to represent CF Json type is `dict`.

For example, in code pipeline Action CF:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-stages-actions.html
`Configuration` field is of type `Json`, so in troposphere:
https://github.com/cloudtools/troposphere/blob/master/troposphere/codepipeline.py
field type is `dict`, what is correct.

I tested this change in my project using version from my fork and it works correctly.
