### PR TITLE
Fix __eq__ protocol

### DIFF
--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -81,6 +81,19 @@ class TestValidate(unittest.TestCase):
             template.add_mapping("mapping", {"n": "v"})
 
 
+class TypeComparator:
+    """ Helper to test the __eq__ protocol """
+
+    def __init__(self, valid_types):
+        self.valid_types = valid_types
+
+    def __eq__(self, other):
+        return isinstance(other, self.valid_types)
+
+    def __ne__(self, other):
+        return not self == other
+
+
 class TestEquality(unittest.TestCase):
     def test_eq(self):
         metadata = "foo"
@@ -98,6 +111,9 @@ class TestEquality(unittest.TestCase):
 
         self.assertEqual(t1, t2)
 
+        self.assertEqual(t1, TypeComparator(Template))
+        self.assertEqual(TypeComparator(Template), t1)
+
     def test_ne(self):
         t1 = Template(Description="foo1", Metadata="bar1")
         t1.add_resource(Bucket("Baz1"))
@@ -108,6 +124,9 @@ class TestEquality(unittest.TestCase):
         t2.add_output(Output("qux2", Value="qux2"))
 
         self.assertNotEqual(t1, t2)
+
+        self.assertNotEqual(t1, TypeComparator(Output))
+        self.assertNotEqual(TypeComparator(Output), t1)
 
     def test_hash(self):
         metadata = "foo"

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -420,7 +420,7 @@ class BaseAWSObject:
             return self.title == other.title and self.to_json() == other.to_json()
         if isinstance(other, dict):
             return {"title": self.title, **self.to_dict()} == other
-        return False
+        return NotImplemented
 
     def __ne__(self, other: object) -> bool:
         return not self == other
@@ -514,7 +514,7 @@ class AWSHelperFn:
             return self.to_json() == other.to_json()
         if isinstance(other, (dict, list)):
             return self.to_dict() == other
-        return False
+        return NotImplemented
 
     def __hash__(self) -> int:
         return hash(self.to_json(indent=0))
@@ -986,10 +986,10 @@ class Template:
         if isinstance(other, Template):
             return self.to_json() == other.to_json()
         else:
-            return False
+            return NotImplemented
 
     def __ne__(self, other: object) -> bool:
-        return not self.__eq__(other)
+        return not self == other
 
     def __hash__(self) -> int:
         return hash(self.to_json())


### PR DESCRIPTION
Hello,

I'm maintaining a deployment tool based on troposphere and the latest update (4.5.0) failed one of my tests. This PR is supposed to fix the issue.

If it is not known how to compare objects, `__eq__` should return `NotImplemented` instead of `False`. That way the right side object of the comparison might possibly take over.
In my specific case the other object is a mock helper, which happily would do the comparison instead (and did until now).

Thank you.