### PR TITLE
Modify `SourceDBInstanceIdentifier` validator to allow `BackupRetentionPeriod`

### DIFF
--- a/troposphere/validators/rds.py
+++ b/troposphere/validators/rds.py
@@ -275,7 +275,6 @@ def validate_dbinstance(self) -> None:
     if "SourceDBInstanceIdentifier" in self.properties:
 
         invalid_replica_properties = (
-            "BackupRetentionPeriod",
             "DBName",
             "MasterUsername",
             "MasterUserPassword",


### PR DESCRIPTION
We use a read-replica MySQL instance to ingest data utilizing a SaaS vendor.

This SaaS vendor requires binary logging on the read-replica instance to enable the replication of data from the RR. When using CloudFormation, without the `BackupRetentionPeriod`, binary logging is disabled on the read-replica instance. 

To enable binlogging using the current version of troposphere, a console change must be made post deployment, or an aws-cli call to enable backup retention from a non-zero value, due to incorrect `invalid_replica_properties`.

This is not ideal because any subsequent CloudFormation changes will revert this to a 0 value, breaking binlog configuration. This change is to be able to enable binary logging with CloudFormation. 

AWS Documentation [here](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.MySQL.BinaryFormat.html) validates that to enable binary logging, backup retention must be set to a non-zero value.

![image](https://user-images.githubusercontent.com/21163004/214390487-5c4760c2-1b7f-4e71-aafd-07301dad3c86.png)


I have tested this in a sandbox environment using CloudFormation with MySQL RDS (non-Aurora) and demonstrated it is a possible, usable parameter as indicated in the screenshots below.

![image](https://user-images.githubusercontent.com/21163004/214390307-6d54398c-6fd0-48a6-9e5e-642791467d86.png)


![image](https://user-images.githubusercontent.com/21163004/214390432-8537c6f4-7d67-40da-96bb-68cdb2321bfa.png)
