### PR TITLE
Add support for list types and validator functions in GlobalsHelperFn type check

### DIFF
--- a/tests/test_serverless.py
+++ b/tests/test_serverless.py
@@ -432,9 +432,21 @@ class TestServerless(unittest.TestCase):
         t.to_json()
 
         with self.assertRaises(AttributeError):
-            _ = Globals(Unexpected="blah")
+            Globals(Unexpected="blah")
         with self.assertRaises(TypeError):
-            _ = Globals(Function="not FunctionGlobals")
+            Globals(Function="not FunctionGlobals")
+
+        # Assert list types are validated correctly
+        FunctionGlobals(Layers=["test"])
+        with self.assertRaises(TypeError):
+            FunctionGlobals(Layers="not a list")
+        with self.assertRaises(TypeError):
+            FunctionGlobals(Layers=[1, 2, 3])
+
+        # Assert function validators work as intended
+        FunctionGlobals(MemorySize=128)
+        with self.assertRaises(ValueError):
+            FunctionGlobals(MemorySize=64)
 
 
 if __name__ == "__main__":

--- a/tests/test_serverless.py
+++ b/tests/test_serverless.py
@@ -431,9 +431,9 @@ class TestServerless(unittest.TestCase):
         )
         t.to_json()
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(AttributeError):
             _ = Globals(Unexpected="blah")
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             _ = Globals(Function="not FunctionGlobals")
 
 

--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -656,31 +656,7 @@ class Application(AWSObject):
         mutually_exclusive(self.__class__.__name__, self.properties, conds)
 
 
-class GlobalsHelperFn(AWSHelperFn):
-    def __init__(self, **kwargs):
-        remaining_kwargs = kwargs.copy()
-        for k, (key_type, required) in self.props.items():
-            if k in kwargs:
-                kwarg_value = remaining_kwargs.pop(k)
-                if not isinstance(kwarg_value, key_type):
-                    raise ValueError(
-                        f"Provided {self.__class__.__name__} property '{k}' is of type {type(kwarg_value)} instead of expected {key_type}"
-                    )
-            elif required:
-                raise ValueError(
-                    f"Required {self.__class__.__name__} property '{k}' not provided"
-                )
-
-        if remaining_kwargs:
-            unexpected_properties = [f"'{k}'" for k in remaining_kwargs.keys()]
-            raise ValueError(
-                f"Unexpected {self.__class__.__name__} properties provided: {unexpected_properties}"
-            )
-
-        self.data = kwargs
-
-
-class FunctionGlobals(GlobalsHelperFn):
+class FunctionGlobals(AWSProperty):
     props: PropsDictType = {
         "AssumeRolePolicyDocument": (policytypes, False),
         "AutoPublishAlias": (str, False),
@@ -706,7 +682,7 @@ class FunctionGlobals(GlobalsHelperFn):
     }
 
 
-class ApiGlobals(GlobalsHelperFn):
+class ApiGlobals(AWSProperty):
     props: PropsDictType = {
         "AccessLogSetting": (AccessLogSetting, False),
         "Auth": (Auth, False),
@@ -727,7 +703,7 @@ class ApiGlobals(GlobalsHelperFn):
     }
 
 
-class HttpApiGlobals(GlobalsHelperFn):
+class HttpApiGlobals(AWSProperty):
     props: PropsDictType = {
         "AccessLogSettings": (AccessLogSettings, False),
         "Auth": (HttpApiAuth, False),
@@ -736,13 +712,13 @@ class HttpApiGlobals(GlobalsHelperFn):
     }
 
 
-class SimpleTableGlobals(GlobalsHelperFn):
+class SimpleTableGlobals(AWSProperty):
     props: PropsDictType = {
         "SSESpecification": (SSESpecification, False),
     }
 
 
-class Globals(GlobalsHelperFn):
+class Globals(AWSProperty):
     """Supported Globals properties.
 
     See: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-specification-template-anatomy-globals.html


### PR DESCRIPTION
Closes #2063

I tried extracting the  function to `troposhpere.validators.__init__.py` as it made more sense to have it there, but its dependence on `AWSHelperFn` created a circular import with `troposhpere.__init__.py`. Fixing that would require picking apart the entire `troposhpere.__init__.py` file.