### PR TITLE
Be more lenient about types for Export

### DIFF
--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -954,7 +954,7 @@ class Template:
 
 
 class Export(AWSHelperFn):
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: Union[str, AWSHelperFn]) -> None:
         self.data = {
             "Name": name,
         }


### PR DESCRIPTION
My use case is something like

```python
  t.add_output([
    Output(
      ...,
      Export=Export(Join(":", ["some", "stuff"]))
    )
  ])
```