### PR TITLE
Add support for Flink 1.15 runtime environment 

### DIFF
--- a/troposphere/validators/kinesisanalyticsv2.py
+++ b/troposphere/validators/kinesisanalyticsv2.py
@@ -15,6 +15,7 @@ def validate_runtime_environment(runtime_environment):
         "FLINK-1_8",
         "FLINK-1_11",
         "FLINK-1_13",
+        "FLINK-1_15",
         "SQL-1_0",
         "ZEPPELIN-FLINK-1_0",
         "ZEPPELIN-FLINK-2_0",


### PR DESCRIPTION
Kinesis Data Analytics now supports Flink 1.15 runtime, see 
https://docs.aws.amazon.com/kinesisanalytics/latest/java/flink-1-15-2.html and https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalyticsv2-application.html#cfn-kinesisanalyticsv2-application-runtimeenvironment


This PR adds support for FLINK-1_15 runtime.

Fix https://github.com/cloudtools/troposphere/issues/2105