### PR TITLE
APIGW Integration Timeout Increase

### DIFF
--- a/troposphere/validators/apigateway.py
+++ b/troposphere/validators/apigateway.py
@@ -4,7 +4,7 @@
 # See LICENSE file for full license.
 
 
-from . import integer_range, json_checker, positive_integer, tags_or_list
+from . import json_checker, positive_integer, tags_or_list
 
 
 def dict_or_string(x):
@@ -29,7 +29,10 @@ def validate_timeout_in_millis(x):
     """
     Property: Integration.TimeoutInMillis
     """
-    return integer_range(50, 29000)(x)
+    int(x)
+    if x < 50:
+        raise ValueError(f"TimeoutInMillis of {x} must be greater than 50")
+    return x
 
 
 def validate_authorizer_ttl(ttl_value):

--- a/troposphere/validators/apigatewayv2.py
+++ b/troposphere/validators/apigatewayv2.py
@@ -4,7 +4,7 @@
 # See LICENSE file for full license.
 
 
-from . import integer_range, json_checker, positive_integer
+from . import json_checker, positive_integer
 
 
 def dict_or_string(x):
@@ -21,7 +21,10 @@ def validate_timeout_in_millis(x):
     """
     Property: Integration.TimeoutInMillis
     """
-    return integer_range(50, 29000)(x)
+    int(x)
+    if x < 50:
+        raise ValueError(f"TimeoutInMillis of {x} must be greater than 50")
+    return x
 
 
 def validate_integration_type(integration_type):


### PR DESCRIPTION
Setting upper limit of integration timeout to max timeout time for a lambda function. This is per the change AWS has rolled out which allows the integration timeout to be increased beyond 29000: https://aws.amazon.com/about-aws/whats-new/2024/06/amazon-api-gateway-integration-timeout-limit-29-seconds/

