### PR TITLE
Object equality fixes

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -20,6 +20,7 @@ from troposphere import (
     cloudformation,
     depends_on_helper,
 )
+from troposphere.cloudformation import Stack
 from troposphere.ec2 import Instance, NetworkInterface, Route, SecurityGroupRule
 from troposphere.elasticloadbalancing import HealthCheck
 from troposphere.s3 import Bucket, PublicRead
@@ -116,6 +117,10 @@ class TestBasic(unittest.TestCase):
         assert GenericHelperFn("foobar") != FakeAWSProperty("foobar")
         assert GenericHelperFn("foobar") != TypeComparator(AWSObject)
         assert TypeComparator(AWSObject) != GenericHelperFn("foobar")
+
+        # Testing __ne__ for objects missing required properties
+        assert Parameter("param1") != Parameter("param2")
+        assert Stack("stack1") != Stack("stack2")
 
     def test_badproperty(self):
         with self.assertRaises(AttributeError):

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -335,8 +335,8 @@ class BaseAWSObject:
         self.do_validation = False
         return self
 
-    def to_dict(self) -> Dict[str, Any]:
-        if self.do_validation:
+    def to_dict(self, validation: bool = True) -> Dict[str, Any]:
+        if validation and self.do_validation:
             self._validate_props()
             self.validate()
 
@@ -351,9 +351,13 @@ class BaseAWSObject:
         else:
             return {}
 
-    def to_json(self, *, indent: int = 4, sort_keys: bool = True) -> str:
+    def to_json(
+        self, *, indent: int = 4, sort_keys: bool = True, validation: bool = True
+    ) -> str:
         """Object as JSON."""
-        return json.dumps(self.to_dict(), indent=indent, sort_keys=sort_keys)
+        return json.dumps(
+            self.to_dict(validation=validation), indent=indent, sort_keys=sort_keys
+        )
 
     @classmethod
     def _from_dict(
@@ -417,7 +421,9 @@ class BaseAWSObject:
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, self.__class__):
-            return self.title == other.title and self.to_json() == other.to_json()
+            return self.title == other.title and self.to_json(
+                validation=False
+            ) == other.to_json(validation=False)
         if isinstance(other, dict):
             return {"title": self.title, **self.to_dict()} == other
         return NotImplemented
@@ -1109,3 +1115,6 @@ class Parameter(AWSDeclaration):
                         "%s can only be used with parameters of "
                         "the CommaDelimitedList type." % p
                     )
+
+    def __hash__(self) -> int:
+        return hash(json.dumps({"title": self.title, **self.to_dict()}, indent=0))


### PR DESCRIPTION
- Add __hash__ to the Parameter class
- Disable validation when doing BaseAWSObject object comparison __eq__