### PR TITLE
#2038 Add support for additional Flink runtime environments

### DIFF
--- a/troposphere/validators/kinesisanalyticsv2.py
+++ b/troposphere/validators/kinesisanalyticsv2.py
@@ -11,11 +11,11 @@ def validate_runtime_environment(runtime_environment):
     """
 
     VALID_RUNTIME_ENVIRONMENTS = (
-        "SQL-1_0",
         "FLINK-1_6",
         "FLINK-1_8",
         "FLINK-1_11",
         "FLINK-1_13",
+        "SQL-1_0",
         "ZEPPELIN-FLINK-1_0",
         "ZEPPELIN-FLINK-2_0",
     )


### PR DESCRIPTION
Kinesis Data Analytics now supports additional Flink runtimes, see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalyticsv2-application.html

This PR adds support for  FLINK-1_13, ZEPPELIN-FLINK-1_0 and ZEPPELIN-FLINK-2_0.

Fix #2038