### PR TITLE
Validate the type for Tags

### DIFF
--- a/tests/test_serverless.py
+++ b/tests/test_serverless.py
@@ -1,6 +1,6 @@
 import unittest
 
-from troposphere import ImportValue, Parameter, Ref, Sub, Tags, Template
+from troposphere import ImportValue, Parameter, Ref, Sub, Template
 from troposphere.s3 import Filter, Rules, S3Key
 from troposphere.serverless import (
     SERVERLESS_TRANSFORM,
@@ -70,7 +70,7 @@ class TestServerless(unittest.TestCase):
             Handler="index.handler",
             Runtime="nodejs",
             CodeUri="s3://bucket/handler.zip",
-            Tags=Tags({"Tag1": "TagValue1", "Tag2": "TagValue2"}),
+            Tags={"Tag1": "TagValue1", "Tag2": "TagValue2"},
         )
         t = Template()
         t.add_resource(serverless_func)

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -73,6 +73,47 @@ class TestTags(unittest.TestCase):
         with self.assertRaises(TypeError):
             Tags({}, "key", "value")
 
+    def test_json_tags(self):
+        from troposphere.batch import ContainerProperties, JobDefinition
+
+        JobDefinition(
+            "myjobdef",
+            Type="container",
+            ContainerProperties=ContainerProperties(
+                Image="image",
+                Vcpus=2,
+                Memory=2000,
+                Command=["echo", "foobar"],
+            ),
+            Tags={"foo": "bar"},
+        )
+
+        with self.assertRaises(TypeError):
+            JobDefinition(
+                "myjobdef",
+                Type="container",
+                ContainerProperties=ContainerProperties(
+                    Image="image",
+                    Vcpus=2,
+                    Memory=2000,
+                    Command=["echo", "foobar"],
+                ),
+                Tags=Tags({"foo": "bar"}),
+            )
+
+        with self.assertRaises(TypeError):
+            JobDefinition(
+                "myjobdef",
+                Type="container",
+                ContainerProperties=ContainerProperties(
+                    Image="image",
+                    Vcpus=2,
+                    Memory=2000,
+                    Command=["echo", "foobar"],
+                ),
+                Tags="string",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -252,9 +252,11 @@ class BaseAWSObject:
             expected_type = self.props[name][0]
 
             # If the value is a AWSHelperFn we can't do much validation
-            # we'll have to leave that to Amazon.  Maybe there's another way
+            # we'll have to leave that to Amazon. Maybe there's another way
             # to deal with this that we'll come up with eventually
-            if isinstance(value, AWSHelperFn):
+            #
+            # Don't do this for Tags since we can validate the assigned type below
+            if isinstance(value, AWSHelperFn) and name != "Tags":
                 return self.properties.__setitem__(name, value)
 
             # If it's a function, call it...


### PR DESCRIPTION
Prior to this change Tags (which is a subclass of AWSHelperFn) would not do validation of the expected type and it prevented validation of Json style Tags needing a dict.

Fixes #2268