### PR TITLE
Add validator for AWS::RDS::DBCluster.ServerlessV2ScalingConfiguration

### DIFF
--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -341,3 +341,16 @@ class TestRDSValidators(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             vrds.validate_capacity(100001)
+
+    def test_v2_validate_capacity(self):
+        vrds.validate_v2_capacity(64)
+        vrds.validate_v2_capacity(0.5)
+
+        with self.assertRaises(ValueError):
+            vrds.validate_v2_capacity(129)
+
+        with self.assertRaises(ValueError):
+            vrds.validate_v2_capacity(1.1)
+
+        with self.assertRaises(ValueError):
+            vrds.validate_v2_max_capacity(0.5)

--- a/troposphere/rds.py
+++ b/troposphere/rds.py
@@ -7,7 +7,7 @@
 
 
 from . import AWSObject, AWSProperty, PropsDictType, Tags
-from .validators import boolean, double, integer
+from .validators import boolean, integer
 from .validators.rds import (
     validate_backtrack_window,
     validate_backup_retention_period,
@@ -21,6 +21,8 @@ from .validators.rds import (
     validate_network_port,
     validate_str_or_int,
     validate_tags_or_list,
+    validate_v2_capacity,
+    validate_v2_max_capacity,
 )
 
 
@@ -67,8 +69,8 @@ class ServerlessV2ScalingConfiguration(AWSProperty):
     """
 
     props: PropsDictType = {
-        "MaxCapacity": (double, False),
-        "MinCapacity": (double, False),
+        "MaxCapacity": (validate_v2_max_capacity, False),
+        "MinCapacity": (validate_v2_capacity, False),
     }
 
 

--- a/troposphere/validators/rds.py
+++ b/troposphere/validators/rds.py
@@ -262,6 +262,49 @@ def validate_capacity(capacity):
     return capacity
 
 
+def validate_v2_capacity(capacity):
+    """
+    Validate ServerlessV2ScalingConfiguration capacity for serverless DBCluster
+    Property: ServerlessV2ScalingConfiguration.MinCapacity
+    """
+    if capacity < 0.5:
+        raise ValueError(
+            "ServerlessV2ScalingConfiguration capacity {} cannot be smaller than 0.5.".format(
+                capacity
+            )
+        )
+    if capacity > 128:
+        raise ValueError(
+            "ServerlessV2ScalingConfiguration capacity {} cannot be larger than 128.".format(
+                capacity
+            )
+        )
+
+    if capacity * 10 % 5 != 0:
+        raise ValueError(
+            "ServerlessV2ScalingConfiguration capacity {} cannot be only specific in half-step increments.".format(
+                capacity
+            )
+        )
+
+    return capacity
+
+
+def validate_v2_max_capacity(capacity):
+    """
+    Validate ServerlessV2ScalingConfiguration max capacity for serverless DBCluster
+    Property: ServerlessV2ScalingConfiguration.MaxCapacity
+    """
+    if capacity < 1:
+        raise ValueError(
+            "ServerlessV2ScalingConfiguration max capacity {} cannot be smaller than 1.".format(
+                capacity
+            )
+        )
+
+    return validate_v2_capacity(capacity)
+
+
 def validate_dbinstance(self) -> None:
     """
     Class: DBInstance


### PR DESCRIPTION
I run the `make regen` and commit the file. Not sure if it is needed or not.