### PR TITLE
Add a simple test for the new AWS::LanguageExtensions transform

### DIFF
--- a/tests/test_language_extensions.py
+++ b/tests/test_language_extensions.py
@@ -1,0 +1,68 @@
+import unittest
+
+from troposphere import AWSHelperFn, Parameter, Template
+from troposphere.sqs import Queue
+
+
+class TestServerless(unittest.TestCase):
+    def test_transform(self):
+        t = Template()
+        t.set_version("2010-09-09")
+        t.set_transform("AWS::LanguageExtensions")
+
+        self.assertEqual(
+            t.to_dict(),
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Transform": "AWS::LanguageExtensions",
+                "Resources": {},
+            },
+        )
+
+    def test_length_function(self):
+        class Length(AWSHelperFn):
+            def __init__(self, data: object) -> None:
+                self.data = {"Fn::Length": data}
+
+        t = Template()
+        t.set_version("2010-09-09")
+        t.set_transform("AWS::LanguageExtensions")
+
+        queue_list = t.add_parameter(Parameter("QueueList", Type="CommaDelimitedList"))
+        queue_name = t.add_parameter(
+            Parameter(
+                "QueueNameParam", Description="Name for your SQS queue", Type="String"
+            )
+        )
+
+        t.add_resource(
+            Queue(
+                "Queue",
+                QueueName=queue_name.ref(),
+                DelaySeconds=Length(queue_list.ref()),
+            )
+        )
+
+        self.assertEqual(
+            t.to_dict(),
+            {
+                "AWSTemplateFormatVersion": "2010-09-09",
+                "Transform": "AWS::LanguageExtensions",
+                "Parameters": {
+                    "QueueList": {"Type": "CommaDelimitedList"},
+                    "QueueNameParam": {
+                        "Description": "Name for your SQS queue",
+                        "Type": "String",
+                    },
+                },
+                "Resources": {
+                    "Queue": {
+                        "Type": "AWS::SQS::Queue",
+                        "Properties": {
+                            "QueueName": {"Ref": "QueueNameParam"},
+                            "DelaySeconds": {"Fn::Length": {"Ref": "QueueList"}},
+                        },
+                    }
+                },
+            },
+        )


### PR DESCRIPTION
See https://aws.amazon.com/about-aws/whats-new/2022/09/aws-cloudformation-new-language-extensions-transform/

I've take the example from https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-languageextension-transform.html to see if that works.

At least the combination of `AWS::LanguageExtensions` with the `AWS::Serverless` transform and globals needs a bit of work.  The globals checks don't work with multiple transforms.  https://github.com/cloudtools/troposphere/blob/759496c4d2ed3fec6fcb7315b98fa9bf7e2335b2/troposphere/__init__.py#L834-L850