### PR TITLE
AWS::RDS::DBCluster: add missing GlobalClusterIdentifier parameter

### DIFF
--- a/troposphere/rds.py
+++ b/troposphere/rds.py
@@ -582,6 +582,7 @@ class DBCluster(AWSObject):
         "Engine": (validate_engine, True),
         "EngineMode": (validate_engine_mode, False),
         "EngineVersion": (str, False),
+        "GlobalClusterIdentifier": (str, False),
         "KmsKeyId": (str, False),
         "MasterUsername": (str, False),
         "MasterUserPassword": (str, False),


### PR DESCRIPTION
`GlobalClusterIdentifier` is missing from `troposphere.rds.DBCluster`.

From CloudFormation Resource Specification:

```json
        "GlobalClusterIdentifier": {
          "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html#cfn-rds-dbcluster-globalclusteridentifier",
          "PrimitiveType": "String",
          "Required": false,
          "UpdateType": "Conditional"
        },
```

From the [documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html#cfn-rds-dbcluster-globalclusteridentifier):

> If you are configuring an Aurora global database cluster and want your Aurora DB cluster to be a secondary member in the global database cluster, specify the global cluster ID of the global database cluster. To define the primary database cluster of the global cluster, use the AWS::RDS::GlobalCluster resource.