### PR TITLE
fix serverless/MQEvent SourceAccessConfigurations property type

### DIFF
--- a/troposphere/serverless.py
+++ b/troposphere/serverless.py
@@ -769,7 +769,7 @@ class MQEvent(AWSObject):
         "MaximumBatchingWindowInSeconds": (integer, False),
         "Queues": ([str], True),
         "SecretsManagerKmsKeyId": (str, False),
-        "SourceAccessConfigurations": ([str], True),
+        "SourceAccessConfigurations": ([SourceAccessConfiguration], True),
     }
 
 


### PR DESCRIPTION
AWS docs/ref:
* https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-function-mq.html#sam-function-mq-sourceaccessconfigurations

fixes error:
* TypeError: <class 'troposphere.serverless.MQEvent'>: MQEvent.SourceAccessConfigurations is <class 'troposphere.awslambda.SourceAccessConfiguration'>, expected [<class 'str'>]
```python
Function(
    title='MyLambdaFunction',
    Events={
        "MQEvent": MQEvent(
            title="MQEvent",
            Broker='arn:aws:mq:us-east-2:123456789012:broker:MyBroker:b-1234a5b6-78cd-901e-2fgh-3i45j6k178l9',
            Queues=['my-queue'],
            SourceAccessConfigurations=[  # now it's array of [SourceAccessConfiguration]
                SourceAccessConfiguration(
                    Type="BASIC_AUTH",
                    URI='arn:aws:secretsmanager:us-east-1:01234567890:secret:MyBrokerSecretName',
                ),
                SourceAccessConfiguration(
                    Type="VIRTUAL_HOST",
                    URI="/",
                ),
            ],
        ),
    }
)
```