### PR TITLE
Add "Policy-Min-TLS-1-2-PFS-2023-10" as valid value TlsSecurityPolicy

### DIFF
--- a/troposphere/validators/elasticsearch.py
+++ b/troposphere/validators/elasticsearch.py
@@ -54,6 +54,7 @@ def validate_tls_security_policy(tls_security_policy):
     VALID_TLS_SECURITY_POLICIES = (
         "Policy-Min-TLS-1-0-2019-07",
         "Policy-Min-TLS-1-2-2019-07",
+        "Policy-Min-TLS-1-2-PFS-2023-10",
     )
 
     if tls_security_policy not in VALID_TLS_SECURITY_POLICIES:


### PR DESCRIPTION
it's not listed in [CloudFormation doc ](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticsearch-domain-domainendpointoptions.html#cfn-elasticsearch-domain-domainendpointoptions-tlssecuritypolicy), but it's mentioned [here](https://docs.aws.amazon.com/securityhub/latest/userguide/es-controls.html#es-8) and I tested that it actually works