### PR TITLE
Update fis.py

### DIFF
--- a/troposphere/fis.py
+++ b/troposphere/fis.py
@@ -12,8 +12,8 @@ from . import AWSObject, AWSProperty
 
 class ExperimentTemplateStopCondition(AWSProperty):
     props = {
-        "source": (str, True),
-        "value": (str, False),
+        "Source": (str, True),
+        "Value": (str, False),
     }
 
 
@@ -21,10 +21,10 @@ class ExperimentTemplate(AWSObject):
     resource_type = "AWS::FIS::ExperimentTemplate"
 
     props = {
-        "actions": (dict, False),
-        "description": (str, True),
-        "roleArn": (str, True),
-        "stopConditions": ([ExperimentTemplateStopCondition], True),
-        "tags": (dict, True),
-        "targets": (dict, True),
+        "Actions": (dict, False),
+        "Description": (str, True),
+        "RoleArn": (str, True),
+        "StopConditions": ([ExperimentTemplateStopCondition], True),
+        "Tags": (dict, True),
+        "Targets": (dict, True),
     }


### PR DESCRIPTION
Even though the CF docs say [1] that FIS resource keys are in camelCase they are actually in PascalCase (just like any other standard AWS resource). It's easily testable by submitting a CF template. I'm contacting AWS to notify them about this discrepancy.

1. https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-fis-experimenttemplate-experimenttemplateaction.html