### PR TITLE
feature: adds support for GetStackOutput intrinsic function

### DIFF
--- a/scripts/cfn2py
+++ b/scripts/cfn2py
@@ -53,7 +53,7 @@ def do_header(d):
     """Output a stock header for the new Python script and also try to
     figure out the Resource imports needed by the template.
     """
-    print('from troposphere import Base64, Select, FindInMap, GetAtt')
+    print('from troposphere import Base64, Select, FindInMap, GetAtt, GetStackOutput')
     print('from troposphere import GetAZs, Join, Output, If, And, Not')
     print('from troposphere import Or, Equals, Condition')
     print('from troposphere import Parameter, Ref, Tags, Template, Export')
@@ -283,6 +283,14 @@ def handle_no_objects(name, values):
     return name + "(" + ", ".join(map(output_value, values)) + ")"
 
 
+def handle_kwargs_dict(name, values):
+    """Handle intrinsic functions whose argument is a dict of named kwargs"""
+    d = values[0]
+    return name + "(" + ", ".join(
+        "{}={}".format(k, output_value(v)) for k, v in d.items()
+    ) + ")"
+
+
 def handle_one_object(name, values):
     """Handle intrinsic functions which have a single named resource"""
     ret = name + "("
@@ -311,6 +319,7 @@ function_map = {
     'Fn::Select': ("Select", handle_one_object),
     'Ref': ("Ref", handle_one_object),
     'Condition': ("Condition", handle_one_object),
+    'Fn::GetStackOutput': ("GetStackOutput", handle_kwargs_dict),
 }
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -7,6 +7,7 @@ from troposphere import (
     AWSProperty,
     Cidr,
     GenericHelperFn,
+    GetStackOutput,
     If,
     Join,
     NoValue,
@@ -530,6 +531,95 @@ class TestSub(unittest.TestCase):
             "Fn::Sub": [
                 "foo ${AWS::Region} ${sub1} ${sub2} ${sub3}",
                 {"sub1": "uno", "sub2": "dos", "sub3": "tres"},
+            ]
+        }
+        self.assertEqual(expected, actual)
+
+
+class TestGetStackOutput(unittest.TestCase):
+    def test_required_only(self):
+        raw = GetStackOutput("ProducerStack", "VpcId")
+        actual = raw.to_dict()
+        expected = {
+            "Fn::GetStackOutput": {
+                "StackName": "ProducerStack",
+                "OutputName": "VpcId",
+            }
+        }
+        self.assertEqual(expected, actual)
+
+    def test_with_region(self):
+        raw = GetStackOutput("ProducerStack", "VpcId", Region="us-west-2")
+        actual = raw.to_dict()
+        expected = {
+            "Fn::GetStackOutput": {
+                "StackName": "ProducerStack",
+                "OutputName": "VpcId",
+                "Region": "us-west-2",
+            }
+        }
+        self.assertEqual(expected, actual)
+
+    def test_with_role_arn(self):
+        raw = GetStackOutput(
+            "ProducerStack",
+            "VpcId",
+            RoleArn="arn:aws:iam::111111111111:role/GetStackOutputRole",
+        )
+        actual = raw.to_dict()
+        expected = {
+            "Fn::GetStackOutput": {
+                "StackName": "ProducerStack",
+                "OutputName": "VpcId",
+                "RoleArn": "arn:aws:iam::111111111111:role/GetStackOutputRole",
+            }
+        }
+        self.assertEqual(expected, actual)
+
+    def test_cross_account_cross_region(self):
+        raw = GetStackOutput(
+            "ProducerStack",
+            "VpcId",
+            Region="us-west-2",
+            RoleArn="arn:aws:iam::111111111111:role/GetStackOutputRole",
+        )
+        actual = raw.to_dict()
+        expected = {
+            "Fn::GetStackOutput": {
+                "StackName": "ProducerStack",
+                "OutputName": "VpcId",
+                "Region": "us-west-2",
+                "RoleArn": "arn:aws:iam::111111111111:role/GetStackOutputRole",
+            }
+        }
+        self.assertEqual(expected, actual)
+
+    def test_accepts_nested_intrinsics(self):
+        raw = GetStackOutput(Ref("SourceStackName"), "SubnetId")
+        actual = raw.to_dict()
+        expected = {
+            "Fn::GetStackOutput": {
+                "StackName": {"Ref": "SourceStackName"},
+                "OutputName": "SubnetId",
+            }
+        }
+        self.assertEqual(expected, actual)
+
+    def test_usable_inside_join(self):
+        raw = Join("-", [GetStackOutput("ProducerStack", "VpcId"), "suffix"])
+        actual = raw.to_dict()
+        expected = {
+            "Fn::Join": [
+                "-",
+                [
+                    {
+                        "Fn::GetStackOutput": {
+                            "StackName": "ProducerStack",
+                            "OutputName": "VpcId",
+                        }
+                    },
+                    "suffix",
+                ],
             ]
         }
         self.assertEqual(expected, actual)

--- a/troposphere/__init__.py
+++ b/troposphere/__init__.py
@@ -691,6 +691,25 @@ class ImportValue(AWSHelperFn):
         self.data = {"Fn::ImportValue": data}
 
 
+class GetStackOutput(AWSHelperFn):
+    def __init__(
+        self,
+        StackName: object,  # noqa: N803
+        OutputName: object,  # noqa: N803
+        Region: Optional[object] = None,  # noqa: N803
+        RoleArn: Optional[object] = None,  # noqa: N803
+    ) -> None:
+        params: Dict[str, Any] = {
+            "StackName": StackName,
+            "OutputName": OutputName,
+        }
+        if Region is not None:
+            params["Region"] = Region
+        if RoleArn is not None:
+            params["RoleArn"] = RoleArn
+        self.data = {"Fn::GetStackOutput": params}
+
+
 class Tag(AWSHelperFn):
     def __init__(self, k: object, v: object) -> None:
         self.data = {


### PR DESCRIPTION
This pull request adds support for the new CloudFormation intrinsic function `Fn::GetStackOutput` to the codebase. The main changes include implementing the `GetStackOutput` class, updating the code generation script to recognize the new function, and adding comprehensive unit tests to ensure correct behavior.

**Support for Fn::GetStackOutput:**

* Added the `GetStackOutput` class to `troposphere/__init__.py`, allowing users to generate the `Fn::GetStackOutput` intrinsic function with optional `Region` and `RoleArn` parameters.
* Updated the import headers in `scripts/cfn2py` to include `GetStackOutput`, ensuring generated Python code can use the new intrinsic.
* Registered `Fn::GetStackOutput` in the `function_map` of `scripts/cfn2py`, with a new handler for keyword arguments.
* Implemented the `handle_kwargs_dict` helper in `scripts/cfn2py` to support intrinsic functions that take named keyword arguments, used by `Fn::GetStackOutput`.

**Testing:**

* Added a new test class `TestGetStackOutput` in `tests/test_basic.py` to verify all usage patterns of the new intrinsic, including required and optional arguments, nested intrinsics, and composition with other functions.
* Imported `GetStackOutput` in the test suite to enable testing.