### PR TITLE
Accept any sequence of resources, parameters, and outputs

### DIFF
--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -776,6 +776,7 @@ class Template:
         raise ValueError('duplicate key "%s" detected' % key)
 
     def _update(self, d: Dict[Any, Any], values: __UpdateTypeVar) -> __UpdateTypeVar:
+        assert not isinstance(values, str)
         if isinstance(values, collections.abc.Sequence) and not isinstance(values, str):
             for v in values:
                 if v.title in d:

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -18,6 +18,7 @@ from typing import (
     List,
     NoReturn,
     Optional,
+    Sequence,
     Set,
     Tuple,
     Type,
@@ -702,14 +703,19 @@ class Tags(AWSHelperFn):
         return cls(**kwargs)
 
 
-__OutputTypeVar = TypeVar("__OutputTypeVar", "Output", List["Output"])
-__ParameterTypeVar = TypeVar("__ParameterTypeVar", "Parameter", List["Parameter"])
+__OutputTypeVar = TypeVar("__OutputTypeVar", "Output", Sequence["Output"])
+__ParameterTypeVar = TypeVar("__ParameterTypeVar", "Parameter", Sequence["Parameter"])
 __ResourceTypeVar = TypeVar(
-    "__ResourceTypeVar", bound=Union[BaseAWSObject, List[BaseAWSObject]]
+    "__ResourceTypeVar", bound=Union[BaseAWSObject, Sequence[BaseAWSObject]]
 )
 __UpdateTypeVar = TypeVar(
     "__UpdateTypeVar",
-    bound=Union[BaseAWSObject, List[BaseAWSObject], List["Output"], List["Parameter"]],
+    bound=Union[
+        BaseAWSObject,
+        Sequence[BaseAWSObject],
+        Sequence["Output"],
+        Sequence["Parameter"],
+    ],
 )
 
 
@@ -770,7 +776,7 @@ class Template:
         raise ValueError('duplicate key "%s" detected' % key)
 
     def _update(self, d: Dict[Any, Any], values: __UpdateTypeVar) -> __UpdateTypeVar:
-        if isinstance(values, list):
+        if isinstance(values, collections.abc.Sequence) and not isinstance(values, str):
             for v in values:
                 if v.title in d:
                     self.handle_duplicate_key(v.title)


### PR DESCRIPTION
When type checking the code below against troposphere 4.0.1, mypy complains about:

```
example.py:28: error: Value of type variable "__ResourceTypeVar" of "broken_bound" cannot be "List[AWSObject]"  [type-var]
example.py:29: error: Value of type variable "__ResourceTypeVarNotBound" of "broken_not_bound" cannot be "List[AWSObject]"  [type-var]
```

For `works(resource: List[BaseAWSObject])`, mypy is able to infer the correct type, but it fails when a TypeVar is used.  I'm not using pyright and therefore cannot say if it has the same problem.

We could use `@overload` instead of `TypeVar` to help mypy infer the correct type.

Using neither a `TypeVar` nor `@overload` isn't an option, because it would not annotate that `add_X` returns the same type it received.

Note that with this change any `Sequence[X]` is accepted and processed and not just `List[X]`.

```python
from typing import List, Sequence, TypeVar, Union

from troposphere import BaseAWSObject
from troposphere.sns import Topic
from troposphere.s3 import Bucket

__ResourceTypeVar = TypeVar(
    "__ResourceTypeVar", bound=Union[BaseAWSObject, List[BaseAWSObject]]
)

__ResourceTypeVarNotBound = TypeVar(
    "__ResourceTypeVarNotBound", BaseAWSObject, List[BaseAWSObject]
)

__ResourceTypeVarWorks = TypeVar(
    "__ResourceTypeVarWorks", bound=Union[BaseAWSObject, Sequence[BaseAWSObject]]
)

__ResourceTypeVarNotBoundWorks = TypeVar(
    "__ResourceTypeVarNotBoundWorks", BaseAWSObject, Sequence[BaseAWSObject]
)

def main() -> None:
    topic = Topic("Topic")
    bucket = Bucket("Bucket")
    broken_bound([topic, bucket])  # line 28
    broken_not_bound([topic, bucket])  # line 29

    works([topic, bucket])
    works_bound([topic, bucket])
    works_not_bound([topic, bucket])

def broken_bound(resources: __ResourceTypeVar) -> None:
    pass

def broken_not_bound(resources: __ResourceTypeVarNotBound) -> None:
    pass

def works(resource: List[BaseAWSObject]) -> None:
    pass

def works_bound(resources: __ResourceTypeVarWorks) -> None:
    pass

def works_not_bound(resources: __ResourceTypeVarNotBoundWorks) -> None:
    pass
```