### PR TITLE
[2299] Add support for FLINK-1_20 in validate_runtime_environment

### DIFF
--- a/troposphere/validators/kinesisanalyticsv2.py
+++ b/troposphere/validators/kinesisanalyticsv2.py
@@ -18,6 +18,7 @@ def validate_runtime_environment(runtime_environment):
         "FLINK-1_15",
         "FLINK-1_18",
         "FLINK-1_19",
+        "FLINK-1_20",
         "SQL-1_0",
         "ZEPPELIN-FLINK-1_0",
         "ZEPPELIN-FLINK-2_0",


### PR DESCRIPTION
AWS has added support for Apache Flink 1.20 in Kinesis Data Analytics. This PR updates the VALID_RUNTIME_ENVIRONMENTS tuple in troposphere/validators/kinesisanalyticsv2.py to include "FLINK-1_20".

This ensures Troposphere users can define applications using the latest supported Flink runtime without encountering validation errors.

Change Summary:

Added "FLINK-1_20" to the list of valid runtime environments

Reference:
Issue: https://github.com/cloudtools/troposphere/issues/2299
[AWS Announcement for Flink 1.20 Support](https://docs.aws.amazon.com/managed-flink/latest/java/flink-1-20.html)
