### PR TITLE
Update rds validator logic

### DIFF
--- a/troposphere/validators/rds.py
+++ b/troposphere/validators/rds.py
@@ -442,8 +442,9 @@ def validate_dbinstance(self) -> None:
             min_storage_size = 20
             min_iops_to_allocated_storage_ratio = 0.5
         else:
-            raise ValueError(f"StorageType gp3 is not supported for engine "
-                             f"{engine}")
+            raise ValueError(
+                f"StorageType gp3 is not supported for engine " f"{engine}"
+            )
         # Validate storage size constraints when under certain sizes
         if (
             not isinstance(allocated_storage, AWSHelperFn)
@@ -456,10 +457,13 @@ def validate_dbinstance(self) -> None:
 
         # Validate storage performance constraints for iops ratios
         if not (
-                not isinstance(allocated_storage, AWSHelperFn)
-                and not isinstance(iops, AWSHelperFn)
-                and (
-                    min_iops_to_allocated_storage_ratio < iops / int(allocated_storage) < max_iops_to_allocated_storage_ratio)
+            not isinstance(allocated_storage, AWSHelperFn)
+            and not isinstance(iops, AWSHelperFn)
+            and (
+                min_iops_to_allocated_storage_ratio
+                < iops / int(allocated_storage)
+                < max_iops_to_allocated_storage_ratio
+            )
         ):
             raise ValueError(
                 "Invalid ratio of Iops to AllocatedStorage. Minimum ratio for "

--- a/troposphere/validators/rds.py
+++ b/troposphere/validators/rds.py
@@ -368,8 +368,10 @@ def validate_dbinstance(self) -> None:
         )
 
     nonetype = type(None)
+    allocated_storage = self.properties.get("AllocatedStorage")
     avail_zone = self.properties.get("AvailabilityZone", None)
     multi_az = self.properties.get("MultiAZ", None)
+    engine = self.properties.get("Engine")
     if not (
         isinstance(avail_zone, (AWSHelperFn, nonetype))
         and isinstance(multi_az, (AWSHelperFn, nonetype))
@@ -381,18 +383,34 @@ def validate_dbinstance(self) -> None:
             )
 
     storage_type = self.properties.get("StorageType", None)
+    if storage_type and storage_type in ["io1"] and "Iops" not in self.properties:
+        raise ValueError("Must specify Iops if using StorageType io1")
+
     if (
         storage_type
-        and storage_type in ["io1", "gp3"]
-        and "Iops" not in self.properties
+        and engine in ["mariadb", "mysql", "postgres"]
+        and storage_type in ["gp3"]
+        and int(allocated_storage) < 400
+        and "Iops" in self.properties
     ):
-        raise ValueError("Must specify Iops if using StorageType io1 or gp3")
+        raise ValueError(
+            "gp3 storage cannot have Iops specified when storage is less than 400GB for mariadb, mysql, postgres"
+        )
 
-    allocated_storage = self.properties.get("AllocatedStorage")
+    if (
+        storage_type
+        and "oracle" in engine
+        and storage_type in ["gp3"]
+        and int(allocated_storage) < 200
+        and "Iops" in self.properties
+    ):
+        raise ValueError(
+            "gp3 storage cannot have Iops specified when storage is less than 200GB for oracle engine types"
+        )
+
     iops = self.properties.get("Iops", None)
     if iops and not isinstance(iops, AWSHelperFn) and storage_type not in ["gp3"]:
         min_storage_size = 100
-        engine = self.properties.get("Engine")
         if not isinstance(engine, AWSHelperFn) and engine.startswith("sqlserver"):
             min_storage_size = 20
 
@@ -411,4 +429,41 @@ def validate_dbinstance(self) -> None:
         ):
             raise ValueError(
                 "AllocatedStorage must be no less than " "1/50th the provisioned Iops"
+            )
+    if iops and not isinstance(iops, AWSHelperFn) and storage_type in ["gp3"]:
+        # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html#gp3-storage
+        min_iops_to_allocated_storage_ratio = 0.0
+        max_iops_to_allocated_storage_ratio = 500.0
+        if engine in ["mariadb", "mysql", "postgres"]:
+            min_storage_size = 400
+        elif "oracle" in engine:
+            min_storage_size = 200
+        elif "sqlserver" in engine:
+            min_storage_size = 20
+            min_iops_to_allocated_storage_ratio = 0.5
+        else:
+            raise ValueError(f"StorageType gp3 is not supported for engine "
+                             f"{engine}")
+        # Validate storage size constraints when under certain sizes
+        if (
+            not isinstance(allocated_storage, AWSHelperFn)
+            and int(allocated_storage) < min_storage_size
+        ):
+            raise ValueError(
+                f"AllocatedStorage must be at least {min_storage_size} when "
+                "Iops is set."
+            )
+
+        # Validate storage performance constraints for iops ratios
+        if not (
+                not isinstance(allocated_storage, AWSHelperFn)
+                and not isinstance(iops, AWSHelperFn)
+                and (
+                    min_iops_to_allocated_storage_ratio < iops / int(allocated_storage) < max_iops_to_allocated_storage_ratio)
+        ):
+            raise ValueError(
+                "Invalid ratio of Iops to AllocatedStorage. Minimum ratio for "
+                f"engine {engine} is {min_iops_to_allocated_storage_ratio} "
+                f"and maximum ratio is {max_iops_to_allocated_storage_ratio}"
+                f"current value is {iops / int(allocated_storage)}"
             )


### PR DESCRIPTION
Troposphere has a new validator released in 4.3.1 that does not allow omitting the `Iops` attribute when gp3 and small StorageType parameters are passed. 

If we passed `Iops` to an instance under 400GB, with EngineType = mysql, postgres, mariadb; deploying CFN will provide the following deployment error:


```
2023-07-27T13:15:27.261000+00:00 CREATE_FAILED (AWS::RDS::DBInstance) testrds Resource handler returned message: "You can't specify IOPS or storage throughput for engine mysql and a storage size less than 400. (Service: Rds, Status Code: 400, Request ID: omitted)" (RequestToken: omitted, HandlerErrorCode: InvalidRequest)
2023-07-27T13:15:28.148000+00:00 CREATE_FAILED (AWS::IAM::Role) role Resource creation cancelled
2023-07-27T13:15:28.592000+00:00 ROLLBACK_IN_PROGRESS (AWS::CloudFormation::Stack) dev-omitted-rds The following resource(s) failed to create: [role, testrds]. Rollback requested by user.
```

Documentation [here](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html#gp3-storage) outlines the possible combinations of parameters related to GP3, EngineType, and conditional values/requirements. 

![image](https://github.com/cloudtools/troposphere/assets/21163004/af18a5d4-4a6d-4236-84dc-99c0e54a3d87)


Reviewing [CloudFormation documentation here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbinstance.html#cfn-rds-dbinstance-iops) states that IOPS is only required for `io1`.

> Note
If you specify io1 for the StorageType property, then you must also specify the Iops property.

This PR updates validation logic to allow small storage RDS instances backed by GP3 to be launched with a valid configuration values as per the above linked documentation. 


Edit post submittal:

Summary of refspec ride-along changes/fixes:
- update gen.py not to suffer recursion of EvaluationForm resource infinintely. Used same method as outlined in `scripts/gen.py` for wafv2
- Patch connect resources to change type to fix out of order circular dependency issues
- Migrate FSX fix patch from s3 file to FSX file
- Update S3 patching to accept `Encryption` Type
- Update Sagemaker patches that were removed in latest refspec
- Remove invalid S3 transfer ItemType. 
- Make refspec, and regen 

