### PR TITLE
Add helpers.userdata.from_file_sub()

### DIFF
--- a/troposphere/helpers/userdata.py
+++ b/troposphere/helpers/userdata.py
@@ -46,7 +46,7 @@ def from_file_sub(filepath):
     rtype: troposphere.Base64
     :return The base64 representation of the file.
     """
-    
+
     try:
         with open(filepath, "rt") as f:
             data = f.read()

--- a/troposphere/helpers/userdata.py
+++ b/troposphere/helpers/userdata.py
@@ -34,3 +34,21 @@ def from_file(filepath, delimiter="", blanklines=False):
         raise IOError("Error opening or reading file: {}".format(filepath))
 
     return Base64(Join(delimiter, data))
+
+
+"""Imports userdata from a file, using Sub for replacing inline variables such as ${AWS::Region}
+
+:type filepath: string
+
+:param filepath  The absolute path to the file.
+
+rtype: troposphere.Base64
+:return The base64 representation of the file.
+"""
+def from_file_sub(filepath):
+    try:
+        with open(filepath, "rt") as f:
+            data = f.read()
+            return Base64(Sub(data))
+    except IOError:
+        raise IOError("Error opening or reading file: {}".format(filepath))

--- a/troposphere/helpers/userdata.py
+++ b/troposphere/helpers/userdata.py
@@ -36,16 +36,17 @@ def from_file(filepath, delimiter="", blanklines=False):
     return Base64(Join(delimiter, data))
 
 
-"""Imports userdata from a file, using Sub for replacing inline variables such as ${AWS::Region}
-
-:type filepath: string
-
-:param filepath  The absolute path to the file.
-
-rtype: troposphere.Base64
-:return The base64 representation of the file.
-"""
 def from_file_sub(filepath):
+    """Imports userdata from a file, using Sub for replacing inline variables such as ${AWS::Region}
+
+    :type filepath: string
+
+    :param filepath  The absolute path to the file.
+
+    rtype: troposphere.Base64
+    :return The base64 representation of the file.
+    """
+    
     try:
         with open(filepath, "rt") as f:
             data = f.read()

--- a/troposphere/helpers/userdata.py
+++ b/troposphere/helpers/userdata.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-from troposphere import Base64, Join
+from troposphere import Base64, Join, Sub
 
 
 def from_file(filepath, delimiter="", blanklines=False):


### PR DESCRIPTION
Imports userdata from a file, using `Sub` for replacing inline variables such as `${AWS::Region}`.

Useful with a userdata script that looks like this:
```bash
#!/bin/bash -ex

echo Region: ${AWS::Region}
...
```

Unlike `from_file()`, doesn't do any text processing.
