### PR TITLE
mypy errors starting with release 3.2.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,9 +43,6 @@ scripts =
 python_requires = >=3.7.0
 zip_safe = false
 
-[options.package_data]
-* = py.typed
-
 [options.extras_require]
 policy = awacs>=2.0.0
 

--- a/troposphere/py.typed
+++ b/troposphere/py.typed
@@ -1,1 +1,0 @@
-# Marker file for PEP 561


### PR DESCRIPTION
# Summary
Starting with release version `3.2.0` we began getting `mypy` errors that did not used to exist when using version `3.1.1`.

# Details
As part of the [commit that introduced](https://github.com/cloudtools/troposphere/commit/07b984f5d1033690878ce2112ebd2281ab8dc560) the new `PropsDictType` variable, the `troposphere/py.typed` file was also added. In accordance with [PEP 561](https://www.python.org/dev/peps/pep-0561/), the presence of this file should be used when the underlying code has types or stubs defined. The example below demonstrates how the `py.typed` can cause `mypy` to throw errors that did not trigger before.

### example.py 
```python
from troposphere import Template
import troposphere.ec2 as ec2
t = Template()
instance = ec2.Instance("myinstance")
instance.ImageId = "ami-951945d0"
instance.InstanceType = "t1.micro"
t.add_resource(instance)
print(t.to_yaml())
```

### setup.cfg
```
[mypy]
disallow_any_generics = True
disallow_incomplete_defs = True
disallow_subclassing_any = True
disallow_untyped_calls = True
disallow_untyped_decorators = True
disallow_untyped_defs = True
exclude = scripts
ignore_missing_imports = True
no_implicit_optional = True
show_error_codes = True
```

### mypy errors
```
$ python3 --version
Python 3.7.10

$ pip3 install mypy

$ pip3 install troposphere==3.1.1
$ mypy example.py 
Success: no issues found in 1 source file

$ pip3 install troposphere==3.2.2
$ mypy example.py 
example.py:3: error: Call to untyped function "Template" in typed context  [no-untyped-call]
example.py:4: error: Call to untyped function "Instance" in typed context  [no-untyped-call]
example.py:7: error: Call to untyped function "add_resource" in typed context  [no-untyped-call]
example.py:8: error: Call to untyped function "to_yaml" in typed context  [no-untyped-call]
Found 4 errors in 1 file (checked 1 source file)

$ rm lib/python3.7/site-packages/troposphere/py.typed 
$ mypy example.py 
Success: no issues found in 1 source file
```

# Suggested Solution
Until `troposphere` fully supports typing across its codebase, I would suggest we remove the `py.typed` file.