### PR TITLE
Added tags to EventBridge (Events) Rule resource and fixed an error in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ make spec
 To generate code, the current process is roughly, scan the CloudFormation history to identify changes and then run (using S3 as an example):
 
 ```
-python3 scripts/gen.py s3 CloudFormationResourceSpecification.json > troposphere/s3.py
+python3 scripts/gen.py s3 > troposphere/s3.py
 ```
 Use the auto-formatters to clean up the generated code using:
 ```

--- a/scripts/patches/events.py
+++ b/scripts/patches/events.py
@@ -4,6 +4,15 @@ patches = [
         "path": "/ResourceTypes/AWS::Events::EventBus/Properties/Tags/ItemType",
         "value": "Tags",
     },
+    {
+        "op": "add",
+        "path": "/ResourceTypes/AWS::Events::Rule/Properties/Tags",
+        "value": {
+            "Type": "List",
+            "ItemType": "Tags",
+            "Required": False,
+        },
+    },
     # Remove unused Tag and TagEntry (remapped to troposphere Tags)
     {
         "op": "remove",

--- a/troposphere/events.py
+++ b/troposphere/events.py
@@ -535,5 +535,6 @@ class Rule(AWSObject):
         "RoleArn": (str, False),
         "ScheduleExpression": (str, False),
         "State": (str, False),
+        "Tags": (Tags, False),
         "Targets": ([Target], False),
     }


### PR DESCRIPTION
Per https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-tagging.html, only two EventBridge resources support tags:  event buses and rules.   The Troposphere EventBus resource had a field for tags, but Rules was missing it, probably because the Cloudformation Resource Specification was missing it.  This is issue https://github.com/cloudtools/troposphere/issues/2151.

This PR adds a jsonpatch to plug Tags for the Events::Rules resource into the resource specification and adds Tags to the Rules class. Also, the example for running `scripts/gen.py` included the cloudformation spec file as an argument, which causes gen.py to treat it as a service name and build a corrupted file.  This patch removes the cloudformation spec file from the example.