### PR TITLE
support for FilterPolicyScope on the sns topic subscription

### DIFF
--- a/troposphere/sns.py
+++ b/troposphere/sns.py
@@ -22,6 +22,7 @@ class SubscriptionResource(AWSObject):
         "DeliveryPolicy": (dict, False),
         "Endpoint": (str, False),
         "FilterPolicy": (dict, False),
+        "FilterPolicyScope": (str, False)
         "Protocol": (str, True),
         "RawMessageDelivery": (boolean, False),
         "RedrivePolicy": (dict, False),

--- a/troposphere/sns.py
+++ b/troposphere/sns.py
@@ -22,7 +22,7 @@ class SubscriptionResource(AWSObject):
         "DeliveryPolicy": (dict, False),
         "Endpoint": (str, False),
         "FilterPolicy": (dict, False),
-        "FilterPolicyScope": (str, False)
+        "FilterPolicyScope": (str, False),
         "Protocol": (str, True),
         "RawMessageDelivery": (boolean, False),
         "RedrivePolicy": (dict, False),


### PR DESCRIPTION
This is will add the new `FilterPolicyScope(string)` which can be used on the sns to filter on message_attributes or message_body.

https://docs.aws.amazon.com/sns/latest/dg/sns-message-filtering.html#sns-message-filtering-scope