### PR TITLE
Add syn-nodejs-puppeteer-7.0 as valid canary runtime

### DIFF
--- a/troposphere/validators/synthetics.py
+++ b/troposphere/validators/synthetics.py
@@ -16,6 +16,7 @@ def canary_runtime_version(runtime_version):
         "syn-nodejs-puppeteer-6.0",
         "syn-nodejs-puppeteer-6.1",
         "syn-nodejs-puppeteer-6.2",
+        "syn-nodejs-puppeteer-7.0",
     ]
     if runtime_version not in valid_runtime_versions:
         raise ValueError(


### PR DESCRIPTION
https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Library_nodejs_puppeteer.html#CloudWatch_Synthetics_runtimeversion-nodejs-puppeteer-7.0