### PR TITLE
Adding two new values to OperatingSystem attributes

### DIFF
--- a/troposphere/validators/ssm.py
+++ b/troposphere/validators/ssm.py
@@ -95,8 +95,11 @@ def operating_system(os):
     """
 
     valid_os = [
+        "ALMA_LINUX",
         "AMAZON_LINUX",
         "AMAZON_LINUX_2",
+        "AMAZON_LINUX_2022",
+        "AMAZON_LINUX_2023",
         "CENTOS",
         "DEBIAN",
         "MACOS",


### PR DESCRIPTION
OperatingSystem accept AMAZON_LINUX_2023 and AMAZON_LINUX_2022
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-patchbaseline.html#cfn-ssm-patchbaseline-operatingsystem