### PR TITLE
Support Throughput for gp3 ebs volumes

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -159,6 +159,7 @@ class EBSBlockDevice(AWSProperty):
         'Encrypted': (boolean, False),
         'KmsKeyId': (basestring, False),
         'Iops': (integer, False),  # Conditional
+        'Throughput': (integer, False),  # Conditional
         'SnapshotId': (basestring, False),  # Conditional
         'VolumeSize': (integer, False),  # Conditional
         'VolumeType': (basestring, False),


### PR DESCRIPTION
This allows setting the `Throughput` field for the AWS `gp3` ebs volumes when creating an `Ec2EBSBlockDevice`.