### PR TITLE
Allow setting hosted elasticsearch volume_types to gp3

### DIFF
--- a/troposphere/validators/elasticsearch.py
+++ b/troposphere/validators/elasticsearch.py
@@ -35,7 +35,7 @@ def validate_volume_type(volume_type):
     Property: EBSOptions.VolumeType
     """
 
-    VALID_VOLUME_TYPES = ("standard", "gp2", "io1")
+    VALID_VOLUME_TYPES = ("standard", "gp2", "gp3", "io1")
 
     if volume_type not in VALID_VOLUME_TYPES:
         raise ValueError(


### PR DESCRIPTION
Referenced https://aws.amazon.com/about-aws/whats-new/2022/07/amazon-opensearch-service-support-ebs-gp3-volume-type/