### PR TITLE
ec2 volume throughput

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -737,7 +737,7 @@ class Volume(AWSObject):
         "Size": (positive_integer, False),
         "SnapshotId": (str, False),
         "Tags": ((Tags, list), False),
-        'Throughput': (positive_integer, False),
+        "Throughput": (positive_integer, False),
         "VolumeType": (str, False),
     }
 

--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -737,6 +737,7 @@ class Volume(AWSObject):
         "Size": (positive_integer, False),
         "SnapshotId": (str, False),
         "Tags": ((Tags, list), False),
+        'Throughput': (positive_integer, False),
         "VolumeType": (str, False),
     }
 


### PR DESCRIPTION
noticed the [throughput](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ebs-volume.html#cfn-ec2-ebs-volume-throughput) property is missing from the AWS::EC2::Volume resource object.

couldn't find any existing unit tests for this resource.