### PR TITLE
Adding optional domain options for custom endpoints

### DIFF
--- a/troposphere/elasticsearch.py
+++ b/troposphere/elasticsearch.py
@@ -41,6 +41,9 @@ class CognitoOptions(AWSProperty):
 
 class DomainEndpointOptions(AWSProperty):
     props = {
+        'CustomEndpoint': (basestring, False),
+        'CustomEndpointCertificateArn': (basestring, False),
+        'CustomEndpointEnabled': (boolean, False),  # Conditional
         'EnforceHTTPS': (boolean, False),
         'TLSSecurityPolicy': (validate_tls_security_policy, False),
     }


### PR DESCRIPTION
This adds on to options available for https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticsearch-domain-domainendpointoptions.html