### PR TITLE
Support "elastic" throughput mode on AWS::EFS::FileSystem

### DIFF
--- a/troposphere/validators/efs.py
+++ b/troposphere/validators/efs.py
@@ -7,13 +7,14 @@ from . import one_of
 
 Bursting = "bursting"
 Provisioned = "provisioned"
+Elastic = "elastic"
 
 
 def throughput_mode_validator(mode):
     """
     Property: FileSystem.ThroughputMode
     """
-    valid_modes = [Bursting, Provisioned]
+    valid_modes = [Bursting, Provisioned, Elastic]
     if mode not in valid_modes:
         raise ValueError(
             'ThroughputMode must be one of: "%s"' % (", ".join(valid_modes))


### PR DESCRIPTION
Add the missing "elastic" type to EFS throughput mode validation.

See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-efs-filesystem.html#cfn-efs-filesystem-throughputmode