### PR TITLE
Allow LaunchTemplateSpecification in LaunchTemplateOverrides

### DIFF
--- a/troposphere/autoscaling.py
+++ b/troposphere/autoscaling.py
@@ -148,6 +148,7 @@ class InstancesDistribution(AWSProperty):
 class LaunchTemplateOverrides(AWSProperty):
     props = {
         "InstanceType": (str, False),
+        "LaunchTemplateSpecification": (LaunchTemplateSpecification, False),
         "WeightedCapacity": (str, False),
     }
 


### PR DESCRIPTION
As per AWS document:

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-launchtemplateoverrides.html