### PR TITLE
TypeError() return the expected Class as last exception argument

### DIFF
--- a/troposphere/validators/iottwinmaker.py
+++ b/troposphere/validators/iottwinmaker.py
@@ -12,11 +12,11 @@ def validate_listvalue(values):
     from ..iottwinmaker import DataValue
 
     if not isinstance(values, list):
-        raise TypeError("ListValue must be a list")
+        raise TypeError("ListValue must be a list", list)
 
     for v in values:
         if not isinstance(v, (DataValue, AWSHelperFn)):
-            raise TypeError("ListValue must contain DataValue or AWSHelperFn")
+            raise TypeError("ListValue must contain DataValue or AWSHelperFn", AWSHelperFn, DataValue)
 
 
 def validate_nestedtypel(value):
@@ -27,4 +27,4 @@ def validate_nestedtypel(value):
     from ..iottwinmaker import DataType
 
     if not isinstance(value, (DataType, AWSHelperFn)):
-        raise TypeError("NestedType must be either DataType or AWSHelperFn")
+        raise TypeError("NestedType must be either DataType or AWSHelperFn", AWSHelperFn, DataType)

--- a/troposphere/validators/wafv2.py
+++ b/troposphere/validators/wafv2.py
@@ -18,7 +18,7 @@ def validate_statement(statement):
     from ..wafv2 import Statement
 
     if not isinstance(statement, (Statement, AWSHelperFn)):
-        raise TypeError(f"{statement} is not a valid Statement")
+        raise TypeError(f"{statement} is not a valid Statement", Statement)
 
     return statement
 


### PR DESCRIPTION
When the validator is used instead of the AWSProperty class (i.e. in WAFv2 for `Statement`), the TypeError() will return the expected AWSProperty SubClass as the last argument. This enables other libraries to identify the expected class and perform manipulations to import the resource property class.

For simpler class types (int, str, etc.) the validators only validate that the input is of that exact type and is simpler to catch.

Went over all the validators, these are the only two with an AWSProperty type validation, for due diligence. Although only need this today with WAFv2