### PR TITLE
[batch] Update ContainerProperties properties

### DIFF
--- a/troposphere/batch.py
+++ b/troposphere/batch.py
@@ -106,6 +106,13 @@ class MountPoints(AWSProperty):
     }
 
 
+class NetworkConfiguration(AWSProperty):
+
+    props = {
+        "AssignPublicIp": (str, False),
+    }
+
+
 class AuthorizationConfig(AWSProperty):
     props = {
         "AccessPointId": (str, False),
@@ -171,6 +178,7 @@ class ContainerProperties(AWSProperty):
         "LogConfiguration": (LogConfiguration, False),
         "Memory": (positive_integer, False),
         "MountPoints": ([MountPoints], False),
+        "NetworkConfiguration": (NetworkConfiguration, False),
         "Privileged": (boolean, False),
         "ReadonlyRootFilesystem": (boolean, False),
         "ResourceRequirements": ([ResourceRequirement], False),


### PR DESCRIPTION
A property is necessary (but not required) when using Batch on Fargate:

`ContainerProperties.NetworkConfiguration`:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-jobdefinition-containerproperties.html#cfn-batch-jobdefinition-containerproperties-networkconfiguration