### PR TITLE
add type annotations for base classes & some validators

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,5 +10,11 @@ indent_size = 4
 [*.py]
 max_line_length = 79
 
+[*.{toml,yaml,yml}]
+indent_size = 2
+
 [Makefile]
 indent_style = tab
+
+[{package,package-lock}.json]
+indent_size = 2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,10 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '17'
       - name: Pip Cache (Linux)
         uses: actions/cache@v1
         if: runner.os == 'Linux'
@@ -35,6 +39,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install --upgrade flake8 cfn_flip>=1.0.2
+      - name: Install Node Dependencies
+        run: npm install
       - name: Run Lints
         run: make lint
       - name: Run Tests

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ docs/_build/
 *.ipynb
 
 .DS_Store
+node_modules

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ fix-isort: ## automatically fix all isort errors
 clean:
 	rm -rf ${p39dir} troposphere.egg-info
 
-lint: lint-flake8 ## run all linters
+lint: lint-flake8 lint-pyright ## run all linters
 
 lint-black: ## run black
 	@echo "Running black... If this fails, run 'make fix-black' to resolve."
@@ -48,6 +48,11 @@ lint-flake8: ## run flake8
 lint-isort: ## run isort
 	@echo "Running isort... If this fails, run 'make fix-isort' to resolve."
 	@isort ${PYDIRS} --check-only
+	@echo ""
+
+lint-pyright: ## run pyright
+	@echo "Running pyright..."
+	@npx pyright
 	@echo ""
 
 release-test:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "troposphere",
+  "version": "0.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "troposphere",
+      "version": "0.0.0",
+      "license": "BSD-3-Clause",
+      "devDependencies": {
+        "pyright": "^1.1.226"
+      }
+    },
+    "node_modules/pyright": {
+      "version": "1.1.226",
+      "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.226.tgz",
+      "integrity": "sha512-ZJx3Kz5v7hc6DIeIVSC3zeCia43rlLD+IK8ip5k+h3gTlIQodaf/zccsCh2xmoBvCTY9VbbbLnDbkITyIW3+MA==",
+      "dev": true,
+      "bin": {
+        "pyright": "index.js",
+        "pyright-langserver": "langserver.index.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    }
+  },
+  "dependencies": {
+    "pyright": {
+      "version": "1.1.226",
+      "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.226.tgz",
+      "integrity": "sha512-ZJx3Kz5v7hc6DIeIVSC3zeCia43rlLD+IK8ip5k+h3gTlIQodaf/zccsCh2xmoBvCTY9VbbbLnDbkITyIW3+MA==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "troposphere",
+  "version": "0.0.0",
+  "directories": {
+    "doc": "docs",
+    "example": "examples",
+    "test": "tests"
+  },
+  "scripts": {
+    "py-type-check": "pyright --venv-path ./"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cloudtools/troposphere.git"
+  },
+  "license": "BSD-3-Clause",
+  "bugs": {
+    "url": "https://github.com/cloudtools/troposphere/issues"
+  },
+  "homepage": "https://github.com/cloudtools/troposphere#readme",
+  "devDependencies": {
+    "pyright": "^1.1.226"
+  },
+  "engines": {
+    "npm": ">=7.0.0",
+    "node": ">=16.0.0"
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[tool.pyright]
+include = [
+  "**/troposphere",
+]
+pythonPlatform = "All"
+pythonVersion = "3.7"
+reportDuplicateImport = "none"
+reportImportCycles = "none"
+reportIncompatibleMethodOverride = "warning"
+reportMissingTypeStubs = "none"
+reportPrivateUsage = "none"
+reportUnknownMemberType = "none"
+reportUnnecessaryIsInstance = "warning"
+reportUnusedImport = "none"
+reportUnusedVariable = "none"
+reportWildcardImportFromLibrary = "none"
+strict = [
+  "**/__init__.py"
+]
+strictParameterNoneValue = false
+typeCheckingMode = "off"
+useLibraryCodeForTypes = true
+venv = ".venv"

--- a/troposphere/type_defs/__init__.py
+++ b/troposphere/type_defs/__init__.py
@@ -1,0 +1,1 @@
+"""Type definitions."""

--- a/troposphere/type_defs/compat.py
+++ b/troposphere/type_defs/compat.py
@@ -1,0 +1,9 @@
+"""Type definition backward compatibility."""
+from __future__ import annotations
+
+import sys
+
+if sys.version_info < (3, 8):  # 3.7
+    from typing_extensions import Literal, Protocol, SupportsIndex
+else:
+    from typing import Literal, Protocol, SupportsIndex

--- a/troposphere/type_defs/compat.py
+++ b/troposphere/type_defs/compat.py
@@ -1,4 +1,5 @@
 """Type definition backward compatibility."""
+# flake8: noqa
 from __future__ import annotations
 
 import sys

--- a/troposphere/type_defs/protocols.py
+++ b/troposphere/type_defs/protocols.py
@@ -1,0 +1,16 @@
+"""Protocols."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .compat import Protocol
+
+
+class JSONreprProtocol(Protocol):
+    def JSONrepr(self, *__args: Any, **__kwargs: Any) -> Dict[str, Any]:
+        raise NotImplementedError
+
+
+class ToDictProtocol(Protocol):
+    def to_dict(self) -> Dict[str, Any]:
+        raise NotImplementedError

--- a/troposphere/validators/__init__.py
+++ b/troposphere/validators/__init__.py
@@ -2,12 +2,42 @@
 # All rights reserved.
 #
 # See LICENSE file for full license.
+from __future__ import annotations
 
 import json
 from re import compile
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    SupportsFloat,
+    SupportsInt,
+    TypeVar,
+    Union,
+    overload,
+)
+
+if TYPE_CHECKING:
+    from .. import AWSHelperFn, Tags
+    from ..type_defs.compat import Literal, SupportsIndex
 
 
-def boolean(x):
+__T = TypeVar("__T")
+
+
+@overload
+def boolean(x: Literal[True, 1, "true", "True"]) -> Literal[True]:
+    ...
+
+
+@overload
+def boolean(x: Literal[False, 0, "false", "False"]) -> Literal[False]:
+    ...
+
+
+def boolean(x: Any) -> bool:
     if x in [True, 1, "1", "true", "True"]:
         return True
     if x in [False, 0, "0", "false", "False"]:
@@ -15,7 +45,7 @@ def boolean(x):
     raise ValueError
 
 
-def integer(x):
+def integer(x: Any) -> Union[str, bytes, SupportsInt, SupportsIndex]:
     try:
         int(x)
     except (ValueError, TypeError):
@@ -24,15 +54,17 @@ def integer(x):
         return x
 
 
-def positive_integer(x):
+def positive_integer(x: Any) -> Union[str, bytes, SupportsInt, SupportsIndex]:
     p = integer(x)
     if int(p) < 0:
         raise ValueError("%r is not a positive integer" % x)
     return x
 
 
-def integer_range(minimum_val, maximum_val):
-    def integer_range_checker(x):
+def integer_range(
+    minimum_val: float, maximum_val: float
+) -> Callable[[Any], Union[str, bytes, SupportsInt, SupportsIndex]]:
+    def integer_range_checker(x: Any) -> Union[str, bytes, SupportsInt, SupportsIndex]:
         i = int(x)
         if i < minimum_val or i > maximum_val:
             raise ValueError(
@@ -43,8 +75,12 @@ def integer_range(minimum_val, maximum_val):
     return integer_range_checker
 
 
-def integer_list_item(allowed_values):
-    def integer_list_item_checker(x):
+def integer_list_item(
+    allowed_values: List[float],
+) -> Callable[[Any], Union[str, bytes, SupportsInt, SupportsIndex]]:
+    def integer_list_item_checker(
+        x: Any,
+    ) -> Union[str, bytes, SupportsInt, SupportsIndex]:
         i = int(x)
         if i in allowed_values:
             return x
@@ -56,7 +92,7 @@ def integer_list_item(allowed_values):
     return integer_list_item_checker
 
 
-def double(x):
+def double(x: Any) -> Union[SupportsFloat, SupportsIndex, str, bytes, bytearray]:
     try:
         float(x)
     except (ValueError, TypeError):
@@ -65,27 +101,27 @@ def double(x):
         return x
 
 
-def tags_or_list(x):
+def tags_or_list(x: Any) -> Union[AWSHelperFn, Tags, List[Any]]:
     """backward compatibility"""
     from .. import AWSHelperFn, Tags
 
     if isinstance(x, (AWSHelperFn, Tags, list)):
-        return x
+        return x  # type: ignore
 
     raise ValueError(f"Value {x} of type {type(x)} must be either Tags or list")
 
 
-def ignore(x):
+def ignore(x: __T) -> __T:
     """Method to indicate bypassing property validation"""
     return x
 
 
-def defer(x):
+def defer(x: __T) -> __T:
     """Method to indicate defering property validation"""
     return x
 
 
-def network_port(x):
+def network_port(x: Any) -> Union[AWSHelperFn, str, bytes, SupportsInt, SupportsIndex]:
     from .. import AWSHelperFn
 
     # Network ports can be Ref items
@@ -98,7 +134,7 @@ def network_port(x):
     return x
 
 
-def s3_bucket_name(b):
+def s3_bucket_name(b: str) -> str:
     # consecutive periods not allowed
 
     if ".." in b:
@@ -117,7 +153,7 @@ def s3_bucket_name(b):
         raise ValueError("%s is not a valid s3 bucket name" % b)
 
 
-def elb_name(b):
+def elb_name(b: str) -> str:
     elb_name_re = compile(
         r"^[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,30}[a-zA-Z0-9]{1})?$"
     )  # noqa
@@ -127,14 +163,16 @@ def elb_name(b):
         raise ValueError("%s is not a valid elb name" % b)
 
 
-def encoding(encoding):
+def encoding(encoding: str) -> str:
     valid_encodings = ["plain", "base64"]
     if encoding not in valid_encodings:
         raise ValueError("Encoding needs to be one of %r" % valid_encodings)
     return encoding
 
 
-def one_of(class_name, properties, property, conditionals):
+def one_of(
+    class_name: str, properties: Dict[str, Any], property: str, conditionals: List[Any]
+) -> None:
     from .. import AWSHelperFn
 
     check_property = properties.get(property)
@@ -155,10 +193,12 @@ def one_of(class_name, properties, property, conditionals):
         )
 
 
-def mutually_exclusive(class_name, properties, conditionals):
+def mutually_exclusive(
+    class_name: str, properties: Dict[str, Any], conditionals: List[Any]
+) -> int:
     from .. import NoValue
 
-    found_list = []
+    found_list: List[Any] = []
     for c in conditionals:
         if c in properties and not properties[c] == NoValue:
             found_list.append(c)
@@ -172,7 +212,9 @@ def mutually_exclusive(class_name, properties, conditionals):
     return specified_count
 
 
-def exactly_one(class_name, properties, conditionals):
+def exactly_one(
+    class_name: str, properties: Dict[str, Any], conditionals: List[Any]
+) -> int:
     specified_count = mutually_exclusive(class_name, properties, conditionals)
     if specified_count != 1:
         raise ValueError(
@@ -182,13 +224,15 @@ def exactly_one(class_name, properties, conditionals):
     return specified_count
 
 
-def check_required(class_name, properties, conditionals):
+def check_required(
+    class_name: str, properties: Dict[str, Any], conditionals: List[Any]
+) -> None:
     for c in conditionals:
         if c not in properties:
             raise ValueError("Resource %s required in %s" % (c, class_name))
 
 
-def json_checker(prop):
+def json_checker(prop: object) -> Any:
     from .. import AWSHelperFn
 
     if isinstance(prop, str):
@@ -204,8 +248,8 @@ def json_checker(prop):
         raise TypeError("json object must be a str or dict")
 
 
-def waf_action_type(action):
+def waf_action_type(action: object) -> Literal["ALLOW", "BLOCK", "COUNT"]:
     valid_actions = ["ALLOW", "BLOCK", "COUNT"]
-    if action not in valid_actions:
-        raise ValueError('Type must be one of: "%s"' % (", ".join(valid_actions)))
-    return action
+    if action in valid_actions:
+        return action
+    raise ValueError('Type must be one of: "%s"' % (", ".join(valid_actions)))


### PR DESCRIPTION
Adds type annotations for classes and functions in (and used in) the root of the project as a first pass at adding type annotations for this project.

This also implements a type checker (pyright) that is set to `off` except for the files that were updated to include type annotations. For those files, it is set to `strict`.