### PR TITLE
Fix valid canary runtime versions

### DIFF
--- a/troposphere/validators/synthetics.py
+++ b/troposphere/validators/synthetics.py
@@ -9,7 +9,13 @@ def canary_runtime_version(runtime_version):
     Property: Canary.RuntimeVersion
     """
 
-    valid_runtime_versions = ["syn-nodejs-2.0", "syn-nodejs-2.0-beta", "syn-1.0"]
+    valid_runtime_versions = [
+        "syn-nodejs-puppeteer-4.0",
+        "syn-nodejs-puppeteer-5.0",
+        "syn-nodejs-puppeteer-5.1",
+        "syn-nodejs-puppeteer-6.0",
+        "syn-nodejs-puppeteer-6.1",
+    ]
     if runtime_version not in valid_runtime_versions:
         raise ValueError(
             'RuntimeVersion must be one of: "%s"' % (", ".join(valid_runtime_versions))


### PR DESCRIPTION
The current Canary runtime versions are outdated. Under `troposphere/validators/synthetics.py` the valid versions are the following:
["syn-nodejs-2.0", "syn-nodejs-2.0-beta", "syn-1.0"]
The versions syn-nodejs-puppeteer-3.5 to syn-nodejs-puppeteer-3.9 were deprecated on January 8, 2024. ([Source](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries_Library.html)) 

The current valid versions are the following:
* syn-nodejs-puppeteer-4.0
* syn-nodejs-puppeteer-5.0
* syn-nodejs-puppeteer-5.1
* syn-nodejs-puppeteer-6.0
* syn-nodejs-puppeteer-6.1

Let's add them to the valid canary runtime versions and replace the old ones.