### PR TITLE
Remove duplicate TargetTrackingScalingPolicyConfiguration from dynamodb.py

### DIFF
--- a/troposphere/dynamodb.py
+++ b/troposphere/dynamodb.py
@@ -143,15 +143,6 @@ class CapacityAutoScalingSettings(AWSProperty):
     }
 
 
-class TargetTrackingScalingPolicyConfiguration(AWSProperty):
-    props = {
-        "DisableScaleIn": (boolean, False),
-        "ScaleInCooldown": (integer, False),
-        "ScaleOutCooldown": (integer, False),
-        "TargetValue": (double, True),
-    }
-
-
 class ReadProvisionedThroughputSettings(AWSProperty):
     props = {
         "ReadCapacityAutoScalingSettings": (CapacityAutoScalingSettings, False),


### PR DESCRIPTION
The duplicate TargetTrackingScalingPolicyConfiguration class defined in dynamodb causes type assertions to fail


`TypeError: <class 'troposphere.dynamodb.CapacityAutoScalingSettings'>: None.TargetTrackingScalingPolicyConfiguration is <class 'troposphere.dynamodb.TargetTrackingScalingPolicyConfiguration'>, expected <class 'troposphere.dynamodb.TargetTrackingScalingPolicyConfiguration'>`