### PR TITLE
Expanding one_of validator

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,6 +1,7 @@
 import unittest
 
 from troposphere import NoValue, Parameter, Ref, Tags
+from troposphere import AWS_REGION
 from troposphere.validators import (
     boolean,
     check_required,
@@ -207,6 +208,7 @@ class TestValidators(unittest.TestCase):
         conds = ["Bilbo", "Frodo"]
         one_of("hobbits", {"first": "Bilbo"}, "first", conds)
         one_of("hobbits", {"first": "Frodo"}, "first", conds)
+        one_of("hobbits", {"first": Ref(AWS_REGION)}, "first", conds)
         with self.assertRaises(ValueError):
             one_of("hobbits", {"first": "Gandalf"}, "first", conds)
             one_of("hobbits", {"first": "Gandalf"}, "second", conds)

--- a/troposphere/ecs.py
+++ b/troposphere/ecs.py
@@ -23,7 +23,7 @@ from .validators.ecs import (
     scope_validator,
     validate_ephemeral_storage_size,
     validate_network_port,
-    validate_rutime_platform,
+    validate_runtime_platform,
     validate_scaling_step_size,
     validate_target_capacity,
     validate_transit_encryption_port,
@@ -635,7 +635,7 @@ class RuntimePlatform(AWSProperty):
     }
 
     def validate(self):
-        validate_rutime_platform(self)
+        validate_runtime_platform(self)
 
 
 class DockerVolumeConfiguration(AWSProperty):

--- a/troposphere/validators/__init__.py
+++ b/troposphere/validators/__init__.py
@@ -135,10 +135,13 @@ def encoding(encoding):
 
 
 def one_of(class_name, properties, property, conditionals):
-    if (
-        isinstance(properties.get(property), (int, float, str, list, dict))
-        and properties.get(property) not in conditionals
+    from .. import AWSHelperFn
+
+    if isinstance(properties.get(property), AWSHelperFn) or issubclass(
+        type(properties.get(property)), AWSHelperFn
     ):
+        return
+    if properties.get(property) not in conditionals:
         raise ValueError(
             # Ensure we handle None as a valid value
             '%s.%s must be one of: "%s"'

--- a/troposphere/validators/__init__.py
+++ b/troposphere/validators/__init__.py
@@ -99,7 +99,6 @@ def network_port(x):
 
 
 def s3_bucket_name(b):
-
     # consecutive periods not allowed
 
     if ".." in b:
@@ -136,7 +135,10 @@ def encoding(encoding):
 
 
 def one_of(class_name, properties, property, conditionals):
-    if properties.get(property) not in conditionals:
+    if (
+        isinstance(properties.get(property), (int, float, str, list, dict))
+        and properties.get(property) not in conditionals
+    ):
         raise ValueError(
             # Ensure we handle None as a valid value
             '%s.%s must be one of: "%s"'
@@ -144,7 +146,8 @@ def one_of(class_name, properties, property, conditionals):
                 class_name,
                 property,
                 ", ".join(condition for condition in conditionals if condition),
-            )
+            ),
+            "or a CFN Intrinsic function / troposphere.AWSHelperFn",
         )
 
 

--- a/troposphere/validators/ecs.py
+++ b/troposphere/validators/ecs.py
@@ -137,7 +137,7 @@ def launch_type_validator(x):
     return x
 
 
-def validate_rutime_platform(self):
+def validate_runtime_platform(self):
     """
     Class: RuntimePlatform
     """


### PR DESCRIPTION
* Fixed typo for validation function
* Validating primitive types for `one_of` as can't use ``troposphere.AWSHelperFn`` due to cyclic include.