### PR TITLE
Add KmsKeyId Attribute to LogGroup

### DIFF
--- a/troposphere/logs.py
+++ b/troposphere/logs.py
@@ -18,6 +18,7 @@ class LogGroup(AWSObject):
     resource_type = "AWS::Logs::LogGroup"
 
     props = {
+        "KmsKeyId": (str, False),
         "LogGroupName": (str, False),
         "RetentionInDays": (integer_list_item(RETENTION_DAYS), False),
     }


### PR DESCRIPTION
This attribute is supported by CloudFormation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-loggroup.html#aws-resource-logs-loggroup-syntax