### PR TITLE
Add serveless HttpApi class

### DIFF
--- a/tests/test_serverless.py
+++ b/tests/test_serverless.py
@@ -17,6 +17,10 @@ from troposphere.serverless import (
     S3Event,
     S3Location,
     SimpleTable,
+    HttpApi,
+    HttpApiAuth,
+    OAuth2Authorizer,
+    HttpApiDomainConfiguration,
 )
 
 
@@ -215,6 +219,80 @@ class TestServerless(unittest.TestCase):
         t = Template()
         t.add_parameter(certificate)
         t.add_resource(serverless_api)
+        t.to_json()
+
+    def test_http_api_definition_uri_defined(self):
+        serverless_http_api = HttpApi(
+            "SomeHttpApi",
+            StageName="testHttp",
+            DefinitionUri="s3://bucket/swagger.yml",
+        )
+        t = Template()
+        t.add_resource(serverless_http_api)
+        t.to_json()
+
+    def test_http_api_both_definition_uri_and_body_defined(self):
+        serverless_http_api = HttpApi(
+            "SomeHttpApi",
+            StageName="testHttp",
+            DefinitionUri="s3://bucket/swagger.yml",
+            DefinitionBody=self.swagger,
+        )
+        t = Template()
+        t.add_resource(serverless_http_api)
+        with self.assertRaises(ValueError):
+            t.to_json()
+
+    def test_http_api_definition_body(self):
+        serverless_http_api = HttpApi(
+            "SomeHttpApi",
+            StageName="testHttp",
+            DefinitionBody=self.swagger,
+        )
+        t = Template()
+        t.add_resource(serverless_http_api)
+        t.to_json()
+
+    def test_http_api_no_definition(self):
+        serverless_api = HttpApi(
+            "SomeHttpApi",
+            StageName="testHttp",
+        )
+        t = Template()
+        t.add_resource(serverless_api)
+        t.to_json()
+
+    def test_http_api_authorization_scopes(self):
+        serverless_api = HttpApi(
+            title="SomeHttpApi",
+            Auth=HttpApiAuth(
+                Authorizers=OAuth2Authorizer(AuthorizationScopes=["scope1", "scope2"])
+            ),
+            StageName="testHttpStageName",
+        )
+        t = Template()
+        t.add_resource(serverless_api)
+        t.to_json()
+
+    def test_http_api_with_domain(self):
+        certificate = Parameter("certificate", Type="String")
+        serverless_http_api = HttpApi(
+            "SomeHttpApi",
+            StageName="testHttp",
+            Domain=HttpApiDomainConfiguration(
+                BasePath=["/"],
+                CertificateArn=Ref(certificate),
+                DomainName=Sub("subdomain.${Zone}", Zone=ImportValue("MyZone")),
+                EndpointConfiguration="REGIONAL",
+                Route53=Route53(
+                    HostedZoneId=ImportValue("MyZone"),
+                    IpV6=True,
+                ),
+            ),
+        )
+        t = Template()
+        t.add_parameter(certificate)
+        t.add_resource(serverless_http_api)
         t.to_json()
 
     def test_simple_table(self):

--- a/tests/test_serverless.py
+++ b/tests/test_serverless.py
@@ -186,7 +186,7 @@ class TestServerless(unittest.TestCase):
         t.add_resource(serverless_api)
         t.to_json()
 
-    def test_api_with_endpoint_configuation(self):
+    def test_api_with_endpoint_configuration(self):
         serverless_api = Api(
             title="SomeApi",
             StageName="testStageName",

--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -7,6 +7,7 @@ import types
 
 from . import AWSHelperFn, AWSObject, AWSProperty
 from .apigateway import AccessLogSetting, CanarySetting, MethodSetting
+from .apigatewayv2 import AccessLogSettings, RouteSettings
 from .awslambda import (
     DestinationConfig,
     Environment,
@@ -25,6 +26,7 @@ from .validators import (
     integer_range,
     mutually_exclusive,
     positive_integer,
+    boolean,
 )
 
 try:
@@ -335,6 +337,10 @@ class EndpointConfiguration(AWSProperty):
             )
 
 
+class ApiDefinition(AWSProperty):
+    props = {"Bucket": (str, True), "Key": (str, True), "Version": (str, False)}
+
+
 class Api(AWSObject):
     resource_type = "AWS::Serverless::Api"
 
@@ -347,7 +353,7 @@ class Api(AWSObject):
         "CanarySetting": (CanarySetting, False),
         "Cors": ((str, Cors), False),
         "DefinitionBody": (dict, False),
-        "DefinitionUri": (str, False),
+        "DefinitionUri": ((str, ApiDefinition), False),
         "Domain": (Domain, False),
         "EndpointConfiguration": (EndpointConfiguration, False),
         "MethodSettings": ([MethodSetting], False),
@@ -365,6 +371,81 @@ class Api(AWSObject):
             "DefinitionUri",
         ]
         mutually_exclusive(self.__class__.__name__, self.properties, conds)
+
+
+class OAuth2Authorizer(AWSProperty):
+    props = {
+        "AuthorizationScopes": (list, False),
+        "IdentitySource": (str, False),
+        "JwtConfiguration": (dict, False),
+    }
+
+
+class LambdaAuthorizationIdentity(AWSProperty):
+    props = {
+        "Context": (list, False),
+        "Headers": (list, False),
+        "QueryStrings": (list, False),
+        "ReauthorizeEvery": (integer, False),
+        "StageVariables": (list, False),
+    }
+
+
+class LambdaAuthorizer(AWSProperty):
+    props = {
+        "AuthorizerPayloadFormatVersion": (str, True),
+        "EnableSimpleResponses": (boolean, False),
+        "FunctionArn": (str, True),
+        "FunctionInvokeRole": (str, False),
+        "Identity": (LambdaAuthorizationIdentity, False),
+    }
+
+
+class HttpApiAuth(AWSProperty):
+    props = {
+        "Authorizers": ((OAuth2Authorizer, LambdaAuthorizer), False),
+        "DefaultAuthorizer": (str, False),
+    }
+
+
+class HttpApiCorsConfiguration(AWSProperty):
+    props = {
+        "AllowCredentials": (boolean, False),
+        "AllowHeaders": (list, False),
+        "AllowMethods": (list, False),
+        "AllowOrigins": (list, False),
+        "ExposeHeaders": (list, False),
+        "MaxAge": (integer, False),
+    }
+
+
+class HttpApiDefinition(ApiDefinition):
+    pass
+
+
+class HttpApiDomainConfiguration(Domain):
+    pass
+
+
+class HttpApi(AWSObject):
+    resource_type = "AWS::Serverless::HttpApi"
+
+    props = {
+        "AccessLogSettings": (AccessLogSettings, False),
+        "Auth": (HttpApiAuth, False),
+        "CorsConfiguration": ((str, HttpApiCorsConfiguration), False),
+        "DefaultRouteSettings": (RouteSettings, False),
+        "DefinitionBody": (str, False),
+        "DefinitionUri": ((str, HttpApiDefinition), False),
+        "Description": (str, False),
+        "DisableExecuteApiEndpoint": (boolean, False),
+        "Domain": (HttpApiDomainConfiguration, False),
+        "FailOnWarnings": (boolean, False),
+        "RouteSettings": (dict, False),
+        "StageName": (str, False),
+        "StageVariables": (dict, False),
+        "Tags": (dict, False),
+    }
 
 
 class PrimaryKey(AWSProperty):

--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -435,7 +435,7 @@ class HttpApi(AWSObject):
         "Auth": (HttpApiAuth, False),
         "CorsConfiguration": ((str, HttpApiCorsConfiguration), False),
         "DefaultRouteSettings": (RouteSettings, False),
-        "DefinitionBody": (str, False),
+        "DefinitionBody": (dict, False),
         "DefinitionUri": ((str, HttpApiDefinition), False),
         "Description": (str, False),
         "DisableExecuteApiEndpoint": (boolean, False),

--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -447,6 +447,13 @@ class HttpApi(AWSObject):
         "Tags": (dict, False),
     }
 
+    def validate(self):
+        conds = [
+            "DefinitionBody",
+            "DefinitionUri",
+        ]
+        mutually_exclusive(self.__class__.__name__, self.properties, conds)
+
 
 class PrimaryKey(AWSProperty):
     props = {"Name": (str, False), "Type": (primary_key_type_validator, False)}


### PR DESCRIPTION
Add support for AWS::Serverless::HttpApi

[sam-resource-httpapi](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-httpapi.html)