### PR TITLE
Allow json/yaml strings for SSM Document.Content property

### DIFF
--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -1,0 +1,19 @@
+import unittest
+
+from troposphere.ssm import Document
+
+
+class TestQueue(unittest.TestCase):
+    def test_Document(self):
+        # dict
+        Document("title", Content={"foo": "bar"}).validate()
+        # Valid yaml and json
+        Document("title", Content='{"foo": "bar"}').validate()
+        Document("title", Content="{foo: bar}").validate()
+        # Invalid json/yaml
+        with self.assertRaises(ValueError):
+            Document("title", Content="*foo").validate()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/troposphere/ssm.py
+++ b/troposphere/ssm.py
@@ -14,6 +14,7 @@ from .validators.ssm import (
     notification_type,
     operating_system,
     task_type,
+    validate_document_content,
     validate_json_checker,
     validate_s3_bucket_name,
 )
@@ -112,7 +113,7 @@ class Document(AWSObject):
 
     props: PropsDictType = {
         "Attachments": ([AttachmentsSource], False),
-        "Content": (dict, True),
+        "Content": (validate_document_content, True),
         "DocumentFormat": (str, False),
         "DocumentType": (str, False),
         "Name": (str, False),

--- a/troposphere/validators/ssm.py
+++ b/troposphere/validators/ssm.py
@@ -7,6 +7,38 @@
 from . import json_checker, s3_bucket_name
 
 
+def validate_document_content(x):
+    """
+    Property: Document.Content
+    """
+
+    def check_json(x):
+        import json
+
+        try:
+            json.loads(x)
+            return True
+        except json.decoder.JSONDecodeError:
+            return False
+
+    def check_yaml(x):
+        import yaml
+
+        try:
+            yaml.safe_load(x)
+            return True
+        except yaml.composer.ComposerError:
+            return False
+
+    if isinstance(x, dict):
+        return x
+
+    if check_json(x) or check_yaml(x):
+        return x
+
+    raise ValueError("Content must be one of dict or json/yaml string")
+
+
 def validate_json_checker(x):
     """
     Property: MaintenanceWindowLambdaParameters.Payload


### PR DESCRIPTION
Fixes #2053

@pmau could you review and verify this fixes your use case?