### PR TITLE
Fix LaunchTemplateData NetworkInterfaces argument type

### DIFF
--- a/troposphere/ec2.py
+++ b/troposphere/ec2.py
@@ -1483,7 +1483,7 @@ class LaunchTemplateData(AWSProperty):
         "MaintenanceOptions": (MaintenanceOptions, False),
         "MetadataOptions": (MetadataOptions, False),
         "Monitoring": (Monitoring, False),
-        "NetworkInterfaces": ([NetworkInterfaces], False),
+        "NetworkInterfaces": ([NetworkInterfaceProperty], False),
         "Placement": (Placement, False),
         "PrivateDnsNameOptions": (PrivateDnsNameOptions, False),
         "RamDiskId": (str, False),


### PR DESCRIPTION
LaunchTemplateData should expect a list of NetworkInterfaceProperty instead of a list of NetworkInterfaces as NetworkInterfaces argument.