### PR TITLE
Transit-Gateway MulticastSupport

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -1251,7 +1251,7 @@ class TransitGateway(AWSObject):
         "DefaultRouteTablePropagation": (str, False),
         "Description": (str, False),
         "DnsSupport": (str, False),
-        'MulticastSupport': (str, False),
+        "MulticastSupport": (str, False),
         "Tags": ((Tags, list), False),
         "VpnEcmpSupport": (str, False),
     }

--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -1251,6 +1251,7 @@ class TransitGateway(AWSObject):
         "DefaultRouteTablePropagation": (str, False),
         "Description": (str, False),
         "DnsSupport": (str, False),
+        'MulticastSupport': (str, False),
         "Tags": ((Tags, list), False),
         "VpnEcmpSupport": (str, False),
     }


### PR DESCRIPTION
Add `MulticastSupport` attribute to `TransitGateway` that is currently supported by CloudFormation. Tested and validated as working. 