### PR TITLE
Add ConnectivityType property for NatGateway

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -164,7 +164,8 @@ class NatGateway(AWSObject):
     resource_type = "AWS::EC2::NatGateway"
 
     props = {
-        "AllocationId": (str, True),
+        "AllocationId": (str, False),
+        "ConnectivityType": (str, False),
         "SubnetId": (str, True),
         "Tags": ((Tags, list), False),
     }


### PR DESCRIPTION
Newly released property for NatGateway to remove the internet gateway requirement when using NAT Gateway for internal natting. See updated Cloudformation docs:https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-natgateway.html