### PR TITLE
fix(AWS::EKS::Nodegroup.Taints): use the correct key for taints 

### DIFF
--- a/troposphere/eks.py
+++ b/troposphere/eks.py
@@ -162,7 +162,7 @@ class LaunchTemplateSpecification(AWSProperty):
 class Taint(AWSProperty):
     props = {
         "Effect": (validate_taint_effect, False),
-        "Name": (validate_taint_key, False),
+        "Key": (validate_taint_key, False),
         "Value": (validate_taint_value, False),
     }
 


### PR DESCRIPTION
Correct key is not `Name` it is `Key`
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-taint.html