### PR TITLE
Add support for ManageMasterUserPassword

### DIFF
--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -47,6 +47,24 @@ class TestRDS(unittest.TestCase):
         ):
             rds_instance.to_dict()
 
+    def test_it_rds_credentials_using_masteruserpassword(self):
+        rds_instance = rds.DBInstance(
+            "SomeTitle",
+            Engine="MySQL",
+            MasterUsername="user",
+            MasterUserPassword="password",
+        )
+        rds_instance.to_dict()
+
+    def test_it_rds_credentials_using_managemasteruserpassword(self):
+        rds_instance = rds.DBInstance(
+            "SomeTitle",
+            Engine="MySQL",
+            MasterUsername="user",
+            ManageMasterUserPassword=True
+        )
+        rds_instance.to_dict()
+
     def test_it_rds_masteruserpassword_and_managemasteruserpassword_mutually_exclusive(self):
         rds_instance = rds.DBInstance(
             "SomeTitle",

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -47,6 +47,21 @@ class TestRDS(unittest.TestCase):
         ):
             rds_instance.to_dict()
 
+    def test_it_rds_masteruserpassword_and_managemasteruserpassword_mutually_exclusive(self):
+        rds_instance = rds.DBInstance(
+            "SomeTitle",
+            Engine="MySQL",
+            MasterUsername="user",
+            MasterUserPassword="password",
+            ManageMasterUserPassword=True
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"Both MasterUserPassword and ManageMasterUserPassword cannot be set simultaneously.",
+        ):
+            rds_instance.to_dict()
+
     def test_it_allows_an_rds_replica(self):
         rds_instance = rds.DBInstance(
             "SomeTitle",

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -41,7 +41,8 @@ class TestRDS(unittest.TestCase):
 
         with self.assertRaisesRegex(
             ValueError,
-            r"Either \(MasterUsername and MasterUserPassword\) or"
+            r"Either \(MasterUsername and either "
+            r"MasterUserPassword or ManageMasterUserPassword\) or"
             r" DBSnapshotIdentifier are required",
         ):
             rds_instance.to_dict()

--- a/troposphere/validators/rds.py
+++ b/troposphere/validators/rds.py
@@ -350,12 +350,13 @@ def validate_dbinstance(self) -> None:
         )
         and (
             "MasterUsername" not in self.properties
-            or "MasterUserPassword" not in self.properties
+            or ("MasterUserPassword" not in self.properties
+                and "ManageMasterUserPassword" not in self.properties)
         )
         and ("DBClusterIdentifier" not in self.properties)
     ):
         raise ValueError(
-            r"Either (MasterUsername and MasterUserPassword) or"
+            r"Either (MasterUsername and either MasterUserPassword or ManageMasterUserPassword) or"
             r" DBSnapshotIdentifier are required in type "
             r"AWS::RDS::DBInstance."
         )

--- a/troposphere/validators/rds.py
+++ b/troposphere/validators/rds.py
@@ -361,6 +361,12 @@ def validate_dbinstance(self) -> None:
             r"AWS::RDS::DBInstance."
         )
 
+    if "MasterUserPassword" in self.properties and "ManageMasterUserPassword" in self.properties:
+        raise ValueError(
+            "Both MasterUserPassword and ManageMasterUserPassword cannot"
+            " be set simultaneously."
+        )
+
     if "KmsKeyId" in self.properties and "StorageEncrypted" not in self.properties:
         raise ValueError(
             "If KmsKeyId is provided, StorageEncrypted is required "


### PR DESCRIPTION
Alternatively, allow the use of `ManageMasterUserPassword` instead of `MasterUserPassword`. Both properties are mutually exclusive and cannot be used simultaneously.

Updated tests to validate `DBInstance` configuration