### PR TITLE
Update glue.py with SNOWFLAKE validate type

### DIFF
--- a/troposphere/validators/glue.py
+++ b/troposphere/validators/glue.py
@@ -26,6 +26,7 @@ def connection_type_validator(type):
         "MONGODB",
         "NETWORK",
         "SFTP",
+        "SNOWFLAKE",
     ]
     if type not in valid_types:
         raise ValueError("% is not a valid value for ConnectionType" % type)


### PR DESCRIPTION
The SNOWFLAKE validation type allows an AWS::Glue::Connection with the ConnectionType of `SNOWFLAKE` to be created.

This is not yet in any documentation nor is the underlying API documented :( 

https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1810

