### PR TITLE
VALID_CONNECTION_PROVIDERTYPE to list and added GH and GH Enterprise

### DIFF
--- a/troposphere/codestarconnections.py
+++ b/troposphere/codestarconnections.py
@@ -6,7 +6,7 @@
 
 from . import AWSObject, Tags
 
-VALID_CONNECTION_PROVIDERTYPE = "Bitbucket"
+VALID_CONNECTION_PROVIDERTYPE = ["Bitbucket", "GitHub", "GitHubEnterpriseServer"]
 
 
 def validate_connection_providertype(connection_providertype):


### PR DESCRIPTION
As per Amazon's [documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codestarconnections-connection.html#aws-resource-codestarconnections-connection-properties) the following provider types are allowed:

- Bitbucket
- GitHub
- GitHubEnterpriseServer