### PR TITLE
Adding Runtime option in JobCommand for updated CloudFormation config

### DIFF
--- a/troposphere/glue.py
+++ b/troposphere/glue.py
@@ -414,6 +414,7 @@ class JobCommand(AWSProperty):
         "Name": (str, False),
         "PythonVersion": (str, False),
         "ScriptLocation": (str, False),
+        "Runtime": (str, False)
     }
 
 


### PR DESCRIPTION
Link:
https://docs.aws.amazon.com/glue/latest/webapi/API_JobCommand.html

Currently Ray runtime option specification is not possible in Troposphere and adding the option can enable the same.