### PR TITLE
Fix compile error in ec2.py

### DIFF
--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -108,3 +108,36 @@ class TestEC2(unittest.TestCase):
         )
         with self.assertRaises(ValueError):
             vpn.to_dict()
+
+    def test_vpn_conn_with_correct_props(self):
+        vpn = ec2.VPNConnection(
+            "VPNConnection",
+            StaticRoutesOnly=True,
+            TransitGatewayId="tgw-b2b86767",
+            CustomerGatewayId="cgw-0e11f167",
+            Type="ipsec.1",
+            VpnTunnelOptionsSpecifications=[
+                ec2.VpnTunnelOptionsSpecification(
+                    PreSharedKey="123_23626326236", TunnelInsideCidr="169.254.15.0/30"
+                ),
+                ec2.VpnTunnelOptionsSpecification(
+                    PreSharedKey="asdf_fds12888", TunnelInsideCidr="169.254.16.0/30"
+                ),
+            ],
+        )
+        vpn.to_dict()
+
+    def test_vpn_conn_tunnel_options_specification(self):
+        ec2.VpnTunnelOptionsSpecification(
+            PreSharedKey="12345678", TunnelInsideCidr="169.254.18.0/30"
+        )
+
+        with self.assertRaises(ValueError):
+            ec2.VpnTunnelOptionsSpecification(
+                PreSharedKey="1234567", TunnelInsideCidr="169.254.0.0/30"
+            )
+
+        with self.assertRaises(ValueError):
+            ec2.VpnTunnelOptionsSpecification(
+                PreSharedKey="0SAD_FEA_SDF", TunnelInsideCidr="192.168.16.0/30"
+            )

--- a/troposphere/validators/ec2.py
+++ b/troposphere/validators/ec2.py
@@ -3,6 +3,7 @@
 #
 # See LICENSE file for full license.
 
+import re
 
 from .. import AWSProperty
 from ..compat import validate_policytype
@@ -196,7 +197,7 @@ def vpn_pre_shared_key(key):
     """
     Property: VpnTunnelOptionsSpecification.PreSharedKey
     """
-    pre_shared_key_match_re = compile(r"^(?!0)([A-Za-z0-9]|\_|\.){8,64}$")
+    pre_shared_key_match_re = re.compile(r"^(?!0)([A-Za-z0-9]|\_|\.){8,64}$")
     if not pre_shared_key_match_re.match(key):
         raise ValueError(
             "%s is not a valid key."
@@ -220,7 +221,7 @@ def vpn_tunnel_inside_cidr(cidr):
         "169.254.5.0/30",
         "169.254.169.252/30",
     ]
-    cidr_match_re = compile(
+    cidr_match_re = re.compile(
         r"^169\.254\.(?:25[0-5]|2[0-4]\d|[01]?\d\d?)"
         r"\.(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\/30$"
     )


### PR DESCRIPTION
Fixed #2155 compile error in ec2.py
Replace the build-in compile() function with re.compile(), and add test cases.