### PR TITLE
Allow AWSHelperFn for Tags properties

### DIFF
--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,6 +1,6 @@
 import unittest
 
-from troposphere import If, Sub, Tag, Tags
+from troposphere import GetAtt, If, Sub, Tag, Tags
 from troposphere.autoscaling import Tags as ASTags
 
 
@@ -88,6 +88,18 @@ class TestTags(unittest.TestCase):
             Tags={"foo": "bar"},
         )
 
+        JobDefinition(
+            "myjobdef",
+            Type="container",
+            ContainerProperties=ContainerProperties(
+                Image="image",
+                Vcpus=2,
+                Memory=2000,
+                Command=["echo", "foobar"],
+            ),
+            Tags=GetAtt("resource", "tags"),
+        )
+
         with self.assertRaises(TypeError):
             JobDefinition(
                 "myjobdef",
@@ -111,6 +123,39 @@ class TestTags(unittest.TestCase):
                     Memory=2000,
                     Command=["echo", "foobar"],
                 ),
+                Tags="string",
+            )
+
+    def test_object_tags(self):
+        from troposphere.dynamodb import KeySchema, Table
+
+        Table(
+            "mytable",
+            KeySchema=[KeySchema(KeyType="HASH", AttributeName="id")],
+            BillingMode="PAY_PER_REQUEST",
+            Tags=Tags(Name="Example"),
+        )
+
+        Table(
+            "mytable",
+            KeySchema=[KeySchema(KeyType="HASH", AttributeName="id")],
+            BillingMode="PAY_PER_REQUEST",
+            Tags=GetAtt("resource", "tags"),
+        )
+
+        with self.assertRaises(TypeError):
+            Table(
+                "mytable",
+                KeySchema=[KeySchema(KeyType="HASH", AttributeName="id")],
+                BillingMode="PAY_PER_REQUEST",
+                Tags={"Name": "Example"},
+            )
+
+        with self.assertRaises(TypeError):
+            Table(
+                "mytable",
+                KeySchema=[KeySchema(KeyType="HASH", AttributeName="id")],
+                BillingMode="PAY_PER_REQUEST",
                 Tags="string",
             )
 

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -256,7 +256,7 @@ class BaseAWSObject:
             # to deal with this that we'll come up with eventually
             #
             # Don't do this for Tags since we can validate the assigned type below
-            if isinstance(value, AWSHelperFn) and name != "Tags":
+            if isinstance(value, AWSHelperFn) and not isinstance(value, Tags):
                 return self.properties.__setitem__(name, value)
 
             # If it's a function, call it...


### PR DESCRIPTION
Instead of checking the property name, we check the type of the value. This means that the Tags class gets checked, but other helper functions are allowed

We were running into this issue, because we have a custom resource that outputs a tag list.

I've also added tests for this case