### PR TITLE
Add fargate ephemeral storage property

### DIFF
--- a/troposphere/ecs.py
+++ b/troposphere/ecs.py
@@ -504,12 +504,19 @@ class ProxyConfiguration(AWSProperty):
     }
 
 
+class EphemeralStorage(AWSProperty):
+    props = {
+        "SizeInGiB": (integer_range(21, 200), False),
+    }
+
+
 class TaskDefinition(AWSObject):
     resource_type = "AWS::ECS::TaskDefinition"
 
     props = {
         "ContainerDefinitions": ([ContainerDefinition], False),
         "Cpu": (str, False),
+        "EphemeralStorage": (EphemeralStorage, False),
         "ExecutionRoleArn": (str, False),
         "Family": (str, False),
         "InferenceAccelerators": ([InferenceAccelerator], False),


### PR DESCRIPTION
Adds ephemeral storage property for use with Fargate as documented here: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-ephemeralstorage.html