### PR TITLE
Adding support for using KinesisStreamSpecification with DynamoDB

### DIFF
--- a/examples/DynamoDB_Table_With_KinesisStreamSpecification.py
+++ b/examples/DynamoDB_Table_With_KinesisStreamSpecification.py
@@ -1,0 +1,106 @@
+# Converted from DynamoDB_Table.template located at:
+# http://aws.amazon.com/cloudformation/aws-cloudformation-templates/
+
+from troposphere import Output, Parameter, Ref, Template
+from troposphere.dynamodb import (
+    AttributeDefinition,
+    KeySchema,
+    KinesisStreamSpecification,
+    ProvisionedThroughput,
+    Table,
+)
+
+t = Template()
+
+t.set_description(
+    "Create a DynamoDB Table with a Kinesis Stream Specification."
+)
+
+hashkeyname = t.add_parameter(
+    Parameter(
+        "HashKeyElementName",
+        Description="HashType PrimaryKey Name",
+        Type="String",
+        AllowedPattern="[a-zA-Z0-9]*",
+        MinLength="1",
+        MaxLength="2048",
+        ConstraintDescription="must contain only alphanumberic characters",
+    )
+)
+
+hashkeytype = t.add_parameter(
+    Parameter(
+        "HashKeyElementType",
+        Description="HashType PrimaryKey Type",
+        Type="String",
+        Default="S",
+        AllowedPattern="[S|N]",
+        MinLength="1",
+        MaxLength="1",
+        ConstraintDescription="must be either S or N",
+    )
+)
+
+readunits = t.add_parameter(
+    Parameter(
+        "ReadCapacityUnits",
+        Description="Provisioned read throughput",
+        Type="Number",
+        Default="10",
+        MinValue="5",
+        MaxValue="10000",
+        ConstraintDescription="should be between 5 and 10000",
+    )
+)
+
+writeunits = t.add_parameter(
+    Parameter(
+        "WriteCapacityUnits",
+        Description="Provisioned write throughput",
+        Type="Number",
+        Default="5",
+        MinValue="5",
+        MaxValue="10000",
+        ConstraintDescription="should be between 5 and 10000",
+    )
+)
+
+streamarn = t.add_parameter(
+    Parameter(
+        "StreamArn",
+        AllowedPattern="arn:aws[-a-z]*:\\S+:\\S+:\\d+:.*",
+        Description="Kinesis StreamArn",
+        Type="String",
+        MinLength="37",
+        MaxLength="1024",
+        ConstraintDescription="must be a valid arn",
+    )
+)
+
+DynamoDBTableWithKinesis = t.add_resource(
+    Table(
+        "DynamoDBTableWithKinesis",
+        AttributeDefinitions=[
+            AttributeDefinition(
+                AttributeName=Ref(hashkeyname), AttributeType=Ref(hashkeytype)
+            ),
+        ],
+        KeySchema=[KeySchema(AttributeName=Ref(hashkeyname), KeyType="HASH")],
+        KinesisStreamSpecification=KinesisStreamSpecification(
+            StreamArn=Ref(streamarn)
+        ),
+        ProvisionedThroughput=ProvisionedThroughput(
+            ReadCapacityUnits=Ref(readunits), WriteCapacityUnits=Ref(writeunits)
+        ),
+    )
+)
+
+t.add_output(
+    Output(
+        "TableName",
+        Value=Ref(DynamoDBTableWithKinesis),
+        Description="Table with Kinesis Stream Specification",
+    )
+)
+
+print(t.to_json())

--- a/tests/examples_output/DynamoDB_Table_With_KinesisStreamSpecification.template
+++ b/tests/examples_output/DynamoDB_Table_With_KinesisStreamSpecification.template
@@ -1,0 +1,92 @@
+{
+    "Description": "Create a DynamoDB Table with a Kinesis Stream Specification.",
+    "Outputs": {
+        "TableName": {
+            "Description": "Table with Kinesis Stream Specification",
+            "Value": {
+                "Ref": "DynamoDBTableWithKinesis"
+            }
+        }
+    },
+    "Parameters": {
+        "HashKeyElementName": {
+            "AllowedPattern": "[a-zA-Z0-9]*",
+            "ConstraintDescription": "must contain only alphanumberic characters",
+            "Description": "HashType PrimaryKey Name",
+            "MaxLength": "2048",
+            "MinLength": "1",
+            "Type": "String"
+        },
+        "HashKeyElementType": {
+            "AllowedPattern": "[S|N]",
+            "ConstraintDescription": "must be either S or N",
+            "Default": "S",
+            "Description": "HashType PrimaryKey Type",
+            "MaxLength": "1",
+            "MinLength": "1",
+            "Type": "String"
+        },
+        "ReadCapacityUnits": {
+            "ConstraintDescription": "should be between 5 and 10000",
+            "Default": "10",
+            "Description": "Provisioned read throughput",
+            "MaxValue": "10000",
+            "MinValue": "5",
+            "Type": "Number"
+        },
+        "StreamArn": {
+            "AllowedPattern": "arn:aws[-a-z]*:\\S+:\\S+:\\d+:.*",
+            "ConstraintDescription": "must be a valid arn",
+            "Description": "Kinesis StreamArn",
+            "MaxLength": "1024",
+            "MinLength": "37",
+            "Type": "String"
+        },
+        "WriteCapacityUnits": {
+            "ConstraintDescription": "should be between 5 and 10000",
+            "Default": "5",
+            "Description": "Provisioned write throughput",
+            "MaxValue": "10000",
+            "MinValue": "5",
+            "Type": "Number"
+        }
+    },
+    "Resources": {
+        "DynamoDBTableWithKinesis": {
+            "Properties": {
+                "AttributeDefinitions": [
+                    {
+                        "AttributeName": {
+                            "Ref": "HashKeyElementName"
+                        },
+                        "AttributeType": {
+                            "Ref": "HashKeyElementType"
+                        }
+                    }
+                ],
+                "KeySchema": [
+                    {
+                        "AttributeName": {
+                            "Ref": "HashKeyElementName"
+                        },
+                        "KeyType": "HASH"
+                    }
+                ],
+                "KinesisStreamSpecification": {
+                    "StreamArn": {
+                        "Ref": "StreamArn"
+                    }
+                },
+                "ProvisionedThroughput": {
+                    "ReadCapacityUnits": {
+                        "Ref": "ReadCapacityUnits"
+                    },
+                    "WriteCapacityUnits": {
+                        "Ref": "WriteCapacityUnits"
+                    }
+                }
+            },
+            "Type": "AWS::DynamoDB::Table"
+        }
+    }
+}

--- a/troposphere/dynamodb.py
+++ b/troposphere/dynamodb.py
@@ -60,6 +60,12 @@ class Key(KeySchema):
     pass
 
 
+class KinesisStreamSpecification(AWSProperty):
+    props = {
+        "StreamArn": (str, True)
+    }
+
+
 class ProvisionedThroughput(AWSProperty):
     props = {
         "ReadCapacityUnits": (int, True),
@@ -127,6 +133,7 @@ class Table(AWSObject):
         "ContributorInsightsSpecification": (ContributorInsightsSpecification, False),
         "GlobalSecondaryIndexes": ([GlobalSecondaryIndex], False),
         "KeySchema": ([KeySchema], True),
+        "KinesisStreamSpecification": (KinesisStreamSpecification, False),
         "LocalSecondaryIndexes": ([LocalSecondaryIndex], False),
         "PointInTimeRecoverySpecification": (PointInTimeRecoverySpecification, False),
         "ProvisionedThroughput": (ProvisionedThroughput, False),


### PR DESCRIPTION
DynamoDB added KDS integration a few months back. Just this past week they added support to CloudFormation. We've been eagerly waiting on this for our application. 

See: [DynamoDB table KinesisStreamSpecification](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-kinesisstreamspecification) 

This is my first pull request to this project so please provide me with any and all feedback. I'm happy to do what is necessary to get this feature added. Thank you! 