### PR TITLE
Add ApiFunctionAuth serverless class for Api Function events

### DIFF
--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -583,6 +583,16 @@ class DynamoDBEvent(AWSObject):
     }
 
 
+class ApiFunctionAuth(AWSProperty):
+    props: PropsDictType = {
+        "ApiKeyRequired": (bool, False),
+        "AuthorizationScopes": (list, False),
+        "Authorizer": (str, False),
+        "InvokeRole": (str, False),
+        "ResourcePolicy": (ResourcePolicyStatement, False),
+    }
+
+
 class RequestModel(AWSProperty):
     props: PropsDictType = {
         "Model": (str, True),
@@ -596,7 +606,7 @@ class ApiEvent(AWSObject):
     resource_type = "Api"
 
     props: PropsDictType = {
-        "Auth": (Auth, False),
+        "Auth": (ApiFunctionAuth, False),
         "Path": (str, True),
         "Method": (str, True),
         "RequestModel": (RequestModel, False),


### PR DESCRIPTION
Api Function Auth follows a different structure from Api Auth and thus should not re-use the same class.
Previously used https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-api-apiauth.html versus intended https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-function-apifunctionauth.html.

This PR fixes this discrepancy.
Fixes #2144