### PR TITLE
Switched ApiGatewayV2 Stage resource props to show tag as a dict inst…

### DIFF
--- a/troposphere/apigatewayv2.py
+++ b/troposphere/apigatewayv2.py
@@ -17,7 +17,6 @@ from .validators.apigatewayv2 import (
     validate_logging_level,
     validate_model,
     validate_passthrough_behavior,
-    validate_tags_or_list,
     validate_timeout_in_millis,
 )
 
@@ -397,7 +396,7 @@ class Stage(AWSObject):
         "RouteSettings": (dict, False),
         "StageName": (str, True),
         "StageVariables": (dict, False),
-        "Tags": (validate_tags_or_list, False),
+        "Tags": (dict, False),
     }
 
 

--- a/troposphere/validators/apigatewayv2.py
+++ b/troposphere/validators/apigatewayv2.py
@@ -59,7 +59,7 @@ def validate_logging_level(logging_level):
     Property: RouteSettings.LoggingLevel
     """
 
-    valid_logging_levels = ["WARN", "INFO", "DEBUG"]
+    valid_logging_levels = ["INFO", "ERROR", "OFF"]
     if logging_level not in valid_logging_levels:
         raise ValueError("{} is not a valid LoggingLevel".format(logging_level))
     return logging_level


### PR DESCRIPTION
…ead of validator, and also updated LogLevels to match CloudFormation/Boto3 definition of LogLevels.   Note the 'Tags' fix to the Stage resource just echos what VpcLink currently does for Tags.