### PR TITLE
Remove valid replication attribute `BackupRetentionPeriod` on `SourceDBInstanceIdentifier` instances

### DIFF
--- a/troposphere/validators/rds.py
+++ b/troposphere/validators/rds.py
@@ -275,7 +275,6 @@ def validate_dbinstance(self) -> None:
     if "SourceDBInstanceIdentifier" in self.properties:
 
         invalid_replica_properties = (
-            "BackupRetentionPeriod",
             "DBName",
             "MasterUsername",
             "MasterUserPassword",


### PR DESCRIPTION
I cannot enable log retention on an RDS instance that is confirmed as a Read Replica using the `SourceDBInstanceIdentifier` due to a troposphere error. 

##### Error message

```
ValueError: BackupRetentionPeriod properties can't be provided when SourceDBInstanceIdentifier is present AWS::RDS::DBInstance.
```

When attempting to turn on retention to enable binlog replication to a 3rd party (non-aws resource), AWS support states that I must enable the `BackupRetentionPeriod` attribute on my RDS instance that is using the `SourceDBInstanceIdentifier` attribute.

Troposphere has a validation check that incorrectly asserts that `BackupRetentionPeriod` is not a valid property, while I can push this Cloudformation configuration to my AWS environment:

```
"exampleRDSInstance": {
  "Properties": {
    "AllocatedStorage": "4000",
    "AllowMajorVersionUpgrade": false,
    "AutoMinorVersionUpgrade": true,
    "CopyTagsToSnapshot": true,
    "DBInstanceClass": "db.m6i.large",
    "DBInstanceIdentifier": "omitted-rr",
    "DBParameterGroupName": {
      "Ref": "omitted"
    },
    "Engine": "mysql",
    "EngineVersion": "8.0.28",
    "Iops": 15000,
    "LicenseModel": "general-public-license",
    "Port": "3306",
    "BackupRetentionPeriod": "7",
    "PreferredMaintenanceWindow": "wed:09:02-wed:09:32",
    "SourceDBInstanceIdentifier": {
      "Fn::ImportValue": "omitted"
    },
    "StorageEncrypted": true,
    "StorageType": "io1",
    "Tags": [omitted]
  },
  "Type": "AWS::RDS::DBInstance"
},
```

This pull request removes the invalid assertion that `BackupRetentionPeriod` is not compatible with `SourceDBInstanceIdentifier`.

[Documentation does not state this as an incompatible attribute.](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbinstance.html#cfn-rds-dbinstance-sourcedbinstanceidentifier)

> Don't set the BackupRetentionPeriod, DBName, MasterUsername, MasterUserPassword, and PreferredBackupWindow properties. The database attributes are inherited from the source DB instance, and backups are disabled for read replicas.