### PR TITLE
Add new oracle-ee-cdb engine to the valid db engine on rds validator

### DIFF
--- a/troposphere/validators/rds.py
+++ b/troposphere/validators/rds.py
@@ -91,6 +91,7 @@ def validate_engine(engine):
         "oracle-se2",
         "oracle-se",
         "oracle-ee",
+        "oracle-ee-cdb",
         "sqlserver-ee",
         "sqlserver-se",
         "sqlserver-ex",


### PR DESCRIPTION
Hopefully this is fine, but feel free to ask any changes need it! PLEASE!

This is adding a new engine to be available in the RDS validator.

Closes
 - #2333 