### PR TITLE
Add support for GitLab sources in CodeBuild projects

### DIFF
--- a/troposphere/validators/codebuild.py
+++ b/troposphere/validators/codebuild.py
@@ -188,6 +188,8 @@ def validate_source(self):
         "CODEPIPELINE",
         "GITHUB",
         "GITHUB_ENTERPRISE",
+        "GITLAB",
+        "GITLAB_SELF_MANAGED",
         "NO_SOURCE",
         "S3",
     ]


### PR DESCRIPTION
GitLab is [now supported](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-source.html#cfn-codebuild-project-source-type) as a source for CodeBuild projects. 