### PR TITLE
Enable support for gp3 EBS volume types in Autoscaling Groups

### DIFF
--- a/tests/test_asg.py
+++ b/tests/test_asg.py
@@ -1,7 +1,7 @@
 import unittest
 
 from troposphere import If, Ref
-from troposphere.autoscaling import AutoScalingGroup
+from troposphere.autoscaling import AutoScalingGroup, EBSBlockDevice
 from troposphere.policies import AutoScalingRollingUpdate, UpdatePolicy
 
 
@@ -136,6 +136,20 @@ class TestAutoScalingGroup(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             self.assertTrue(group.validate())
+
+    def test_can_define_gp3_ebsblockdevice(self):
+        ebs = EBSBlockDevice(
+            DeleteOnTermination=True,
+            Encrypted=True,
+            Iops=3000,
+            Throughput=500,
+            VolumeSize=100,
+            VolumeType="gp3"
+        )
+
+        self.assertEquals(ebs.properties["VolumeType"], "gp3")
+        self.assertIn("Throughput", ebs.properties,
+                      "gp3 volumes require an additional Throughput param")
 
 
 if __name__ == "__main__":

--- a/troposphere/autoscaling.py
+++ b/troposphere/autoscaling.py
@@ -439,6 +439,7 @@ class EBSBlockDevice(AWSProperty):
         "Encrypted": (boolean, False),
         "Iops": (integer, False),
         "SnapshotId": (str, False),
+        "Throughput": (integer, False),
         "VolumeSize": (integer, False),
         "VolumeType": (str, False),
     }


### PR DESCRIPTION
Hi, the EBSBlockDevice properties class used by Autoscaling Groups does not support the creation of gp3 EBS volume types, because it doesn't currently handle the required **Throughput** parameter as described here [CloudFormation Docs](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig-blockdev-template.html)

This PR adds the missing Throughput param and adds a test to confirm class can be instantiated correctly for gp3 volumes

Please let me know if any further updates or changes are needed.  This is a blocking issue currently on our environment.

Thanks
Iain