### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ include = [
   "**/troposphere",
 ]
 pythonPlatform = "All"
-pythonVersion = "3.7"
+pythonVersion = "3.8"
 reportDuplicateImport = "none"
 reportImportCycles = "none"
 reportIncompatibleMethodOverride = "warning"

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -32,7 +31,6 @@ tests_require = awacs>=2.0.0
 include_package_data = true
 install_requires =
     cfn_flip >= 1.0.2
-    typing-extensions >= 3.7.4.3; python_version < "3.8"
 packages =
     troposphere
     troposphere.openstack
@@ -42,7 +40,7 @@ packages =
 scripts =
     scripts/cfn
     scripts/cfn2py
-python_requires = >=3.7.0
+python_requires = >=3.8
 zip_safe = false
 
 [options.extras_require]

--- a/troposphere/type_defs/compat.py
+++ b/troposphere/type_defs/compat.py
@@ -2,9 +2,4 @@
 # flake8: noqa
 from __future__ import annotations
 
-import sys
-
-if sys.version_info < (3, 8):  # 3.7
-    from typing_extensions import Final, Literal, Protocol, SupportsIndex
-else:
-    from typing import Final, Literal, Protocol, SupportsIndex
+from typing import Final, Literal, Protocol, SupportsIndex


### PR DESCRIPTION
Python 3.7 reached its EOL on 2023-06-27, see https://peps.python.org/pep-0537/#lifespan

Python 3.7 was removed from the test matrix in commit bf8730b9a4307ee3e75f05d95c2ccdc23078a6ba.