### PR TITLE
Add TimeZone property to autoscaling.ScheduledAction (AWS::AutoScaling::ScheduledAction)

### DIFF
--- a/troposphere/autoscaling.py
+++ b/troposphere/autoscaling.py
@@ -344,6 +344,7 @@ class ScheduledAction(AWSObject):
         "MinSize": (integer, False),
         "Recurrence": (str, False),
         "StartTime": (str, False),
+        "TimeZone": (str, False)
     }
 
 


### PR DESCRIPTION
This was added to Cloudformation on June 18. (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/ReleaseHistory.html)

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-scheduledaction.html

