### PR TITLE
add all valid origin_request_policy config behaviors to validators

### DIFF
--- a/troposphere/validators/cloudfront.py
+++ b/troposphere/validators/cloudfront.py
@@ -116,7 +116,7 @@ def cloudfront_origin_request_cookie_behavior(cookie_behavior):
     """
     Property: OriginRequestCookiesConfig.CookieBehavior
     """
-    valid_values = ["none", "whitelist", "all"]
+    valid_values = ["none", "whitelist", "all", "allExcept"]
     if cookie_behavior not in valid_values:
         raise ValueError(
             'CookieBehavior must be one of: "%s"' % (", ".join(valid_values))
@@ -128,7 +128,7 @@ def cloudfront_origin_request_header_behavior(header_behavior):
     """
     Property: OriginRequestHeadersConfig.HeaderBehavior
     """
-    valid_values = ["none", "whitelist", "allViewer", "allViewerAndWhitelistCloudFront"]
+    valid_values = ["none", "whitelist", "allViewer", "allViewerAndWhitelistCloudFront", "allExcept"]
     if header_behavior not in valid_values:
         raise ValueError(
             'HeaderBehavior must be one of: "%s"' % (", ".join(valid_values))
@@ -140,7 +140,7 @@ def cloudfront_origin_request_query_string_behavior(query_string_behavior):
     """
     Property: OriginRequestQueryStringsConfig.QueryStringBehavior
     """
-    valid_values = ["none", "whitelist", "all"]
+    valid_values = ["none", "whitelist", "all", "allExcept"]
     if query_string_behavior not in valid_values:
         raise ValueError(
             'QueryStringBehavior must be one of: "%s"' % (", ".join(valid_values))


### PR DESCRIPTION
"allExcept" is a valid behavior for the query_string/cookies/header config in AWS but is not allowed by the troposphere validators

Headers Config:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-originrequestpolicy-headersconfig.html#cfn-cloudfront-originrequestpolicy-headersconfig-headerbehavior

Cookies Config:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-originrequestpolicy-cookiesconfig.html#cfn-cloudfront-originrequestpolicy-cookiesconfig-cookiebehavior

Query Strings Config:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-originrequestpolicy-querystringsconfig.html#cfn-cloudfront-originrequestpolicy-querystringsconfig-querystringbehavior
