### PR TITLE
Update firehose.py parameter type validation

### DIFF
--- a/troposphere/firehose.py
+++ b/troposphere/firehose.py
@@ -8,7 +8,11 @@ from .validators import boolean, integer, positive_integer
 
 
 def processor_type_validator(x):
-    valid_types = ["Lambda"]
+    valid_types = [ "Lambda",
+                    "MetadataExtraction",
+                    "RecordDeAggregation",
+                    "AppendDelimiterToRecord"
+                  ]
     if x not in valid_types:
         raise ValueError("Type must be one of: %s" %
                          ", ".join(valid_types))


### PR DESCRIPTION
Added all processor types for validation of processor type. As per the https://docs.aws.amazon.com/firehose/latest/APIReference/API_Processor.html, the valid parameter types are RecordDeAggregation | Lambda | MetadataExtraction | AppendDelimiterToRecord which should be part of the validation.