### PR TITLE
Remove gp3 from list of storage types that require Iops to be set for RDS

### DIFF
--- a/troposphere/validators/rds.py
+++ b/troposphere/validators/rds.py
@@ -383,10 +383,10 @@ def validate_dbinstance(self) -> None:
     storage_type = self.properties.get("StorageType", None)
     if (
         storage_type
-        and storage_type in ["io1", "gp3"]
+        and storage_type in ["io1"]
         and "Iops" not in self.properties
     ):
-        raise ValueError("Must specify Iops if using StorageType io1 or gp3")
+        raise ValueError("Must specify Iops if using StorageType io1")
 
     allocated_storage = self.properties.get("AllocatedStorage")
     iops = self.properties.get("Iops", None)


### PR DESCRIPTION
Cloudformation does not allow to set Iops for storage GP3 < 400Gib, example error:
Resource handler returned message: "You can't specify IOPS or storage throughput for engine mysql and a storage size less than 400. (Service: Rds, Status Code: 400
For <400Gib it's set automatically to 3000 and >=400 Gib is set to 12000 