### PR TITLE
Add `cfn_flip` to install_requires again

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ test_suite = tests
 tests_require = awacs>=2.0.0
 include_package_data = true
 install_requires =
+    cfn_flip >= 1.0.2
     typing-extensions >= 3.7.4.3; python_version < "3.8"
 packages =
     troposphere


### PR DESCRIPTION
Fixes cloudtools/troposphere#1926