### PR TITLE
add FilterCriteria to serverless/KinesisEvent

### DIFF
--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -571,6 +571,7 @@ class KinesisEvent(AWSObject):
         "BisectBatchOnFunctionError": (bool, False),
         "DestinationConfig": (DestinationConfig, False),
         "Enabled": (bool, False),
+        "FilterCriteria": (FilterCriteria, False),
         "MaximumBatchingWindowInSeconds": (positive_integer, False),
         "MaximumRecordAgeInSeconds": (integer_range(60, 604800), False),
         "MaximumRetryAttempts": (positive_integer, False),


### PR DESCRIPTION
AWS docs/ref:
* https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-function-kinesis.html#sam-function-kinesis-filtercriteria

fixes error:
* AttributeError: Kinesis object does not support attribute FilterCriteria

```python
Function(
    title='MyLambdaFunction',
    Events={
        "KinesisEvent": KinesisEvent(
            title="KinesisEvent",
            Stream='arn:aws:kinesis:us-east-1:123456789012:stream/my-stream',
            StartingPosition=TRIM_HORIZON,
            FilterCriteria=FilterCriteria(  # this change allows to add filters
                Filters=[
                    Filter(Pattern='{"key": ["val1", "val2"]}'),
                ]
            ),
        )
    }
)
```