### PR TITLE
Add Architectures to AWS::Serverless::Function

### DIFF
--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -131,6 +131,7 @@ class Function(AWSObject):
     resource_type = "AWS::Serverless::Function"
 
     props = {
+        "Architectures": ([str], False),
         "AssumeRolePolicyDocument": (policytypes, False),
         "AutoPublishAlias": (str, False),
         "AutoPublishCodeSha256": (str, False),


### PR DESCRIPTION
Per the [SAM Developer Guide](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-function.html#sam-function-architectures)